### PR TITLE
Don't clone on vector add/subtract

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -151,28 +151,26 @@ public class Vector3d {
         return new Vector3d(getX(), getY(), getZ());
     }
 
-    public Vector3d add(Vector3d target) {
-        Vector3d result = new Vector3d(x, y, z);
-        result.x += target.x;
-        result.y += target.y;
-        result.z += target.z;
-        return result;
-    }
-
     public Vector3d add(double x, double y, double z) {
-        return add(new Vector3d(x, y, z));
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
     }
 
-    public Vector3d subtract(Vector3d target) {
-        Vector3d result = new Vector3d(x, y, z);
-        result.x -= target.x;
-        result.y -= target.y;
-        result.z -= target.z;
-        return result;
+    public Vector3d add(Vector3d target) {
+        return add(target.x, target.y, target.z);
     }
 
     public Vector3d subtract(double x, double y, double z) {
-        return subtract(new Vector3d(x, y, z));
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
+    }
+
+    public Vector3d subtract(Vector3d target) {
+        return subtract(target.x, target.y, target.z);
     }
 
     public double distance(Vector3d target) {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -151,6 +151,28 @@ public class Vector3f {
         return new Vector3f(getX(), getY(), getZ());
     }
 
+    public Vector3f add(float x, float y, float z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
+    }
+
+    public Vector3f add(Vector3f target) {
+        return add(target.x, target.y, target.z);
+    }
+
+    public Vector3f subtract(float x, float y, float z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
+    }
+
+    public Vector3f subtract(Vector3f target) {
+        return subtract(target.x, target.y, target.z);
+    }
+
     @Override
     public String toString() {
         return "X: " + x + ", Y: " + y + ", Z: " + z;

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -207,6 +207,28 @@ public class Vector3i {
         return new Vector3i(getX(), getY(), getZ());
     }
 
+    public Vector3i add(int x, int y, int z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
+    }
+
+    public Vector3i add(Vector3i target) {
+        return add(target.x, target.y, target.z);
+    }
+
+    public Vector3i subtract(int x, int y, int z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
+    }
+
+    public Vector3i subtract(Vector3i target) {
+        return subtract(target.x, target.y, target.z);
+    }
+
     @Override
     public String toString() {
         return "X: " + x + ", Y: " + y + ", Z: " + z;


### PR DESCRIPTION
Right now vectors are this super weird mix of mutable/immutable, with the add/subtract methods cloning the vector before doing their operation. I think it would be better if these methods operated on the object itself instead of cloning and returning, as vectors aren't immutable and current behavior is weird.