### PR TITLE
Remove assumption of SocketChannel

### DIFF
--- a/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/EarlyChannelInjectorLegacy.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/EarlyChannelInjectorLegacy.java
@@ -29,7 +29,6 @@ import net.minecraft.util.io.netty.channel.Channel;
 import net.minecraft.util.io.netty.channel.ChannelFuture;
 import net.minecraft.util.io.netty.channel.ChannelHandler;
 import net.minecraft.util.io.netty.channel.ChannelInitializer;
-import net.minecraft.util.io.netty.channel.socket.SocketChannel;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 
@@ -203,7 +202,7 @@ public class EarlyChannelInjectorLegacy implements EarlyInjector {
                         childHandlerField.setAccessible(true);
                     }
 
-                    ChannelInitializer<SocketChannel> oldInit = (ChannelInitializer<SocketChannel>) childHandlerField.get(handler);
+                    ChannelInitializer<Channel> oldInit = (ChannelInitializer<Channel>) childHandlerField.get(handler);
                     if (oldInit instanceof PEChannelInitializerLegacy) {
                         bootstrapAcceptor = handler;
                     }
@@ -217,7 +216,7 @@ public class EarlyChannelInjectorLegacy implements EarlyInjector {
             }
 
             try {
-                ChannelInitializer<SocketChannel> oldInit = (ChannelInitializer<SocketChannel>) childHandlerField.get(bootstrapAcceptor);
+                ChannelInitializer<Channel> oldInit = (ChannelInitializer<Channel>) childHandlerField.get(bootstrapAcceptor);
                 if (oldInit instanceof PEChannelInitializerLegacy) {
                     childHandlerField.setAccessible(true);
                     childHandlerField.set(bootstrapAcceptor, ((PEChannelInitializerLegacy) oldInit).getOldChannelInitializer());

--- a/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/PEChannelInitializerLegacy.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/PEChannelInitializerLegacy.java
@@ -21,12 +21,12 @@ package io.github.retrooper.packetevents.injector.legacy.early;
 import io.github.retrooper.packetevents.PacketEvents;
 import io.github.retrooper.packetevents.injector.legacy.PlayerChannelHandlerLegacy;
 import io.github.retrooper.packetevents.utils.reflection.Reflection;
+import net.minecraft.util.io.netty.channel.Channel;
 import net.minecraft.util.io.netty.channel.ChannelInitializer;
-import net.minecraft.util.io.netty.channel.socket.SocketChannel;
 
 import java.lang.reflect.Method;
 
-public class PEChannelInitializerLegacy extends ChannelInitializer<SocketChannel> {
+public class PEChannelInitializerLegacy extends ChannelInitializer<Channel> {
     private final ChannelInitializer<?> oldChannelInitializer;
     private Method initChannelMethod;
 
@@ -44,11 +44,11 @@ public class PEChannelInitializerLegacy extends ChannelInitializer<SocketChannel
     }
 
     @Override
-    protected void initChannel(SocketChannel socketChannel) throws Exception {
-        initChannelMethod.invoke(oldChannelInitializer, socketChannel);
+    protected void initChannel(Channel channel) throws Exception {
+        initChannelMethod.invoke(oldChannelInitializer, channel);
         PlayerChannelHandlerLegacy channelHandler = new PlayerChannelHandlerLegacy();
-        if (socketChannel.pipeline().get("packet_handler") != null) {
-            socketChannel.pipeline().addBefore("packet_handler", PacketEvents.get().getHandlerName(), channelHandler);
+        if (channel.pipeline().get("packet_handler") != null) {
+            channel.pipeline().addBefore("packet_handler", PacketEvents.get().getHandlerName(), channelHandler);
         }
     }
 }

--- a/src/main/java/io/github/retrooper/packetevents/injector/modern/early/EarlyChannelInjectorModern.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/modern/early/EarlyChannelInjectorModern.java
@@ -29,7 +29,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.socket.SocketChannel;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 
@@ -212,7 +211,7 @@ public class EarlyChannelInjectorModern implements EarlyInjector {
                         childHandlerField.setAccessible(true);
                     }
 
-                    ChannelInitializer<SocketChannel> oldInit = (ChannelInitializer<SocketChannel>) childHandlerField.get(handler);
+                    ChannelInitializer<Channel> oldInit = (ChannelInitializer<Channel>) childHandlerField.get(handler);
                     if (oldInit instanceof PEChannelInitializerModern) {
                         bootstrapAcceptor = handler;
                     }
@@ -226,7 +225,7 @@ public class EarlyChannelInjectorModern implements EarlyInjector {
             }
 
             try {
-                ChannelInitializer<SocketChannel> oldInit = (ChannelInitializer<SocketChannel>) childHandlerField.get(bootstrapAcceptor);
+                ChannelInitializer<Channel> oldInit = (ChannelInitializer<Channel>) childHandlerField.get(bootstrapAcceptor);
                 if (oldInit instanceof PEChannelInitializerModern) {
                     childHandlerField.setAccessible(true);
                     childHandlerField.set(bootstrapAcceptor, ((PEChannelInitializerModern) oldInit).getOldChannelInitializer());

--- a/src/main/java/io/github/retrooper/packetevents/injector/modern/early/PEChannelInitializerModern.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/modern/early/PEChannelInitializerModern.java
@@ -23,11 +23,10 @@ import io.github.retrooper.packetevents.injector.modern.PlayerChannelHandlerMode
 import io.github.retrooper.packetevents.utils.reflection.Reflection;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.socket.SocketChannel;
 
 import java.lang.reflect.Method;
 
-public class PEChannelInitializerModern extends ChannelInitializer<SocketChannel> {
+public class PEChannelInitializerModern extends ChannelInitializer<Channel> {
     private final ChannelInitializer<?> oldChannelInitializer;
     private Method initChannelMethod;
 
@@ -52,8 +51,8 @@ public class PEChannelInitializerModern extends ChannelInitializer<SocketChannel
     }
 
     @Override
-    protected void initChannel(SocketChannel socketChannel) throws Exception {
-        initChannelMethod.invoke(oldChannelInitializer, socketChannel);
-        postInitChannel(socketChannel);
+    protected void initChannel(Channel channel) throws Exception {
+        initChannelMethod.invoke(oldChannelInitializer, channel);
+        postInitChannel(channel);
     }
 }


### PR DESCRIPTION
Hello, Geyser person here. We're working on some changes to inject Geyser players in the server so they don't create a TCP connection. However, the channels they use aren't SocketChannels, meaning this library would break with the changes. This PR rectifies that by setting all mentions of SocketChannel to Channel. Tested with Paper 1.16.5 and CraftBukkit 1.7.10 using the Attack Detector example plugin.

Without these changes, https://github.com/PaperMC/Paper/pull/5611 will also break. 

Thanks!