### PR TITLE
Fixed WrapperPlayServerSpawnPlayer and WrapperPlayServerEntityTeleport for 1.8 & 1.7.10

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityTeleport.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityTeleport.java
@@ -87,8 +87,8 @@ public class WrapperPlayServerEntityTeleport extends PacketWrapper<WrapperPlaySe
 
     @Override
     public void writeData() {
+        writeVarInt(entityID);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
-            writeVarInt(entityID);
             writeDouble(position.x);
             writeDouble(position.y);
             writeDouble(position.z);
@@ -96,7 +96,6 @@ public class WrapperPlayServerEntityTeleport extends PacketWrapper<WrapperPlaySe
             writeByte((int) (pitch * ROTATION_FACTOR));
             writeBoolean(onGround);
         } else {
-            writeInt(entityID);
             writeInt(MathUtil.floor(position.x * 32.0));
             writeInt(MathUtil.floor(position.y * 32.0));
             writeInt(MathUtil.floor(position.z * 32.0));

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityTeleport.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityTeleport.java
@@ -57,22 +57,18 @@ public class WrapperPlayServerEntityTeleport extends PacketWrapper<WrapperPlaySe
 
     @Override
     public void readData() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
+        if (serverVersion == ServerVersion.V_1_7_10) {
+             entityID = readInt();
+            position = new Vector3d((readInt() / 32.0), (readInt() / 32.0), (readInt() / 32.0));
+            yaw = readByte() / ROTATION_FACTOR;
+            pitch = readByte() / ROTATION_FACTOR;
+            onGround = false;
+        } else {
             entityID = readVarInt();
             position = new Vector3d(readDouble(), readDouble(), readDouble());
             yaw = readByte() / ROTATION_FACTOR;
             pitch = readByte() / ROTATION_FACTOR;
             onGround = readBoolean();
-        } else {
-            entityID = readInt();
-            position = new Vector3d((readInt() / 32.0), (readInt() / 32.0), (readInt() / 32.0));
-            yaw = readByte() / ROTATION_FACTOR;
-            pitch = readByte() / ROTATION_FACTOR;
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-                onGround = readBoolean();
-            } else {
-                onGround = false;
-            }
         }
     }
 
@@ -87,23 +83,21 @@ public class WrapperPlayServerEntityTeleport extends PacketWrapper<WrapperPlaySe
 
     @Override
     public void writeData() {
-        writeVarInt(entityID);
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
+        if (serverVersion == ServerVersion.V_1_7_10) {
+            writeInt(entityID);
+            writeInt(MathUtil.floor(position.x * 32.0));
+            writeInt(MathUtil.floor(position.y * 32.0));
+            writeInt(MathUtil.floor(position.z * 32.0));
+            writeByte((int) (yaw * ROTATION_FACTOR));
+            writeByte((int) (pitch * ROTATION_FACTOR));
+        } else {
+            writeVarInt(entityID);
             writeDouble(position.x);
             writeDouble(position.y);
             writeDouble(position.z);
             writeByte((int) (yaw * ROTATION_FACTOR));
             writeByte((int) (pitch * ROTATION_FACTOR));
             writeBoolean(onGround);
-        } else {
-            writeInt(MathUtil.floor(position.x * 32.0));
-            writeInt(MathUtil.floor(position.y * 32.0));
-            writeInt(MathUtil.floor(position.z * 32.0));
-            writeByte((int) (yaw * ROTATION_FACTOR));
-            writeByte((int) (pitch * ROTATION_FACTOR));
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-                writeBoolean(onGround);
-            }
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPlayer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPlayer.java
@@ -123,7 +123,7 @@ public class WrapperPlayServerSpawnPlayer extends PacketWrapper<WrapperPlayServe
         writeByte((byte) (yaw * ROTATION_DIVISOR));
         writeByte((byte) (pitch * ROTATION_DIVISOR));
         if (!v1_9) {
-            writeByte(item.getId());
+            writeShort(item.getId());
         }
         if (serverVersion.isOlderThan(ServerVersion.V_1_15)) {
             writeEntityMetadata(entityMetadata);

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -50,8 +50,8 @@ shadowJar {
     archiveClassifier.set('')
     archiveVersion.set('')
 
-    relocate("net.kyori", "com.github.retrooper.packetevents.libs.kyori")
-    relocate("com.google.gson", "com.github.retrooper.packetevents.libs.gson")
+    // Do not relocate 'net.kyori' because this is a issue for api users
+//    relocate("com.google.gson", "com.github.retrooper.packetevents.libs.gson")
     minimize()
 }
 


### PR DESCRIPTION
Fixes for 1.8 and lower named entity spawn

Removed relocation of libraries as it was changing imports of adventure api and logging errors for its usecase
![image](https://user-images.githubusercontent.com/71663979/150538276-d8182ece-f1e8-406e-b04e-91a9da7d4bc5.png)
