### PR TITLE
Fix FLYING packet on 1.17

### DIFF
--- a/src/main/java/io/github/retrooper/packetevents/packettype/PacketType.java
+++ b/src/main/java/io/github/retrooper/packetevents/packettype/PacketType.java
@@ -220,7 +220,7 @@ public class PacketType {
                 insertPacketID(PacketTypeClasses.Play.Client.POSITION, POSITION);
                 insertPacketID(PacketTypeClasses.Play.Client.POSITION_LOOK, POSITION_LOOK);
                 insertPacketID(PacketTypeClasses.Play.Client.LOOK, LOOK);
-                insertPacketID(PacketTypeClasses.Play.Client.FLYING, FLYING);
+                insertPacketID(PacketTypeClasses.Play.Client.GROUND, FLYING);
                 insertPacketID(PacketTypeClasses.Play.Client.VEHICLE_MOVE, VEHICLE_MOVE);
                 insertPacketID(PacketTypeClasses.Play.Client.BOAT_MOVE, BOAT_MOVE);
                 insertPacketID(PacketTypeClasses.Play.Client.PICK_ITEM, PICK_ITEM);

--- a/src/main/java/io/github/retrooper/packetevents/packettype/PacketTypeClasses.java
+++ b/src/main/java/io/github/retrooper/packetevents/packettype/PacketTypeClasses.java
@@ -139,7 +139,7 @@ public class PacketTypeClasses {
         public static class Client {
             private static String COMMON_PREFIX;
             private static String PREFIX;
-            public static Class<?> FLYING, POSITION, POSITION_LOOK, LOOK, CLIENT_COMMAND,
+            public static Class<?> FLYING, POSITION, POSITION_LOOK, LOOK, GROUND, CLIENT_COMMAND,
                     TRANSACTION, BLOCK_DIG, ENTITY_ACTION, USE_ENTITY,
                     WINDOW_CLICK, STEER_VEHICLE, CUSTOM_PAYLOAD, ARM_ANIMATION,
                     BLOCK_PLACE, USE_ITEM, ABILITIES, HELD_ITEM_SLOT,
@@ -172,7 +172,12 @@ public class PacketTypeClasses {
                     POSITION_LOOK = SubclassUtil.getSubClass(FLYING, "PacketPlayInPositionLook");
                     LOOK = SubclassUtil.getSubClass(FLYING, "PacketPlayInLook");
                 }
-
+                if (PacketEvents.get().getServerUtils().getVersion().isNewerThanOrEquals(ServerVersion.v_1_17)) {
+                    GROUND = SubclassUtil.getSubClass(FLYING, "d");
+                }
+                else {
+                    GROUND = FLYING;
+                }
                 //This packet does not exist in the 1.17+ protocol
                 TRANSACTION = Reflection.getClassByNameWithoutException(COMMON_PREFIX + "Transaction");
                 //This packet was added in 1.17 protocol


### PR DESCRIPTION
It's a subclass of the FLYING packet and isn't a packet itself.  I'm calling it GROUND because it only has the ground status without anything else updated.  I've left the packet name as FLYING to maintain compatibility with previous versions, although it would be technically more correct to rename it all to GROUND.