### PR TITLE
1.7.8 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.retrooper</groupId>
     <artifactId>packetevents</artifactId>
-    <version>1.7.7</version>
+    <version>1.7.8</version>
 
     <!-- You can build the project with this: "mvn clean compile assembly:single" -->
     <build>
@@ -122,6 +122,20 @@
             <version>4.5.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ProtocolSupport</groupId>
+            <artifactId>ProtocolSupport</artifactId>
+            <version>3d24efeda6</version>
+        </dependency>
+
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/src/main/java/io/github/retrooper/packetevents/packetmanager/PacketManager.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetmanager/PacketManager.java
@@ -41,9 +41,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class PacketManager {
-
-    private static final AtomicInteger handlerID = new AtomicInteger();
-    private final int handlerNumber = handlerID.getAndIncrement();
     private final Plugin plugin;
     private final boolean tinyProtocolMode;
     public final TinyProtocol tinyProtocol;
@@ -57,8 +54,8 @@ public class PacketManager {
             tinyProtocol = new TinyProtocol(plugin);
             nettyProtocol = null;
         } else {
-            tinyProtocol = null;
             nettyProtocol = new NettyPacketManager(plugin);
+            tinyProtocol = null;
         }
     }
 
@@ -163,7 +160,7 @@ public class PacketManager {
     }
 
     public String getNettyHandlerName() {
-        return "pe-" + plugin.getName() + "-" + handlerNumber;
+        return "pe-" + plugin.getName();
     }
 
     public Object read(Player player, Object channel, Object packet) {
@@ -278,12 +275,13 @@ public class PacketManager {
     }
 
     private void interceptLogin(PacketLoginEvent event) {
-        if (event.getPacketId() == PacketType.Login.HANDSHAKE &&
-        PacketEvents.getAPI().getServerUtils().getVersion() != ServerVersion.v_1_7_10) {
-                WrappedPacketLoginHandshake handshake = new WrappedPacketLoginHandshake(event.getNMSPacket());
-                int protocolVersion = handshake.getProtocolVersion();
-                ClientVersion version = ClientVersion.getClientVersion(protocolVersion);
-                PacketEvents.getAPI().getPlayerUtils().clientVersionsMap.put(event.getChannel(), version);
+        if (event.getPacketId() == PacketType.Login.HANDSHAKE
+                && PacketEvents.getAPI().getServerUtils().getVersion() != ServerVersion.v_1_7_10
+                && !PacketEvents.getAPI().getServerUtils().isBungeeCordEnabled()) {
+            WrappedPacketLoginHandshake handshake = new WrappedPacketLoginHandshake(event.getNMSPacket());
+            int protocolVersion = handshake.getProtocolVersion();
+            ClientVersion version = ClientVersion.getClientVersion(protocolVersion);
+            PacketEvents.getAPI().getPlayerUtils().clientVersionsMap.put(event.getChannel(), version);
         }
     }
 

--- a/src/main/java/io/github/retrooper/packetevents/packetwrappers/in/useentity/WrappedPacketInUseEntity.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetwrappers/in/useentity/WrappedPacketInUseEntity.java
@@ -38,11 +38,7 @@ public final class WrappedPacketInUseEntity extends WrappedPacket {
     }
 
     public static void load() {
-        //System.out.println("USE ENTITY HAS BEEN LOADED BROOOIOII");
         Class<?> useEntityClass = NMSUtils.getNMSClassWithoutException("PacketPlayInUseEntity");
-        /*if(useEntityClass == null) {
-            System.out.println("failed to init use entity wtfffff");
-        }*/
         try {
             enumEntityUseActionClass = NMSUtils.getNMSClass("EnumEntityUseAction");
         } catch (ClassNotFoundException e) {

--- a/src/main/java/io/github/retrooper/packetevents/settings/PacketEventsSettings.java
+++ b/src/main/java/io/github/retrooper/packetevents/settings/PacketEventsSettings.java
@@ -25,7 +25,6 @@
 package io.github.retrooper.packetevents.settings;
 
 import io.github.retrooper.packetevents.utils.server.ServerVersion;
-import net.minecraft.server.v1_8_R3.Packet;
 
 public class PacketEventsSettings {
     private ServerVersion backupServerVersion = ServerVersion.v_1_7_10;

--- a/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
@@ -53,7 +53,8 @@ public enum ClientVersion {
     v_1_16_1(736),
     v_1_16_2(751),
     v_1_16_3(753),
-    HIGHER_THAN_SUPPORTED_VERSIONS(754),
+    v_1_16_4(754),
+    HIGHER_THAN_SUPPORTED_VERSIONS(755),
     /**
      * Pre releases just aren't supported, we would end up with so many enum constants.
      */
@@ -65,6 +66,7 @@ public enum ClientVersion {
 
     private static final int lowestSupportedProtocolVersion = 5;
     private static final int highestSupportedProtocolVersion = 753;
+
     ClientVersion(int protocolVersion) {
         this.protocolVersion = protocolVersion;
     }
@@ -94,24 +96,21 @@ public enum ClientVersion {
     }
 
     public static ClientVersion getClientVersion(int protocolVersion) {
-        if(protocolVersion == -1) {
-          return ClientVersion.UNRESOLVED;
+        if (protocolVersion == -1) {
+            return ClientVersion.UNRESOLVED;
         }
-        for(ClientVersion version : ClientVersion.values()) {
-            if(version.protocolVersion > protocolVersion) {
+        for (ClientVersion version : ClientVersion.values()) {
+            if (version.protocolVersion > protocolVersion) {
                 break;
-            }
-            else if(version.protocolVersion == protocolVersion) {
+            } else if (version.protocolVersion == protocolVersion) {
                 return version;
             }
         }
-        if(protocolVersion < lowestSupportedProtocolVersion) {
+        if (protocolVersion < lowestSupportedProtocolVersion) {
             return LOWER_THAN_SUPPORTED_VERSIONS;
-        }
-        else if(protocolVersion > highestSupportedProtocolVersion) {
+        } else if (protocolVersion > highestSupportedProtocolVersion) {
             return HIGHER_THAN_SUPPORTED_VERSIONS;
-        }
-        else if(protocolVersion > lowestSupportedProtocolVersion
+        } else if (protocolVersion > lowestSupportedProtocolVersion
                 && protocolVersion < highestSupportedProtocolVersion) {
             return ANY_PRE_RELEASE_VERSION;
         }

--- a/src/main/java/io/github/retrooper/packetevents/utils/server/ServerVersion.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/server/ServerVersion.java
@@ -38,7 +38,7 @@ public enum ServerVersion {
 	v_1_11_2((short) 316), v_1_12((short) 335), v_1_12_1((short) 338), v_1_12_2((short) 340), v_1_13((short) 393),
 	v_1_13_1((short) 401), v_1_13_2((short) 404), v_1_14((short) 477), v_1_14_1((short) 480), v_1_14_2((short) 485),
 	v_1_14_3((short) 490), v_1_14_4((short) 498), v_1_15((short) 573), v_1_15_1((short) 575), v_1_15_2((short) 578),
-	v_1_16((short) 735), v_1_16_1((short) 736), v_1_16_2((short) 751), v_1_16_3((short) 753), ERROR((short) -1), EMPTY((short) -1);
+	v_1_16((short) 735), v_1_16_1((short) 736), v_1_16_2((short) 751), v_1_16_3((short) 753), v_1_16_4((short)754),ERROR((short) -1);
 
 	private static final String nmsVersionSuffix = Bukkit.getServer().getClass().getPackage().getName()
 			.replace(".", ",").split(",")[3];
@@ -57,6 +57,9 @@ public enum ServerVersion {
 	private static ServerVersion getVersionNoCache() {
 		if (reversedValues[0] == null) {
 			reversedValues = ServerVersion.reverse(values());
+		}
+		if(reversedValues == null) {
+			throw new IllegalStateException("Failed to reverse the ServerVersion enum constant values.");
 		}
 		for (final ServerVersion val : reversedValues) {
 			String valName = val.name().substring(2).replace("_", ".");
@@ -125,7 +128,7 @@ public enum ServerVersion {
 	 * @return True if the supplied version is lower or equal, false if it is higher
 	 *         than the server's version.
 	 */
-	public boolean isAtLeast(final ServerVersion version) {
+	public boolean isHigherThanOrEquals(final ServerVersion version) {
 		return protocolId >= version.protocolId;
 	}
 
@@ -149,7 +152,7 @@ public enum ServerVersion {
 	 * @return True if the supplied version is higher or equal, false if it is lower
 	 *         than the server's version.
 	 */
-	public boolean isAtMost(final ServerVersion version) {
+	public boolean isLowerThanOrEquals(final ServerVersion version) {
 		return version.protocolId >= protocolId;
 	}
 }

--- a/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/VersionLookupUtils.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/VersionLookupUtils.java
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 retrooper
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.retrooper.packetevents.utils.versionlookup;
+
+import io.github.retrooper.packetevents.utils.versionlookup.protocollib.ProtocolLibVersionLookupUtils;
+import io.github.retrooper.packetevents.utils.versionlookup.protocolsupport.ProtocolSupportVersionLookupUtils;
+import io.github.retrooper.packetevents.utils.versionlookup.viaversion.ViaVersionLookupUtils;
+import org.bukkit.entity.Player;
+
+public class VersionLookupUtils {
+    public static boolean isDependencyAvailable() {
+        return ViaVersionLookupUtils.isAvailable() || ProtocolSupportVersionLookupUtils.isAvailable()
+                || ProtocolLibVersionLookupUtils.isAvailable();
+    }
+
+    public static int getProtocolVersion(Player player) {
+        if (ViaVersionLookupUtils.isAvailable()) {
+            return ViaVersionLookupUtils.getProtocolVersion(player);
+        } else if (ProtocolSupportVersionLookupUtils.isAvailable()) {
+            return ProtocolSupportVersionLookupUtils.getProtocolVersion(player);
+        } else if (ProtocolLibVersionLookupUtils.isAvailable()) {
+            return ProtocolLibVersionLookupUtils.getProtocolVersion(player);
+        }
+        return -1;
+    }
+}

--- a/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/protocollib/ProtocolLibVersionLookupUtils.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/protocollib/ProtocolLibVersionLookupUtils.java
@@ -22,35 +22,18 @@
  * SOFTWARE.
  */
 
-package io.github.retrooper.packetevents.example;
+package io.github.retrooper.packetevents.utils.versionlookup.protocollib;
 
-import io.github.retrooper.packetevents.PacketEvents;
-import io.github.retrooper.packetevents.event.PacketListenerDynamic;
-import io.github.retrooper.packetevents.event.impl.PacketReceiveEvent;
-import io.github.retrooper.packetevents.event.priority.PacketEventPriority;
-import io.github.retrooper.packetevents.packettype.PacketType;
-import io.github.retrooper.packetevents.packetwrappers.in.chat.WrappedPacketInChat;
-import io.github.retrooper.packetevents.utils.player.ClientVersion;
-import io.github.retrooper.packetevents.utils.server.ServerVersion;
-import org.bukkit.plugin.java.JavaPlugin;
+import com.comphenix.protocol.ProtocolLibrary;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
-public class MainExample extends JavaPlugin {
-
-    @Override
-    public void onLoad() {
-        PacketEvents.load();
+public class ProtocolLibVersionLookupUtils {
+    public static boolean isAvailable() {
+        return Bukkit.getPluginManager().isPluginEnabled("ProtocolLib");
     }
 
-    @Override
-    public void onEnable() {
-        PacketEvents.getSettings().injectAsync(true).ejectAsync(true)
-                .backupServerVersion(ServerVersion.v_1_7_10).checkForUpdates(true).injectEarly(true).
-                packetHandlingThreadCount(1);
-        PacketEvents.init(this);
-    }
-
-    @Override
-    public void onDisable() {
-        PacketEvents.stop();
+    public static int getProtocolVersion(Player player) {
+        return ProtocolLibrary.getProtocolManager().getProtocolVersion(player);
     }
 }

--- a/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/protocolsupport/ProtocolSupportVersionLookupUtils.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/protocolsupport/ProtocolSupportVersionLookupUtils.java
@@ -22,35 +22,18 @@
  * SOFTWARE.
  */
 
-package io.github.retrooper.packetevents.example;
+package io.github.retrooper.packetevents.utils.versionlookup.protocolsupport;
 
-import io.github.retrooper.packetevents.PacketEvents;
-import io.github.retrooper.packetevents.event.PacketListenerDynamic;
-import io.github.retrooper.packetevents.event.impl.PacketReceiveEvent;
-import io.github.retrooper.packetevents.event.priority.PacketEventPriority;
-import io.github.retrooper.packetevents.packettype.PacketType;
-import io.github.retrooper.packetevents.packetwrappers.in.chat.WrappedPacketInChat;
-import io.github.retrooper.packetevents.utils.player.ClientVersion;
-import io.github.retrooper.packetevents.utils.server.ServerVersion;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import protocolsupport.api.ProtocolSupportAPI;
 
-public class MainExample extends JavaPlugin {
-
-    @Override
-    public void onLoad() {
-        PacketEvents.load();
+public class ProtocolSupportVersionLookupUtils {
+    public static boolean isAvailable() {
+        return Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport");
     }
-
-    @Override
-    public void onEnable() {
-        PacketEvents.getSettings().injectAsync(true).ejectAsync(true)
-                .backupServerVersion(ServerVersion.v_1_7_10).checkForUpdates(true).injectEarly(true).
-                packetHandlingThreadCount(1);
-        PacketEvents.init(this);
-    }
-
-    @Override
-    public void onDisable() {
-        PacketEvents.stop();
+    
+    public static int getProtocolVersion(Player player) {
+        return ProtocolSupportAPI.getProtocolVersion(player).getId();
     }
 }

--- a/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/v_1_7_10/ProtocolVersionAccessor_v_1_7.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/v_1_7_10/ProtocolVersionAccessor_v_1_7.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package io.github.retrooper.packetevents.utils.v_1_7_10;
+package io.github.retrooper.packetevents.utils.versionlookup.v_1_7_10;
 
 import org.bukkit.entity.Player;
 

--- a/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/viaversion/ViaVersionLookupUtils.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/versionlookup/viaversion/ViaVersionLookupUtils.java
@@ -22,35 +22,18 @@
  * SOFTWARE.
  */
 
-package io.github.retrooper.packetevents.example;
+package io.github.retrooper.packetevents.utils.versionlookup.viaversion;
 
-import io.github.retrooper.packetevents.PacketEvents;
-import io.github.retrooper.packetevents.event.PacketListenerDynamic;
-import io.github.retrooper.packetevents.event.impl.PacketReceiveEvent;
-import io.github.retrooper.packetevents.event.priority.PacketEventPriority;
-import io.github.retrooper.packetevents.packettype.PacketType;
-import io.github.retrooper.packetevents.packetwrappers.in.chat.WrappedPacketInChat;
-import io.github.retrooper.packetevents.utils.player.ClientVersion;
-import io.github.retrooper.packetevents.utils.server.ServerVersion;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import us.myles.ViaVersion.api.Via;
 
-public class MainExample extends JavaPlugin {
-
-    @Override
-    public void onLoad() {
-        PacketEvents.load();
+public class ViaVersionLookupUtils {
+    public static boolean isAvailable() {
+        return Bukkit.getPluginManager().isPluginEnabled("ViaVersion");
     }
 
-    @Override
-    public void onEnable() {
-        PacketEvents.getSettings().injectAsync(true).ejectAsync(true)
-                .backupServerVersion(ServerVersion.v_1_7_10).checkForUpdates(true).injectEarly(true).
-                packetHandlingThreadCount(1);
-        PacketEvents.init(this);
-    }
-
-    @Override
-    public void onDisable() {
-        PacketEvents.stop();
+    public static int getProtocolVersion(Player player) {
+        return Via.getAPI().getPlayerVersion(player.getUniqueId());
     }
 }


### PR DESCRIPTION
* Official 1.16.4 support
ClientVersion.v_1_16_4, ServerVersion.v_1_16_4 created
* Unfortunately PacketEvents.getSettings().useProtocolLibIfAvailable(boolean) setting most likely won't be coming back
* Bungee client version resolving bug fixed
* Recommended to have ViaVersion, ProtocolSupport or ProtocolLib on your spigot server, as PacketEvents makes use of them to resolve client version ONLY if they are available.
They are required on the spigot server ONLY if you have a bungee network.
* Interruption of PacketEvents.stop() protected(Two plugins can no longer break PacketEvents by both of them attempting to stop it)