### PR TITLE
Fixed incorrect HealthDisplay data in ScoreboardObjective wrapper

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerScoreboardObjective.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerScoreboardObjective.java
@@ -1,6 +1,5 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
-import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -55,7 +54,11 @@ public class WrapperPlayServerScoreboardObjective extends PacketWrapper<WrapperP
         name = readString();
         mode = ObjectiveMode.values()[readByte()];
         displayName = Optional.ofNullable(readString());
-        display = Optional.ofNullable(HealthDisplay.getByName(readString()));
+        if (serverVersion.isOlderThan(ServerVersion.V_1_13)) {
+            display = Optional.ofNullable(HealthDisplay.getByName(readString()));
+        } else {
+            display = Optional.of(HealthDisplay.values()[readVarInt()]);
+        }
     }
 
     @Override
@@ -74,8 +77,10 @@ public class WrapperPlayServerScoreboardObjective extends PacketWrapper<WrapperP
             writeString(displayName.orElse(""));
             if (serverVersion == ServerVersion.V_1_7_10)
                 writeString("integer");
-            else
+            else if (serverVersion.isOlderThan(ServerVersion.V_1_13))
                 writeString(display.orElse(HealthDisplay.INTEGER).name().toLowerCase());
+            else
+                writeVarInt(display.orElse(HealthDisplay.INTEGER).ordinal());
         }
     }
 


### PR DESCRIPTION
ScoreboardObjective wrapper wasn't using the correct health display read/write for 1.13+

This PR fixes it