### PR TITLE
Don't allow the handler to be added twice

### DIFF
--- a/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/PEChannelInitializerLegacy.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/legacy/early/PEChannelInitializerLegacy.java
@@ -48,7 +48,12 @@ public class PEChannelInitializerLegacy extends ChannelInitializer<Channel> {
         initChannelMethod.invoke(oldChannelInitializer, channel);
         PlayerChannelHandlerLegacy channelHandler = new PlayerChannelHandlerLegacy();
         if (channel.pipeline().get("packet_handler") != null) {
-            channel.pipeline().addBefore("packet_handler", PacketEvents.get().getHandlerName(), channelHandler);
+            String handlerName = PacketEvents.get().getHandlerName();
+            if (channel.pipeline().get(handlerName) != null) {
+                PacketEvents.get().getPlugin().getLogger().warning("[PacketEvents] Attempted to initialize a channel twice!");
+            } else {
+                channel.pipeline().addBefore("packet_handler", handlerName, channelHandler);
+            }
         }
     }
 }

--- a/src/main/java/io/github/retrooper/packetevents/injector/modern/early/PEChannelInitializerModern.java
+++ b/src/main/java/io/github/retrooper/packetevents/injector/modern/early/PEChannelInitializerModern.java
@@ -38,7 +38,12 @@ public class PEChannelInitializerModern extends ChannelInitializer<Channel> {
     public static void postInitChannel(Channel channel) {
         PlayerChannelHandlerModern channelHandler = new PlayerChannelHandlerModern();
         if (channel.pipeline().get("packet_handler") != null) {
-            channel.pipeline().addBefore("packet_handler", PacketEvents.get().getHandlerName(), channelHandler);
+            String handlerName = PacketEvents.get().getHandlerName();
+            if (channel.pipeline().get(handlerName) != null) {
+                PacketEvents.get().getPlugin().getLogger().warning("[PacketEvents] Attempted to initialize a channel twice!");
+            } else {
+                channel.pipeline().addBefore("packet_handler", handlerName, channelHandler);
+            }
         }
     }
 


### PR DESCRIPTION
Hello once again! This is indirectly a Geyser issue, but I will explain what's going on over on our end.

In order to get Geyser clients onto the server using our upcoming "direct injection" method that doesn't require initializing a TCP connection, we need to copy the ChannelInitializer of the existing ChannelFuture: https://github.com/Camotoy/Geyser/blob/inject/bootstrap/spigot/src/main/java/org/geysermc/platform/spigot/GeyserSpigotInjector.java#L106. Because PacketEvents is a library and not a plugin, we can't try to inject our changes before yours (because it's not bound to one plugin ID or class name), so that ChannelInitializer we copy could have the PacketEvents injection. Then, when we put our new ChannelFuture into the ServerConnection list, PacketEvents will replace the ChannelInitializer in the new ChannelFuture, meaning the PacketEvents ChannelInitializer code will be ran twice, and a stack trace is produced. 

This PR just checks to see if PacketEvents' injector was already injected, and doesn't inject if so.

I didn't initially catch this because I was running Paper with its new injection code. The error is only thrown on Spigot or pre-1.16.5.

Let me know if you want a test Geyser instance that would throw an error prior to this PR.