### PR TITLE
Fxed memory leak with UUID objects

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/MessageSender.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/MessageSender.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.protocol.chat;
 
+import com.github.retrooper.packetevents.util.UUIDUtil;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +37,7 @@ public class MessageSender {
     }
 
     public MessageSender(@Nullable Component displayName, @Nullable Component teamName) {
-        this(new UUID(0L, 0L), displayName, teamName);
+        this(UUIDUtil.DUMMY, displayName, teamName);
     }
 
     public UUID getUUID() {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/UUIDUtil.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/UUIDUtil.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class UUIDUtil {
+    public static final UUID DUMMY = new UUID(0L, 0L);
     private static final Pattern PATTERN = Pattern.compile("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})");
 
     public static UUID fromStringWithoutDashes(String uuid) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChatMessage.java
@@ -25,6 +25,7 @@ import com.github.retrooper.packetevents.protocol.chat.MessageSender;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.util.AdventureSerializer;
+import com.github.retrooper.packetevents.util.UUIDUtil;
 import com.github.retrooper.packetevents.util.crypto.SaltSignature;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import net.kyori.adventure.text.Component;
@@ -181,7 +182,7 @@ public class WrapperPlayServerChatMessage extends PacketWrapper<WrapperPlayServe
             //UUID never null, if unspecified, it should be 0L, 0L
             UUID uuid = sender.getUUID();
             if (uuid == null) {
-                uuid = new UUID(0L, 0L);
+                uuid = UUIDUtil.DUMMY;
             }
             writeUUID(uuid);
             if (v1_19) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnEntity.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnEntity.java
@@ -24,6 +24,7 @@ import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.MathUtil;
+import com.github.retrooper.packetevents.util.UUIDUtil;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
@@ -138,7 +139,7 @@ public class WrapperPlayServerSpawnEntity extends PacketWrapper<WrapperPlayServe
         boolean v1_15 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15);
         boolean v1_19 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19);
         if (v1_9) {
-            writeUUID(uuid.orElse(new UUID(0L, 0L)));
+            writeUUID(uuid.orElse(UUIDUtil.DUMMY));
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_14)) {
             writeVarInt(entityType.getId(serverVersion.toClientVersion()));

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnLivingEntity.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnLivingEntity.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.world.Location;
 import com.github.retrooper.packetevents.util.MathUtil;
+import com.github.retrooper.packetevents.util.UUIDUtil;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
@@ -76,7 +77,7 @@ public class WrapperPlayServerSpawnLivingEntity extends PacketWrapper<WrapperPla
     public void read() {
         this.entityID = readVarInt();
         if (serverVersion.isOlderThan(ServerVersion.V_1_9)) {
-            this.entityUUID = new UUID(0L, 0L);
+            this.entityUUID = UUIDUtil.DUMMY;
             int entityTypeID = readByte() & 255;
             entityType = EntityTypes.getById(serverVersion.toClientVersion(), entityTypeID);
             this.position = new Vector3d(readInt() / POSITION_FACTOR, readInt() / POSITION_FACTOR, readInt() / POSITION_FACTOR);

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
@@ -23,6 +23,7 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.world.Direction;
 import com.github.retrooper.packetevents.protocol.world.PaintingType;
+import com.github.retrooper.packetevents.util.UUIDUtil;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +44,7 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
     }
 
     public WrapperPlayServerSpawnPainting(int entityId, Vector3i position, Direction direction) {
-        this(entityId, new UUID(0L, 0L), null, position, direction);
+        this(entityId, UUIDUtil.DUMMY, null, position, direction);
     }
 
     public WrapperPlayServerSpawnPainting(int entityId, UUID uuid, Vector3i position, Direction direction) {
@@ -65,7 +66,7 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
             this.uuid = readUUID();
         } else {
-            this.uuid = new UUID(0L, 0L);
+            this.uuid = UUIDUtil.DUMMY;
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_13)) {
             this.type = PaintingType.getById(readVarInt());


### PR DESCRIPTION
Creating new UUID objects will lead to a memory leak after some time, so we just cache one value and use that.