### PR TITLE
Added WrapperPlayClientUpdateCommandBlock and WrapperPlayClientUpdateCommandBlockMinecart

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
@@ -19,140 +19,139 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 // From MCProtocolLib
 public class WrapperPlayClientUpdateCommandBlock extends PacketWrapper<WrapperPlayClientUpdateCommandBlock> {
-  private static final int FLAG_TRACK_OUTPUT = 0x01;
-  private static final int FLAG_CONDITIONAL = 0x02;
-  private static final int FLAG_AUTOMATIC = 0x04;
+    private static final int FLAG_TRACK_OUTPUT = 0x01;
+    private static final int FLAG_CONDITIONAL = 0x02;
+    private static final int FLAG_AUTOMATIC = 0x04;
 
-  private Vector3i position;
-  private String command;
-  private CommandBlockMode mode;
-  private boolean doesTrackOutput;
-  private boolean conditional;
-  private boolean automatic;
-  // PacketEvents
-  private short flags;
+    private Vector3i position;
+    private String command;
+    private CommandBlockMode mode;
+    private boolean doesTrackOutput;
+    private boolean conditional;
+    private boolean automatic;
+    // PacketEvents
+    private short flags;
 
-  public WrapperPlayClientUpdateCommandBlock(PacketReceiveEvent event) {
-    super(event);
-  }
-
-  public WrapperPlayClientUpdateCommandBlock(Vector3i position, String command, CommandBlockMode mode, boolean doesTrackOutput, boolean conditional, boolean automatic) {
-    super(PacketType.Play.Client.UPDATE_COMMAND_BLOCK);
-    this.position = position;
-    this.command = command;
-    this.mode = mode;
-    this.doesTrackOutput = doesTrackOutput;
-    this.conditional = conditional;
-    this.automatic = automatic;
-  }
-
-  @Override
-  public void read() {
-    this.position = new Vector3i(readLong());
-    this.command = readString();
-    this.mode = CommandBlockMode.VALUES[readVarInt()];
-    this.flags = readUnsignedByte();
-    this.doesTrackOutput = (flags & FLAG_TRACK_OUTPUT) != 0;
-    this.conditional = (flags & FLAG_CONDITIONAL) != 0;
-    this.automatic = (flags & FLAG_AUTOMATIC) != 0;
-  }
-
-  @Override
-  public void write() {
-    writeLong(position.getSerializedPosition());
-    writeString(command);
-    writeVarInt(mode.ordinal());
-    if (this.doesTrackOutput) {
-      flags |= FLAG_TRACK_OUTPUT;
+    public WrapperPlayClientUpdateCommandBlock(PacketReceiveEvent event) {
+        super(event);
     }
-    if (this.conditional) {
-      flags |= FLAG_CONDITIONAL;
+
+    public WrapperPlayClientUpdateCommandBlock(Vector3i position, String command, CommandBlockMode mode, boolean doesTrackOutput, boolean conditional, boolean automatic) {
+        super(PacketType.Play.Client.UPDATE_COMMAND_BLOCK);
+        this.position = position;
+        this.command = command;
+        this.mode = mode;
+        this.doesTrackOutput = doesTrackOutput;
+        this.conditional = conditional;
+        this.automatic = automatic;
     }
-    if (this.automatic) {
-      flags |= FLAG_AUTOMATIC;
+
+    @Override
+    public void read() {
+        this.position = new Vector3i(readLong());
+        this.command = readString();
+        this.mode = CommandBlockMode.VALUES[readVarInt()];
+        this.flags = readUnsignedByte();
+        this.doesTrackOutput = (flags & FLAG_TRACK_OUTPUT) != 0;
+        this.conditional = (flags & FLAG_CONDITIONAL) != 0;
+        this.automatic = (flags & FLAG_AUTOMATIC) != 0;
     }
-    writeByte(flags);
-  }
 
-  @Override
-  public void copy(WrapperPlayClientUpdateCommandBlock wrapper) {
-    this.position = wrapper.position;
-    this.command = wrapper.command;
-    this.mode = wrapper.mode;
-    this.doesTrackOutput = wrapper.doesTrackOutput;
-    this.conditional = wrapper.conditional;
-    this.automatic = wrapper.automatic;
-    this.flags = wrapper.flags;
-  }
+    @Override
+    public void write() {
+        writeLong(position.getSerializedPosition());
+        writeString(command);
+        writeVarInt(mode.ordinal());
+        if (this.doesTrackOutput) {
+            flags |= FLAG_TRACK_OUTPUT;
+        }
+        if (this.conditional) {
+            flags |= FLAG_CONDITIONAL;
+        }
+        if (this.automatic) {
+            flags |= FLAG_AUTOMATIC;
+        }
+        writeByte(flags);
+    }
 
-  public Vector3i getPosition() {
-    return position;
-  }
+    @Override
+    public void copy(WrapperPlayClientUpdateCommandBlock wrapper) {
+        this.position = wrapper.position;
+        this.command = wrapper.command;
+        this.mode = wrapper.mode;
+        this.doesTrackOutput = wrapper.doesTrackOutput;
+        this.conditional = wrapper.conditional;
+        this.automatic = wrapper.automatic;
+        this.flags = wrapper.flags;
+    }
 
-  public void setPosition(Vector3i position) {
-    this.position = position;
-  }
+    public Vector3i getPosition() {
+        return position;
+    }
 
-  public String getCommand() {
-    return command;
-  }
+    public void setPosition(Vector3i position) {
+        this.position = position;
+    }
 
-  public void setCommand(String command) {
-    this.command = command;
-  }
+    public String getCommand() {
+        return command;
+    }
 
-  public CommandBlockMode getMode() {
-    return mode;
-  }
+    public void setCommand(String command) {
+        this.command = command;
+    }
 
-  public void setMode(CommandBlockMode mode) {
-    this.mode = mode;
-  }
+    public CommandBlockMode getMode() {
+        return mode;
+    }
 
-  public boolean isDoesTrackOutput() {
-    return doesTrackOutput;
-  }
+    public void setMode(CommandBlockMode mode) {
+        this.mode = mode;
+    }
 
-  public void setDoesTrackOutput(boolean doesTrackOutput) {
-    this.doesTrackOutput = doesTrackOutput;
-  }
+    public boolean isDoesTrackOutput() {
+        return doesTrackOutput;
+    }
 
-  public boolean isConditional() {
-    return conditional;
-  }
+    public void setDoesTrackOutput(boolean doesTrackOutput) {
+        this.doesTrackOutput = doesTrackOutput;
+    }
 
-  public void setConditional(boolean conditional) {
-    this.conditional = conditional;
-  }
+    public boolean isConditional() {
+        return conditional;
+    }
 
-  public boolean isAutomatic() {
-    return automatic;
-  }
+    public void setConditional(boolean conditional) {
+        this.conditional = conditional;
+    }
 
-  public void setAutomatic(boolean automatic) {
-    this.automatic = automatic;
-  }
+    public boolean isAutomatic() {
+        return automatic;
+    }
 
-  public short getFlags() {
-    return flags;
-  }
+    public void setAutomatic(boolean automatic) {
+        this.automatic = automatic;
+    }
 
-  public void setFlags(short flags) {
-    this.flags = flags;
-  }
+    public short getFlags() {
+        return flags;
+    }
 
-  public enum CommandBlockMode {
-    SEQUENCE,
-    AUTO,
-    REDSTONE;
+    public void setFlags(short flags) {
+        this.flags = flags;
+    }
 
-    public static final CommandBlockMode[] VALUES = values();
-  }
+    public enum CommandBlockMode {
+        SEQUENCE,
+        AUTO,
+        REDSTONE;
+
+        public static final CommandBlockMode[] VALUES = values();
+    }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
@@ -55,17 +55,9 @@ public class WrapperPlayClientUpdateCommandBlock extends PacketWrapper<WrapperPl
 
   @Override
   public void read() {
-    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-      this.position = new Vector3i(readLong());
-    } else {
-      int x = readInt();
-      int y = readShort();
-      int z = readInt();
-      this.position = new Vector3i(x, y, z);
-    }
+    this.position = new Vector3i(readLong());
     this.command = readString();
     this.mode = CommandBlockMode.VALUES[readVarInt()];
-
     this.flags = readUnsignedByte();
     this.doesTrackOutput = (flags & FLAG_TRACK_OUTPUT) != 0;
     this.conditional = (flags & FLAG_CONDITIONAL) != 0;
@@ -74,29 +66,18 @@ public class WrapperPlayClientUpdateCommandBlock extends PacketWrapper<WrapperPl
 
   @Override
   public void write() {
-    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-      long positionVector = position.getSerializedPosition();
-      writeLong(positionVector);
-    } else {
-      writeInt(position.x);
-      writeShort(position.y);
-      writeInt(position.z);
-    }
+    writeLong(position.getSerializedPosition());
     writeString(command);
     writeVarInt(mode.ordinal());
-
     if (this.doesTrackOutput) {
       flags |= FLAG_TRACK_OUTPUT;
     }
-
     if (this.conditional) {
       flags |= FLAG_CONDITIONAL;
     }
-
     if (this.automatic) {
       flags |= FLAG_AUTOMATIC;
     }
-
     writeByte(flags);
   }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlock.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2021 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.play.client;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+
+// From MCProtocolLib
+public class WrapperPlayClientUpdateCommandBlock extends PacketWrapper<WrapperPlayClientUpdateCommandBlock> {
+  private static final int FLAG_TRACK_OUTPUT = 0x01;
+  private static final int FLAG_CONDITIONAL = 0x02;
+  private static final int FLAG_AUTOMATIC = 0x04;
+
+  private Vector3i position;
+  private String command;
+  private CommandBlockMode mode;
+  private boolean doesTrackOutput;
+  private boolean conditional;
+  private boolean automatic;
+  // PacketEvents
+  private short flags;
+
+  public WrapperPlayClientUpdateCommandBlock(PacketReceiveEvent event) {
+    super(event);
+  }
+
+  public WrapperPlayClientUpdateCommandBlock(Vector3i position, String command, CommandBlockMode mode, boolean doesTrackOutput, boolean conditional, boolean automatic) {
+    super(PacketType.Play.Client.UPDATE_COMMAND_BLOCK);
+    this.position = position;
+    this.command = command;
+    this.mode = mode;
+    this.doesTrackOutput = doesTrackOutput;
+    this.conditional = conditional;
+    this.automatic = automatic;
+  }
+
+  @Override
+  public void read() {
+    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+      this.position = new Vector3i(readLong());
+    } else {
+      int x = readInt();
+      int y = readShort();
+      int z = readInt();
+      this.position = new Vector3i(x, y, z);
+    }
+    this.command = readString();
+    this.mode = CommandBlockMode.VALUES[readVarInt()];
+
+    this.flags = readUnsignedByte();
+    this.doesTrackOutput = (flags & FLAG_TRACK_OUTPUT) != 0;
+    this.conditional = (flags & FLAG_CONDITIONAL) != 0;
+    this.automatic = (flags & FLAG_AUTOMATIC) != 0;
+  }
+
+  @Override
+  public void write() {
+    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+      long positionVector = position.getSerializedPosition();
+      writeLong(positionVector);
+    } else {
+      writeInt(position.x);
+      writeShort(position.y);
+      writeInt(position.z);
+    }
+    writeString(command);
+    writeVarInt(mode.ordinal());
+
+    if (this.doesTrackOutput) {
+      flags |= FLAG_TRACK_OUTPUT;
+    }
+
+    if (this.conditional) {
+      flags |= FLAG_CONDITIONAL;
+    }
+
+    if (this.automatic) {
+      flags |= FLAG_AUTOMATIC;
+    }
+
+    writeByte(flags);
+  }
+
+  @Override
+  public void copy(WrapperPlayClientUpdateCommandBlock wrapper) {
+    this.position = wrapper.position;
+    this.command = wrapper.command;
+    this.mode = wrapper.mode;
+    this.doesTrackOutput = wrapper.doesTrackOutput;
+    this.conditional = wrapper.conditional;
+    this.automatic = wrapper.automatic;
+    this.flags = wrapper.flags;
+  }
+
+  public Vector3i getPosition() {
+    return position;
+  }
+
+  public void setPosition(Vector3i position) {
+    this.position = position;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public void setCommand(String command) {
+    this.command = command;
+  }
+
+  public CommandBlockMode getMode() {
+    return mode;
+  }
+
+  public void setMode(CommandBlockMode mode) {
+    this.mode = mode;
+  }
+
+  public boolean isDoesTrackOutput() {
+    return doesTrackOutput;
+  }
+
+  public void setDoesTrackOutput(boolean doesTrackOutput) {
+    this.doesTrackOutput = doesTrackOutput;
+  }
+
+  public boolean isConditional() {
+    return conditional;
+  }
+
+  public void setConditional(boolean conditional) {
+    this.conditional = conditional;
+  }
+
+  public boolean isAutomatic() {
+    return automatic;
+  }
+
+  public void setAutomatic(boolean automatic) {
+    this.automatic = automatic;
+  }
+
+  public short getFlags() {
+    return flags;
+  }
+
+  public void setFlags(short flags) {
+    this.flags = flags;
+  }
+
+  public enum CommandBlockMode {
+    SEQUENCE,
+    AUTO,
+    REDSTONE;
+
+    public static final CommandBlockMode[] VALUES = values();
+  }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlockMinecart.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateCommandBlockMinecart.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2021 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.play.client;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+
+public class WrapperPlayClientUpdateCommandBlockMinecart extends PacketWrapper<WrapperPlayClientUpdateCommandBlockMinecart> {
+  private int entityId;
+  private String command;
+  private boolean trackOutput;
+
+  public WrapperPlayClientUpdateCommandBlockMinecart(PacketReceiveEvent event) {
+    super(event);
+  }
+
+  public WrapperPlayClientUpdateCommandBlockMinecart(int entityId, String command, boolean trackOutput) {
+    super(PacketType.Play.Client.UPDATE_COMMAND_BLOCK_MINECART);
+    this.entityId = entityId;
+    this.command = command;
+    this.trackOutput = trackOutput;
+  }
+
+  @Override
+  public void read() {
+    this.entityId = readVarInt();
+    this.command = readString();
+    this.trackOutput = readBoolean();
+  }
+
+  @Override
+  public void write() {
+    writeVarInt(this.entityId);
+    writeString(this.command);
+    writeBoolean(this.trackOutput);
+  }
+
+  @Override
+  public void copy(WrapperPlayClientUpdateCommandBlockMinecart wrapper) {
+    this.entityId = wrapper.entityId;
+    this.command = wrapper.command;
+    this.trackOutput = wrapper.trackOutput;
+  }
+
+  public int getEntityId() {
+    return entityId;
+  }
+
+  public void setEntityId(int entityId) {
+    this.entityId = entityId;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public void setCommand(String command) {
+    this.command = command;
+  }
+
+  public boolean isTrackOutput() {
+    return trackOutput;
+  }
+
+  public void setTrackOutput(boolean trackOutput) {
+    this.trackOutput = trackOutput;
+  }
+}


### PR DESCRIPTION
Both packets were introduced in server version 1.13, so they will not work for lower versions - logically.
Tested Server-Versions: 1.13.2, 1.14.4, 1.16.5, 1.18.2