### PR TITLE
Cleaned up and improved some wrappers

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/server/MultiVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/server/MultiVersion.java
@@ -1,0 +1,27 @@
+package com.github.retrooper.packetevents.manager.server;
+
+/**
+ * This enum contains all possible comparison types for server versions.
+ */
+public enum MultiVersion {
+    /*
+    The server version equals the compared server version.
+     */
+    EQUALS,
+    /*
+    The server version is newer than the compared server version.
+     */
+    NEWER_THAN,
+    /*
+    The server version is newer than or equal to the compared server version.
+     */
+    NEWER_THAN_OR_EQUALS,
+    /*
+    The server version is older than the compared server version.
+     */
+    OLDER_THAN,
+    /*
+    The server version is older than or equal to the compared server version.
+     */
+    OLDER_THAN_OR_EQUALS;
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
@@ -19,7 +19,6 @@
 package com.github.retrooper.packetevents.manager.server;
 
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.ApiStatus.Experimental;
 import org.jetbrains.annotations.NotNull;
 
@@ -242,6 +241,8 @@ public enum ServerVersion {
     @Experimental
     public boolean is(@NotNull MultiVersion version, @NotNull ServerVersion target) {
         switch (version) {
+            case EQUALS:
+                return protocolVersion == target.protocolVersion;
             case NEWER_THAN:
                 return isNewerThan(target);
             case NEWER_THAN_OR_EQUALS:
@@ -252,27 +253,5 @@ public enum ServerVersion {
                 return isOlderThanOrEquals(target);
         }
         return false;
-    }
-
-    /**
-     * This enum contains all possible comparison types for server versions.
-     */
-    public enum MultiVersion {
-        /*
-        The server version is newer than the compared server version.
-         */
-        NEWER_THAN,
-        /*
-        The server version is newer than or equal to the compared server version.
-         */
-        NEWER_THAN_OR_EQUALS,
-        /*
-        The server version is older than the compared server version.
-         */
-        OLDER_THAN,
-        /*
-        The server version is older than or equal to the compared server version.
-         */
-        OLDER_THAN_OR_EQUALS;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatVisibility.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatVisibility.java
@@ -1,0 +1,13 @@
+package com.github.retrooper.packetevents.protocol.chat;
+
+public enum ChatVisibility {
+    FULL,
+    SYSTEM,
+    HIDDEN;
+
+    private static final ChatVisibility[] VALUES = values();
+
+    public static ChatVisibility getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandMatch.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandMatch.java
@@ -1,0 +1,36 @@
+package com.github.retrooper.packetevents.protocol.command;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class CommandMatch {
+    private String text;
+    private @Nullable Component tooltip;
+
+    public CommandMatch(String text) {
+        this(text, Component.empty());
+    }
+
+    public CommandMatch(String text, @Nullable Component tooltip) {
+        this.text = text;
+        this.tooltip = tooltip;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Optional<Component> getTooltip() {
+        return Optional.ofNullable(tooltip);
+    }
+
+    public void setTooltip(@Nullable Component tooltip) {
+        this.tooltip = tooltip;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandRange.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandRange.java
@@ -1,0 +1,31 @@
+package com.github.retrooper.packetevents.protocol.command;
+
+public class CommandRange {
+    private int begin;
+    private int end;
+
+    public CommandRange(int begin, int end) {
+        this.begin = begin;
+        this.end = end;
+    }
+
+    public int getBegin() {
+        return begin;
+    }
+
+    public void setBegin(int begin) {
+        this.begin = begin;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public int getLength() {
+        return end - begin;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityAction.java
@@ -1,0 +1,19 @@
+package com.github.retrooper.packetevents.protocol.entity;
+
+public enum EntityAction {
+    START_SNEAKING,
+    STOP_SNEAKING,
+    LEAVE_BED,
+    START_SPRINTING,
+    STOP_SPRINTING,
+    START_JUMPING_WITH_HORSE,
+    STOP_JUMPING_WITH_HORSE,
+    OPEN_HORSE_INVENTORY,
+    START_FLYING_WITH_ELYTRA;
+
+    private static final EntityAction[] VALUES = values();
+
+    public EntityAction getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityInteractAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityInteractAction.java
@@ -1,0 +1,13 @@
+package com.github.retrooper.packetevents.protocol.entity;
+
+public enum InteractAction {
+    INTERACT,
+    ATTACK,
+    INTERACT_AT;
+
+    private static final InteractAction[] VALUES = values();
+
+    public static InteractAction getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityInteractAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityInteractAction.java
@@ -1,13 +1,13 @@
 package com.github.retrooper.packetevents.protocol.entity;
 
-public enum InteractAction {
+public enum EntityInteractAction {
     INTERACT,
     ATTACK,
     INTERACT_AT;
 
-    private static final InteractAction[] VALUES = values();
+    private static final EntityInteractAction[] VALUES = values();
 
-    public static InteractAction getById(int index) {
+    public static EntityInteractAction getById(int index) {
         return VALUES[index];
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/InteractAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/InteractAction.java
@@ -1,0 +1,13 @@
+package com.github.retrooper.packetevents.protocol.entity;
+
+public enum InteractAction {
+    INTERACT,
+    ATTACK,
+    INTERACT_AT;
+
+    private static final InteractAction[] VALUES = values();
+
+    public static InteractAction getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/data/provider/PlayerDataProvider.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/data/provider/PlayerDataProvider.java
@@ -113,7 +113,7 @@ public class PlayerDataProvider extends LivingEntityDataProvider {
                     skinPartsMask = (byte) entityData.getValue();
                     break;
                 case 18:
-                    mainArm = HumanoidArm.VALUES[(byte) entityData.getValue()];
+                    mainArm = HumanoidArm.getById((byte) entityData.getValue());
                     break;
                 case 19:
                     leftShoulderNBT = (NBTCompound) entityData.getValue();

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/npc/NPC.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/npc/NPC.java
@@ -22,6 +22,7 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.player.*;
+import com.github.retrooper.packetevents.protocol.scoreboard.*;
 import com.github.retrooper.packetevents.protocol.world.Location;
 import com.github.retrooper.packetevents.wrapper.play.server.*;
 import net.kyori.adventure.text.Component;
@@ -71,7 +72,9 @@ public class NPC {
     }
 
     public void spawn(Object channel) {
-        if (hasSpawned(channel)) return;
+        if (hasSpawned(channel)) {
+            return;
+        }
         WrapperPlayServerPlayerInfo playerInfoPacket =
                 new WrapperPlayServerPlayerInfo(WrapperPlayServerPlayerInfo.Action.ADD_PLAYER, getPlayerInfoData());
         PacketEvents.getAPI().getProtocolManager().sendPacket(channel, playerInfoPacket);
@@ -91,8 +94,10 @@ public class NPC {
     }
 
     public void despawn(Object channel) {
-        if (!hasSpawned(channel)) return;
-        //TODO Confirm if we need to destroy the team too
+        if (!hasSpawned(channel)) {
+            return;
+        }
+        // TODO: Confirm if we need to destroy the team too
         WrapperPlayServerDestroyEntities destroyEntities = new WrapperPlayServerDestroyEntities(getId());
         PacketEvents.getAPI().getProtocolManager().sendPacket(channel, destroyEntities);
         channels.remove(channel);
@@ -213,9 +218,7 @@ public class NPC {
         for (Object channel : channels) {
             //Destroy team
             WrapperPlayServerTeams removeTeam =
-                    new WrapperPlayServerTeams("custom_name_team",
-                            WrapperPlayServerTeams.TeamMode.REMOVE,
-                            Optional.empty());
+                    new WrapperPlayServerTeams("custom_name_team", TeamMode.REMOVE, "");
             PacketEvents.getAPI().getProtocolManager().sendPacket(channel, removeTeam);
 
             if (npc.getNameColor() != null || npc.getPrefixName() != null
@@ -369,17 +372,16 @@ public class NPC {
 
     private WrapperPlayServerTeams generateTeamsData() {
         return new WrapperPlayServerTeams("custom_name_team",
-                WrapperPlayServerTeams.TeamMode.CREATE,
-                Optional.of(
-                        new WrapperPlayServerTeams.ScoreBoardTeamInfo(
-                                Component.text("custom_name_team"),
-                                prefixName,
-                                suffixName,
-                                WrapperPlayServerTeams.NameTagVisibility.ALWAYS,
-                                WrapperPlayServerTeams.CollisionRule.ALWAYS,
-                                nameColor,
-                                WrapperPlayServerTeams.OptionData.NONE
-                        )),
+                TeamMode.CREATE,
+                new TeamInfo(
+                        Component.text("custom_name_team"),
+                        prefixName,
+                        suffixName,
+                        NameTagVisibility.ALWAYS,
+                        CollisionRule.ALWAYS,
+                        nameColor,
+                        OptionData.NONE
+                ),
                 getProfile().getName());
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/npc/NPC.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/npc/NPC.java
@@ -372,7 +372,7 @@ public class NPC {
 
     private WrapperPlayServerTeams generateTeamsData() {
         return new WrapperPlayServerTeams("custom_name_team",
-                TeamMode.CREATE,
+                TeamMode.ADD,
                 new TeamInfo(
                         Component.text("custom_name_team"),
                         prefixName,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/EquipmentSlot.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/EquipmentSlot.java
@@ -18,8 +18,13 @@
 
 package com.github.retrooper.packetevents.protocol.player;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import java.util.*;
 
 public enum EquipmentSlot {
     MAINHAND(0),
@@ -29,25 +34,69 @@ public enum EquipmentSlot {
     CHESTPLATE(3),
     HELMET(4);
 
-    private static final EquipmentSlot[] VALUES = values();
+    private static final EquipmentSlot[] VALUES;
+    private static final Map<Integer, EquipmentSlot> EQUIPMENT_SLOT_MAP;
+
+    static {
+        // TODO: Remove the cache at some point as we don't want to cache this.
+        // TODO: We can remove it after removing the deprecated method.
+        VALUES = values();
+        EQUIPMENT_SLOT_MAP = new HashMap<>(VALUES.length);
+        for (EquipmentSlot slot : VALUES) {
+            EQUIPMENT_SLOT_MAP.put(slot.getId(PacketEvents.getAPI().getServerManager().getVersion()), slot);
+        }
+    }
 
     private final byte legacyId;
 
     EquipmentSlot(int legacyId) {
-        this.legacyId =(byte) legacyId;
+        this.legacyId = (byte) legacyId;
     }
 
+    /**
+     * Gets the legacy id, or the modern id, depending on the server version.
+     * The legacy id is being returned on server versions below or equals 1.9.
+     *
+     * @param version The server version.
+     * @return The legacy id, or the modern id, depending on the server version.
+     */
     public int getId(ServerVersion version) {
         if (version.isOlderThan(ServerVersion.V_1_9)) {
             return legacyId;
-        }
-        else {
+        } else {
             return ordinal();
         }
     }
 
+    /**
+     * Get the EquipmentSlot from the given id.<p>
+     * This method only returns {@code null} if the id is not valid.</p>
+     * <p></p>
+     * <b>IMPORTANT</b><p>
+     * If your server version is below or equals 1.9, the id can only be between 0 and 4.</p>
+     * If your server version is newer than 1.9, the id can be between 0 and 5.
+     *
+     * @param id      The id of the EquipmentSlot.
+     * @return The EquipmentSlot from the given id.
+     */
+    public static Optional<EquipmentSlot> byId(@Range(from = 0, to = 5) int id) {
+        // This is O(1)
+        return Optional.ofNullable(EQUIPMENT_SLOT_MAP.get(id));
+    }
+
+    /**
+     * Gets the EquipmentSlot from the given id.
+     * This method only returns {@code null} if the id is not valid.
+     *
+     * @param version The version of the server.
+     * @param id      The id of the EquipmentSlot.
+     * @return The EquipmentSlot from the given id.
+     * @deprecated Use {@link #byId(int)} instead.
+     */
     @Nullable
-    public static EquipmentSlot getById(ServerVersion version, int id) {
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.0-RELEASE")
+    public static EquipmentSlot getById(ServerVersion version, @Range(from = 0, to = 5) int id) {
         // FIXME: try making this O(1)
         for (EquipmentSlot slot : VALUES) {
             if (slot.getId(version) == id) {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/HumanoidArm.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/HumanoidArm.java
@@ -22,13 +22,13 @@ public enum HumanoidArm {
     LEFT,
     RIGHT;
 
+    private static final HumanoidArm[] VALUES = values();
+
     public int getId() {
         return this == RIGHT ? 0 : 1;
     }
 
-    public static final HumanoidArm[] VALUES = values(); // FIXME: it is illegal(unsafe) to expose this, make it private or eliminate it!
-
-    public static HumanoidArm getById(int handValue) {
-        return handValue == 0 ? RIGHT : LEFT;
+    public static HumanoidArm getById(int index) {
+        return VALUES[index];
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/InteractionHand.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/InteractionHand.java
@@ -34,7 +34,7 @@ public enum InteractionHand {
         return ordinal();
     }
 
-    public static InteractionHand getById(int id) {
-        return VALUES[id];
+    public static InteractionHand getById(int index) {
+        return VALUES[index];
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/resourcepack/ResourcePacketResult.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/resourcepack/ResourcePacketResult.java
@@ -1,0 +1,16 @@
+package com.github.retrooper.packetevents.protocol.resourcepack;
+
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientResourcePackStatus;
+
+public enum ResourcePacketResult {
+    SUCCESSFULLY_LOADED,
+    DECLINED,
+    FAILED_DOWNLOAD,
+    ACCEPTED;
+
+    private static final ResourcePacketResult[] VALUES = values();
+
+    public static ResourcePacketResult getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/CollisionRule.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/CollisionRule.java
@@ -9,23 +9,23 @@ public enum CollisionRule {
     PUSH_OWN_TEAM("pushOwnTeam");
 
     private static final CollisionRule[] VALUES = CollisionRule.values();
-    private final String id;
+    private final String name;
 
-    CollisionRule(String id) {
-        this.id = id;
+    CollisionRule(String name) {
+        this.name = name;
     }
 
     @Nullable
-    public static CollisionRule getById(String id) {
+    public static CollisionRule getByName(String name) {
         for (CollisionRule value : VALUES) {
-            if (value.id.equalsIgnoreCase(id)) {
+            if (value.name.equalsIgnoreCase(name)) {
                 return value;
             }
         }
         return null;
     }
 
-    public String getId() {
-        return id;
+    public String getName() {
+        return name;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/CollisionRule.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/CollisionRule.java
@@ -1,0 +1,31 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum CollisionRule {
+    ALWAYS("always"),
+    NEVER("never"),
+    PUSH_OTHER_TEAMS("pushOtherTeams"),
+    PUSH_OWN_TEAM("pushOwnTeam");
+
+    private static final CollisionRule[] VALUES = CollisionRule.values();
+    private final String id;
+
+    CollisionRule(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public static CollisionRule getById(String id) {
+        for (CollisionRule value : VALUES) {
+            if (value.id.equalsIgnoreCase(id)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/NameTagVisibility.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/NameTagVisibility.java
@@ -1,0 +1,31 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum NameTagVisibility {
+    ALWAYS("always"),
+    NEVER("never"),
+    HIDE_FOR_OTHER_TEAMS("hideForOtherTeams"),
+    HIDE_FOR_OWN_TEAM("hideForOwnTeam");
+
+    private static final NameTagVisibility[] VALUES = NameTagVisibility.values();
+    private final String id;
+
+    NameTagVisibility(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public static NameTagVisibility getById(String id) {
+        for (NameTagVisibility value : VALUES) {
+            if (value.id.equalsIgnoreCase(id)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/NameTagVisibility.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/NameTagVisibility.java
@@ -9,23 +9,23 @@ public enum NameTagVisibility {
     HIDE_FOR_OWN_TEAM("hideForOwnTeam");
 
     private static final NameTagVisibility[] VALUES = NameTagVisibility.values();
-    private final String id;
+    private final String name;
 
-    NameTagVisibility(String id) {
-        this.id = id;
+    NameTagVisibility(String name) {
+        this.name = name;
     }
 
     @Nullable
-    public static NameTagVisibility getById(String id) {
+    public static NameTagVisibility getByName(String name) {
         for (NameTagVisibility value : VALUES) {
-            if (value.id.equalsIgnoreCase(id)) {
+            if (value.name.equalsIgnoreCase(name)) {
                 return value;
             }
         }
         return null;
     }
 
-    public String getId() {
-        return id;
+    public String getName() {
+        return name;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/OptionData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/OptionData.java
@@ -1,0 +1,31 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum OptionData {
+    NONE((byte) 0x00),
+    FRIENDLY_FIRE((byte) 0x01),
+    FRIENDLY_CAN_SEE_INVISIBLE((byte) 0x02),
+    ALL((byte) 0x03);
+
+    private static final OptionData[] VALUES = values();
+    private final byte byteValue;
+
+    OptionData(byte value) {
+        byteValue = value;
+    }
+
+    public byte getByteValue() {
+        return byteValue;
+    }
+
+    @Nullable
+    public static OptionData fromValue(byte value) {
+        for (OptionData data : VALUES) {
+            if (data.getByteValue() == value) {
+                return data;
+            }
+        }
+        return null;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamInfo.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamInfo.java
@@ -1,0 +1,88 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.jetbrains.annotations.Nullable;
+
+public class TeamInfo {
+    private @Nullable Component displayName;
+    private @Nullable Component prefix;
+    private @Nullable Component suffix;
+    private NameTagVisibility tagVisibility;
+    private CollisionRule collisionRule;
+    private NamedTextColor color;
+    private OptionData optionData;
+
+    public TeamInfo(@Nullable Component displayName, @Nullable Component prefix, @Nullable Component suffix, NameTagVisibility tagVisibility,
+                    CollisionRule collisionRule, NamedTextColor color, OptionData optionData) {
+        this.displayName = displayName;
+        if (prefix == null) {
+            prefix = Component.empty();
+        }
+        if (suffix == null) {
+            suffix = Component.empty();
+        }
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.tagVisibility = tagVisibility;
+        this.collisionRule = collisionRule;
+        this.color = color;
+        this.optionData = optionData;
+    }
+
+    public @Nullable Component getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(@Nullable Component displayName) {
+        this.displayName = displayName;
+    }
+
+    public @Nullable Component getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(@Nullable Component prefix) {
+        this.prefix = prefix;
+    }
+
+    public @Nullable Component getSuffix() {
+        return suffix;
+    }
+
+    public void setSuffix(@Nullable Component suffix) {
+        this.suffix = suffix;
+    }
+
+    public NameTagVisibility getTagVisibility() {
+        return tagVisibility;
+    }
+
+    public void setTagVisibility(NameTagVisibility tagVisibility) {
+        this.tagVisibility = tagVisibility;
+    }
+
+    public CollisionRule getCollisionRule() {
+        return collisionRule;
+    }
+
+    public void setCollisionRule(CollisionRule collisionRule) {
+        this.collisionRule = collisionRule;
+    }
+
+    public NamedTextColor getColor() {
+        return color;
+    }
+
+    public void setColor(NamedTextColor color) {
+        this.color = color;
+    }
+
+    public OptionData getOptionData() {
+        return optionData;
+    }
+
+    public void setOptionData(OptionData optionData) {
+        this.optionData = optionData;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamMode.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamMode.java
@@ -1,11 +1,11 @@
 package com.github.retrooper.packetevents.protocol.scoreboard;
 
 public enum TeamMode {
-    CREATE,
+    ADD,
     REMOVE,
-    UPDATE,
-    ADD_ENTITIES,
-    REMOVE_ENTITIES;
+    CHANGE,
+    JOIN,
+    LEAVE;
 
     private static final TeamMode[] VALUES = values();
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamMode.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamMode.java
@@ -1,0 +1,15 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+public enum TeamMode {
+    CREATE,
+    REMOVE,
+    UPDATE,
+    ADD_ENTITIES,
+    REMOVE_ENTITIES;
+
+    private static final TeamMode[] VALUES = values();
+
+    public static TeamMode getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/UpdateScore.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/UpdateScore.java
@@ -1,0 +1,12 @@
+package com.github.retrooper.packetevents.protocol.scoreboard;
+
+public enum UpdateScore {
+    CREATE_OR_UPDATE_ITEM,
+    REMOVE_ITEM;
+
+    private static final UpdateScore[] VALUES = values();
+
+    public static UpdateScore getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/window/WindowClickType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/window/WindowClickType.java
@@ -1,0 +1,17 @@
+package com.github.retrooper.packetevents.protocol.window;
+
+public enum WindowClickType {
+    PICKUP,
+    QUICK_MOVE,
+    SWAP,
+    CLONE,
+    THROW,
+    QUICK_CRAFT,
+    PICKUP_ALL;
+
+    private static final WindowClickType[] VALUES = values();
+
+    public static WindowClickType getById(int index) {
+        return VALUES[index];
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -789,7 +789,7 @@ public class PacketWrapper<T extends PacketWrapper> {
         }
     }
 
-    // TODO: Rewrite this method to make it more dynamical
+    // TODO: Rewrite this method with a more dynamic way of handling infinite versions
     public <V> void writeMultiVersional(MultiVersion version, ServerVersion target,
                                         MultiVersion versionSecond, ServerVersion targetSecond, V value,
                                         Writer<V> first, Writer<V> second, Writer<V> third) {
@@ -801,6 +801,20 @@ public class PacketWrapper<T extends PacketWrapper> {
             third.accept(this, value);
         }
     }
+
+    public <V> void writeMultiVersionals(List<MultiVersion> versions, List<ServerVersion> targetVersions,
+                                    V value, List<Writer<V>> writers) {
+        if (versions.size() != targetVersions.size() || versions.size() != writers.size()) {
+            throw new IllegalArgumentException("The lists of versions, targets, and writers must be the same length");
+        }
+
+        for (int i = 0; i < versions.size(); i++) {
+            if (serverVersion.is(versions.get(i), targetVersions.get(i))) {
+                writers.get(i).accept(this, value);
+            }
+        }
+    }
+
 
     @Experimental
     public void writeMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -22,8 +22,8 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.manager.server.ServerVersion.MultiVersion;
 import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.netty.buffer.UnpooledByteBufAllocationHelper;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
@@ -749,6 +749,17 @@ public class PacketWrapper<T extends PacketWrapper> {
     }
 
     @Experimental
+    public void readMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,
+                          Consumer<PacketWrapper<?>> second) {
+        if (serverVersion.is(version, target)) {
+            System.out.println("First");
+            first.accept(this);
+        } else {
+            System.out.println("Second");
+            second.accept(this);
+        }
+    }
+
     public <U, V, R> U readMultiVersional(MultiVersion version, ServerVersion target, Reader<V> first, Reader<R> second) {
         if (serverVersion.is(version, target)) {
             return (U) first.apply(this);
@@ -757,12 +768,47 @@ public class PacketWrapper<T extends PacketWrapper> {
         }
     }
 
-    @Experimental
+    // TODO: Rewrite this method to make it more dynamical
+    public <U, V, R, X> U readMultiVersional(MultiVersion version, ServerVersion target,
+                                             MultiVersion versionSecond, ServerVersion targetSecond,
+                                             Reader<V> first, Reader<R> second, Reader<X> third) {
+        if (serverVersion.is(version, target)) {
+            return (U) first.apply(this);
+        } else if (serverVersion.is(versionSecond, targetSecond)) {
+            return (U) second.apply(this);
+        } else {
+            return (U) third.apply(this);
+        }
+    }
+
     public <V> void writeMultiVersional(MultiVersion version, ServerVersion target, V value, Writer<V> first, Writer<V> second) {
         if (serverVersion.is(version, target)) {
             first.accept(this, value);
         } else {
             second.accept(this, value);
+        }
+    }
+
+    // TODO: Rewrite this method to make it more dynamical
+    public <V> void writeMultiVersional(MultiVersion version, ServerVersion target,
+                                        MultiVersion versionSecond, ServerVersion targetSecond, V value,
+                                        Writer<V> first, Writer<V> second, Writer<V> third) {
+        if (serverVersion.is(version, target)) {
+            first.accept(this, value);
+        } else if (serverVersion.is(versionSecond, targetSecond)) {
+            second.accept(this, value);
+        } else {
+            third.accept(this, value);
+        }
+    }
+
+    @Experimental
+    public void writeMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,
+                          Consumer<PacketWrapper<?>> second) {
+        if (serverVersion.is(version, target)) {
+            first.accept(this);
+        } else {
+            second.accept(this);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -752,10 +752,8 @@ public class PacketWrapper<T extends PacketWrapper> {
     public void readMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,
                           Consumer<PacketWrapper<?>> second) {
         if (serverVersion.is(version, target)) {
-            System.out.println("First");
             first.accept(this);
         } else {
-            System.out.println("Second");
             second.accept(this);
         }
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/server/WrapperLoginServerEncryptionRequest.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/server/WrapperLoginServerEncryptionRequest.java
@@ -35,7 +35,7 @@ import java.security.PublicKey;
  * @see WrapperLoginClientEncryptionResponse
  */
 public class WrapperLoginServerEncryptionRequest extends PacketWrapper<WrapperLoginServerEncryptionRequest> {
-    private String serverID;
+    private String serverId;
     private PublicKey publicKey;
     private byte[] verifyToken;
 
@@ -43,37 +43,37 @@ public class WrapperLoginServerEncryptionRequest extends PacketWrapper<WrapperLo
         super(event);
     }
 
-    public WrapperLoginServerEncryptionRequest(String serverID, byte[] publicKeyBytes, byte[] verifyToken) {
+    public WrapperLoginServerEncryptionRequest(String serverId, byte[] publicKeyBytes, byte[] verifyToken) {
         super(PacketType.Login.Server.ENCRYPTION_REQUEST);
-        this.serverID = serverID;
+        this.serverId = serverId;
         this.publicKey = MinecraftEncryptionUtil.publicKey(publicKeyBytes);
         this.verifyToken = verifyToken;
     }
 
-    public WrapperLoginServerEncryptionRequest(String serverID, PublicKey publicKey, byte[] verifyToken) {
+    public WrapperLoginServerEncryptionRequest(String serverId, PublicKey publicKey, byte[] verifyToken) {
         super(PacketType.Login.Server.ENCRYPTION_REQUEST);
-        this.serverID = serverID;
+        this.serverId = serverId;
         this.publicKey = publicKey;
         this.verifyToken = verifyToken;
     }
 
     @Override
     public void read() {
-        this.serverID = readString(20);
+        this.serverId = readString(20);
         this.publicKey = readPublicKey();
         this.verifyToken = readByteArray(ByteBufHelper.readableBytes(buffer));
     }
 
     @Override
     public void write() {
-        writeString(serverID, 20);
+        writeString(serverId, 20);
         writePublicKey(publicKey);
         writeByteArray(verifyToken);
     }
 
     @Override
     public void copy(WrapperLoginServerEncryptionRequest wrapper) {
-        this.serverID = wrapper.serverID;
+        this.serverId = wrapper.serverId;
         this.publicKey = wrapper.publicKey;
         this.verifyToken = wrapper.verifyToken;
     }
@@ -84,11 +84,11 @@ public class WrapperLoginServerEncryptionRequest extends PacketWrapper<WrapperLo
      * @return Server ID
      */
     public String getServerId() {
-        return serverID;
+        return serverId;
     }
 
-    public void setServerId(String serverID) {
-        this.serverID = serverID;
+    public void setServerId(String serverId) {
+        this.serverId = serverId;
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAdvancementTab.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAdvancementTab.java
@@ -27,38 +27,38 @@ import java.util.Optional;
 
 public class WrapperPlayClientAdvancementTab extends PacketWrapper<WrapperPlayClientAdvancementTab> {
     private Action action;
-    private @Nullable String tabID;
+    private @Nullable String tabId;
 
     public WrapperPlayClientAdvancementTab(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientAdvancementTab(Action action, @Nullable String tabID) {
+    public WrapperPlayClientAdvancementTab(Action action, @Nullable String tabId) {
         super(PacketType.Play.Client.ADVANCEMENT_TAB);
         this.action = action;
-        this.tabID = tabID;
+        this.tabId = tabId;
     }
 
     @Override
     public void read() {
         action = Action.getById(readVarInt());
         if (action == Action.OPENED_TAB) {
-            tabID = readString();
+            tabId = readString();
         }
-    }
-
-    @Override
-    public void copy(WrapperPlayClientAdvancementTab wrapper) {
-        action = wrapper.action;
-        tabID = wrapper.tabID;
     }
 
     @Override
     public void write() {
         writeVarInt(action.ordinal());
         if (action == Action.OPENED_TAB) {
-            writeString(tabID);
+            writeString(tabId);
         }
+    }
+
+    @Override
+    public void copy(WrapperPlayClientAdvancementTab wrapper) {
+        action = wrapper.action;
+        tabId = wrapper.tabId;
     }
 
     public Action getAction() {
@@ -70,15 +70,16 @@ public class WrapperPlayClientAdvancementTab extends PacketWrapper<WrapperPlayCl
     }
 
     public Optional<String> getTabId() {
-        return Optional.ofNullable(tabID);
+        return Optional.ofNullable(tabId);
     }
 
-    public void setTabId(String tabID) {
-        this.tabID = tabID;
+    public void setTabId(@Nullable String tabId) {
+        this.tabId = tabId;
     }
 
     public enum Action {
-        OPENED_TAB, CLOSED_SCREEN;
+        OPENED_TAB,
+        CLOSED_SCREEN;
 
         private static final Action[] VALUES = values();
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
@@ -25,6 +25,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This packet is sent when the client swings their arm.
@@ -61,9 +62,9 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
     }
 
     /**
-     * Hand used for the animation.
-     * On {@link ClientVersion#V_1_9}, an off-hand was introduced and specifies which arm has been swung.
-     * For {@link ClientVersion#V_1_8} and {@link ClientVersion#V_1_7_10} clients only have a main hand.
+     * Hand used for the animation.<p>
+     * On {@link ClientVersion#V_1_9}, an {@link InteractionHand#OFF_HAND} was introduced and specifies which arm has been swung.</p>
+     * For {@link ClientVersion#V_1_8} and {@link ClientVersion#V_1_7_10} clients only have a {@link InteractionHand#MAIN_HAND}.
      *
      * @return Hand
      */
@@ -72,14 +73,15 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
     }
 
     /**
-     * Modify the hand used for the animation.
-     * On {@link ClientVersion#V_1_9}, an off-hand was introduced and specifies which arm has been swung.
-     * For {@link ClientVersion#V_1_8} and {@link ClientVersion#V_1_7_10} clients only have a main hand.
-     * Modifying the hand on 1.8 and 1.7 clients is redundant.
+     * Modify the hand used for the animation.<p>
+     * On {@link ClientVersion#V_1_9}, an {@link InteractionHand#OFF_HAND} was introduced and specifies which arm has been swung.</p>
+     * For {@link ClientVersion#V_1_8} and {@link ClientVersion#V_1_7_10} clients only have a {@link InteractionHand#MAIN_HAND}.<p>
+     * </p>
+     * <b>Modifying the hand on 1.8 and 1.7 clients is redundant.</b>
      *
      * @param interactionHand Hand used for the animation
      */
-    public void setHand(InteractionHand interactionHand) {
+    public void setHand(@NotNull InteractionHand interactionHand) {
         this.interactionHand = interactionHand;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -42,7 +43,7 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
 
     @Override
     public void read() {
-        this.interactionHand = readMultiVersional(ServerVersion.MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
+        this.interactionHand = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
                 packetWrapper -> InteractionHand.getById(packetWrapper.readVarInt()),
                 packetWrapper -> InteractionHand.MAIN_HAND);
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -42,16 +43,9 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
 
     @Override
     public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
-            this.interactionHand = InteractionHand.getById(readVarInt());
-        } else {
-            this.interactionHand = InteractionHand.MAIN_HAND;
-        }
-    }
-
-    @Override
-    public void copy(WrapperPlayClientAnimation wrapper) {
-        this.interactionHand = wrapper.interactionHand;
+        this.interactionHand = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
+                packetWrapper -> InteractionHand.getById(packetWrapper.readVarInt()),
+                packetWrapper -> InteractionHand.MAIN_HAND);
     }
 
     @Override
@@ -59,6 +53,11 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
             writeVarInt(interactionHand.getId());
         }
+    }
+
+    @Override
+    public void copy(WrapperPlayClientAnimation wrapper) {
+        this.interactionHand = wrapper.interactionHand;
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientAnimation.java
@@ -19,7 +19,6 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
@@ -43,7 +42,7 @@ public class WrapperPlayClientAnimation extends PacketWrapper<WrapperPlayClientA
 
     @Override
     public void read() {
-        this.interactionHand = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
+        this.interactionHand = readMultiVersional(ServerVersion.MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
                 packetWrapper -> InteractionHand.getById(packetWrapper.readVarInt()),
                 packetWrapper -> InteractionHand.MAIN_HAND);
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatCommand.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatCommand.java
@@ -6,18 +6,24 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.crypto.MessageSignData;
 import com.github.retrooper.packetevents.util.crypto.SaltSignature;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 
 public class WrapperPlayClientChatCommand extends PacketWrapper<WrapperPlayClientChatCommand> {
     private String command;
-    private MessageSignData messageSignData;
+    // 1.19+
+    private @Nullable MessageSignData messageSignData;
 
     public WrapperPlayClientChatCommand(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientChatCommand(String command, MessageSignData messageSignData) {
+    public WrapperPlayClientChatCommand(String command) {
+        this(command, null);
+    }
+
+    public WrapperPlayClientChatCommand(String command, @Nullable MessageSignData messageSignData) {
         super(PacketType.Play.Client.CHAT_COMMAND);
         this.command = command;
         this.messageSignData = messageSignData;
@@ -59,11 +65,11 @@ public class WrapperPlayClientChatCommand extends PacketWrapper<WrapperPlayClien
         this.command = command;
     }
 
-    public MessageSignData getMessageSignData() {
+    public @Nullable MessageSignData getMessageSignData() {
         return messageSignData;
     }
 
-    public void setMessageSignData(MessageSignData messageSignData) {
+    public void setMessageSignData(@Nullable MessageSignData messageSignData) {
         this.messageSignData = messageSignData;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
@@ -43,7 +43,7 @@ import java.util.UUID;
  */
 public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClientChatMessage> {
     private String message;
-    private Optional<MessageSignData> messageSignData = Optional.empty();
+    private MessageSignData messageSignData;
 
     public WrapperPlayClientChatMessage(PacketReceiveEvent event) {
         super(event);
@@ -52,7 +52,7 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
     public WrapperPlayClientChatMessage(String message, @Nullable MessageSignData messageSignData) {
         super(PacketType.Play.Client.CHAT_MESSAGE);
         this.message = message;
-        this.messageSignData = Optional.ofNullable(messageSignData);
+        this.messageSignData = messageSignData;
     }
 
     @Override
@@ -63,14 +63,8 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
             Instant timestamp = readTimestamp();
             SaltSignature saltSignature = readSaltSignature();
             boolean signedPreview = readBoolean();
-            this.messageSignData = Optional.of(new MessageSignData(saltSignature, timestamp, signedPreview));
+            this.messageSignData = new MessageSignData(saltSignature, timestamp, signedPreview);
         }
-    }
-
-    @Override
-    public void copy(WrapperPlayClientChatMessage wrapper) {
-        this.message = wrapper.message;
-        this.messageSignData = wrapper.messageSignData;
     }
 
     @Override
@@ -78,10 +72,16 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
         int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : 100;
         writeString(this.message, maxMessageLength);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
-            writeTimestamp(messageSignData.get().getTimestamp());
-            writeSaltSignature(messageSignData.get().getSaltSignature());
-            writeBoolean(messageSignData.get().isSignedPreview());
+            writeTimestamp(messageSignData.getTimestamp());
+            writeSaltSignature(messageSignData.getSaltSignature());
+            writeBoolean(messageSignData.isSignedPreview());
         }
+    }
+
+    @Override
+    public void copy(WrapperPlayClientChatMessage wrapper) {
+        this.message = wrapper.message;
+        this.messageSignData = wrapper.messageSignData;
     }
 
     /**
@@ -107,22 +107,22 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
     }
 
     public Optional<MessageSignData> getMessageSignData() {
-        return messageSignData;
+        return Optional.ofNullable(messageSignData);
     }
 
     public void setMessageSignData(@Nullable MessageSignData messageSignData) {
-        this.messageSignData = Optional.ofNullable(messageSignData);
+        this.messageSignData = messageSignData;
     }
 
     protected boolean verify(UUID uuid, PublicKey key) {
-        if (!messageSignData.isPresent()) {
+        if (messageSignData == null) {
             System.out.println("wait a minute!");
             return false;
         }
         Component component = Component.text(message);
         System.out.println("str: " + AdventureSerializer.toJson(component));
         try {
-            return MessageVerifier.verify(uuid, messageSignData.get(), key, String.format("{\"text\":\"%s\"}", message));
+            return MessageVerifier.verify(uuid, messageSignData, key, String.format("{\"text\":\"%s\"}", message));
         } catch (NoSuchAlgorithmException | SignatureException | InvalidKeyException e) {
             e.printStackTrace();
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
@@ -43,10 +43,15 @@ import java.util.UUID;
  */
 public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClientChatMessage> {
     private String message;
-    private MessageSignData messageSignData;
+    // 1.19+
+    private @Nullable MessageSignData messageSignData;
 
     public WrapperPlayClientChatMessage(PacketReceiveEvent event) {
         super(event);
+    }
+
+    public WrapperPlayClientChatMessage(String message) {
+        this(message, null);
     }
 
     public WrapperPlayClientChatMessage(String message, @Nullable MessageSignData messageSignData) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClickWindowButton.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClickWindowButton.java
@@ -26,35 +26,35 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
  * This packet is used when clicking on window buttons. Until 1.14, this was only used by enchantment tables.
  */
 public class WrapperPlayClientClickWindowButton extends PacketWrapper<WrapperPlayClientClickWindowButton> {
-    private int windowID;
-    private int buttonID;
+    private int windowId;
+    private int buttonId;
 
     public WrapperPlayClientClickWindowButton(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientClickWindowButton(int windowID, int buttonID) {
+    public WrapperPlayClientClickWindowButton(int windowId, int buttonId) {
         super(PacketType.Play.Client.CLICK_WINDOW_BUTTON);
-        this.windowID = windowID;
-        this.buttonID = buttonID;
+        this.windowId = windowId;
+        this.buttonId = buttonId;
     }
 
     @Override
     public void read() {
-        this.windowID = readByte();
-        this.buttonID = readByte();
+        this.windowId = readByte();
+        this.buttonId = readByte();
     }
 
     @Override
     public void write() {
-        writeByte(this.windowID);
-        writeByte(this.buttonID);
+        writeByte(this.windowId);
+        writeByte(this.buttonId);
     }
 
     @Override
     public void copy(WrapperPlayClientClickWindowButton wrapper) {
-        this.windowID = wrapper.windowID;
-        this.buttonID = wrapper.buttonID;
+        this.windowId = wrapper.windowId;
+        this.buttonId = wrapper.buttonId;
     }
 
     /**
@@ -63,16 +63,16 @@ public class WrapperPlayClientClickWindowButton extends PacketWrapper<WrapperPla
      * @return Window ID
      */
     public int getWindowId() {
-        return windowID;
+        return windowId;
     }
 
     /**
      * Modify the ID of the window.
      *
-     * @param windowID Window ID
+     * @param windowId Window ID
      */
-    public void setWindowId(int windowID) {
-        this.windowID = windowID;
+    public void setWindowId(int windowId) {
+        this.windowId = windowId;
     }
 
     /**
@@ -82,16 +82,16 @@ public class WrapperPlayClientClickWindowButton extends PacketWrapper<WrapperPla
      * @return Button ID
      */
     public int getButtonId() {
-        return buttonID;
+        return buttonId;
     }
 
     /**
      * Modify the meaning.
      * Learn more on wiki.vg/Protocol.
      *
-     * @param buttonID Button ID
+     * @param buttonId Button ID
      */
-    public void setButtonId(int buttonID) {
-        this.buttonID = buttonID;
+    public void setButtonId(int buttonId) {
+        this.buttonId = buttonId;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClientStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClientStatus.java
@@ -19,8 +19,8 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.manager.server.ServerVersion.MultiVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientCloseWindow.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientCloseWindow.java
@@ -23,37 +23,37 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayClientCloseWindow extends PacketWrapper<WrapperPlayClientCloseWindow> {
-    private int windowID;
+    private int windowId;
 
     public WrapperPlayClientCloseWindow(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientCloseWindow(int windowID) {
+    public WrapperPlayClientCloseWindow(int windowId) {
         super(PacketType.Play.Client.CLOSE_WINDOW);
-        this.windowID = windowID;
+        this.windowId = windowId;
     }
 
     @Override
     public void read() {
-        this.windowID = readUnsignedByte();
+        this.windowId = readUnsignedByte();
     }
 
     @Override
     public void write() {
-        writeByte(this.windowID);
+        writeByte(this.windowId);
     }
 
     @Override
     public void copy(WrapperPlayClientCloseWindow wrapper) {
-        this.windowID = wrapper.windowID;
+        this.windowId = wrapper.windowId;
     }
 
     public int getWindowId() {
-        return windowID;
+        return windowId;
     }
 
-    public void setWindowId(int windowID) {
-        this.windowID = windowID;
+    public void setWindowId(int windowId) {
+        this.windowId = windowId;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientEntityAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientEntityAction.java
@@ -20,45 +20,42 @@ package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.entity.EntityAction;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayClientEntityAction extends PacketWrapper<WrapperPlayClientEntityAction> {
-    private int entityID;
-    private Action action;
+    private int entityId;
+    private EntityAction action;
     private int jumpBoost;
 
     public WrapperPlayClientEntityAction(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientEntityAction(int entityID, Action action, int jumpBoost) {
+    public WrapperPlayClientEntityAction(int entityId, EntityAction action, int jumpBoost) {
         super(PacketType.Play.Client.ENTITY_ACTION);
-        this.entityID = entityID;
+        this.entityId = entityId;
         this.action = action;
         this.jumpBoost = jumpBoost;
     }
 
     @Override
     public void read() {
-        entityID = readVarInt();
-        action = Action.VALUES[readVarInt()];
-        if (serverVersion.isOlderThan(ServerVersion.V_1_9)) {
-            if (action == Action.STOP_JUMPING_WITH_HORSE) {
-                action = Action.OPEN_HORSE_INVENTORY;
-            }
+        entityId = readVarInt();
+        action = EntityAction.LEAVE_BED.getById(readVarInt());
+        if (serverVersion.isOlderThan(ServerVersion.V_1_9) && action == EntityAction.STOP_JUMPING_WITH_HORSE) {
+            action = EntityAction.OPEN_HORSE_INVENTORY;
         }
         jumpBoost = readVarInt();
     }
 
     @Override
     public void write() {
-        writeVarInt(entityID);
+        writeVarInt(entityId);
         int actionIndex = action.ordinal();
-        if (serverVersion.isOlderThan(ServerVersion.V_1_9)) {
-            if (action == Action.OPEN_HORSE_INVENTORY) {
-                actionIndex--;
-            }
+        if (serverVersion.isOlderThan(ServerVersion.V_1_9) && action == EntityAction.OPEN_HORSE_INVENTORY) {
+            actionIndex--;
         }
         writeVarInt(actionIndex);
         writeVarInt(jumpBoost);
@@ -66,24 +63,24 @@ public class WrapperPlayClientEntityAction extends PacketWrapper<WrapperPlayClie
 
     @Override
     public void copy(WrapperPlayClientEntityAction wrapper) {
-        entityID = wrapper.entityID;
+        entityId = wrapper.entityId;
         action = wrapper.action;
         jumpBoost = wrapper.jumpBoost;
     }
 
     public int getEntityId() {
-        return entityID;
+        return entityId;
     }
 
-    public void setEntityId(int entityID) {
-        this.entityID = entityID;
+    public void setEntityId(int entityId) {
+        this.entityId = entityId;
     }
 
-    public Action getAction() {
+    public EntityAction getAction() {
         return action;
     }
 
-    public void setAction(Action action) {
+    public void setAction(EntityAction action) {
         this.action = action;
     }
 
@@ -93,19 +90,5 @@ public class WrapperPlayClientEntityAction extends PacketWrapper<WrapperPlayClie
 
     public void setJumpBoost(int jumpBoost) {
         this.jumpBoost = jumpBoost;
-    }
-
-    public enum Action {
-        START_SNEAKING,
-        STOP_SNEAKING,
-        LEAVE_BED,
-        START_SPRINTING,
-        STOP_SPRINTING,
-        START_JUMPING_WITH_HORSE,
-        STOP_JUMPING_WITH_HORSE,
-        OPEN_HORSE_INVENTORY,
-        START_FLYING_WITH_ELYTRA;
-
-        public static final Action[] VALUES = values();
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientInteractEntity.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientInteractEntity.java
@@ -19,11 +19,14 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.entity.InteractAction;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.InteractionHand;
 import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -33,19 +36,20 @@ import java.util.Optional;
  * Please note that this packet is NOT sent whenever the client middle-clicks, the {@link WrapperPlayClientCreativeInventoryAction} packet is sent instead.
  */
 public class WrapperPlayClientInteractEntity extends PacketWrapper<WrapperPlayClientInteractEntity> {
-    private int entityID;
+    private int entityId;
     private InteractAction interactAction;
-    private Optional<Vector3f> target;
+    private @Nullable Vector3f target;
     private InteractionHand interactionHand;
-    private Optional<Boolean> sneaking;
+    private boolean sneaking;
 
     public WrapperPlayClientInteractEntity(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientInteractEntity(int entityID, InteractAction interactAction, InteractionHand interactionHand, Optional<Vector3f> target, Optional<Boolean> sneaking) {
+    public WrapperPlayClientInteractEntity(int entityId, InteractAction interactAction, InteractionHand interactionHand,
+                                           @Nullable Vector3f target, boolean sneaking) {
         super(PacketType.Play.Client.INTERACT_ENTITY);
-        this.entityID = entityID;
+        this.entityId = entityId;
         this.interactAction = interactAction;
         this.interactionHand = interactionHand;
         this.target = target;
@@ -54,69 +58,72 @@ public class WrapperPlayClientInteractEntity extends PacketWrapper<WrapperPlayCl
 
     @Override
     public void read() {
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            this.entityID = readInt();
-            byte typeIndex = readByte();
-            this.interactAction = InteractAction.VALUES[typeIndex];
-            this.target = Optional.empty();
-            this.interactionHand = InteractionHand.MAIN_HAND;
-            this.sneaking = Optional.empty();
-        } else {
-            this.entityID = readVarInt();
-            int typeIndex = readVarInt();
-            this.interactAction = InteractAction.VALUES[typeIndex];
-            if (interactAction == InteractAction.INTERACT_AT) {
-                float x = readFloat();
-                float y = readFloat();
-                float z = readFloat();
-                this.target = Optional.of(new Vector3f(x, y, z));
-            } else {
-                this.target = Optional.empty();
-            }
+        this.entityId = readMultiVersional(MultiVersion.EQUALS, ServerVersion.V_1_7_10,
+                PacketWrapper::readInt,
+                PacketWrapper::readVarInt);
 
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9) && (interactAction == InteractAction.INTERACT || interactAction == InteractAction.INTERACT_AT)) {
-                int handID = readVarInt();
-                this.interactionHand = InteractionHand.getById(handID);
-            } else {
-                this.interactionHand = InteractionHand.MAIN_HAND;
-            }
+        // Haven't tested this method yet
+        readMulti(MultiVersion.EQUALS, ServerVersion.V_1_7_10,
+                wrapper -> {
+                    this.entityId = wrapper.readInt();
+                    this.interactAction = InteractAction.getById(wrapper.readByte());
+                    this.interactionHand = InteractionHand.MAIN_HAND;
+                }, wrapper -> {
+                    this.entityId = wrapper.readVarInt();
+                    this.interactAction = InteractAction.getById(wrapper.readVarInt());
+                    if (interactAction == InteractAction.INTERACT_AT) {
+                        float x = wrapper.readFloat();
+                        float y = wrapper.readFloat();
+                        float z = wrapper.readFloat();
+                        this.target = new Vector3f(x, y, z);
+                    }
 
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
-                this.sneaking = Optional.of(readBoolean());
-            } else {
-                this.sneaking = Optional.empty();
-            }
-        }
+                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)
+                            && (interactAction == InteractAction.INTERACT || interactAction == InteractAction.INTERACT_AT)) {
+                        this.interactionHand = InteractionHand.getById(wrapper.readVarInt());
+                    } else {
+                        this.interactionHand = InteractionHand.MAIN_HAND;
+                    }
+
+                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
+                        this.sneaking = wrapper.readBoolean();
+                    }
+                });
     }
 
     @Override
     public void write() {
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            writeInt(entityID);
-            writeByte(interactAction.ordinal());
-        } else {
-            writeVarInt(entityID);
-            writeVarInt(interactAction.ordinal());
-            if (interactAction == InteractAction.INTERACT_AT) {
-                Vector3f targetVec = target.orElse(new Vector3f(0.0F, 0.0F, 0.0F));
-                writeFloat(targetVec.x);
-                writeFloat(targetVec.y);
-                writeFloat(targetVec.z);
-            }
+        writeMultiVersional(MultiVersion.EQUALS, ServerVersion.V_1_7_10, entityId,
+                PacketWrapper::writeInt,
+                PacketWrapper::writeVarInt);
+        writeMultiVersional(MultiVersion.EQUALS, ServerVersion.V_1_7_10, interactAction.ordinal(),
+                PacketWrapper::writeByte,
+                (packetWrapper, integer) -> {
+                    packetWrapper.writeVarInt(integer);
+                    if (interactAction == InteractAction.INTERACT_AT) {
+                        if (target == null) {
+                            target = new Vector3f(0.0F, 0.0F, 0.0F);
+                        }
+                        Vector3f targetVec = target;
+                        writeFloat(targetVec.x);
+                        writeFloat(targetVec.y);
+                        writeFloat(targetVec.z);
+                    }
 
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9) && (interactAction == InteractAction.INTERACT || interactAction == InteractAction.INTERACT_AT)) {
-                writeVarInt(interactionHand.getId());
-            }
+                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9) &&
+                            (interactAction == InteractAction.INTERACT || interactAction == InteractAction.INTERACT_AT)) {
+                        writeVarInt(interactionHand.getId());
+                    }
 
-            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
-                writeBoolean(sneaking.orElse(false));
-            }
-        }
+                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
+                        writeBoolean(sneaking);
+                    }
+                });
     }
 
     @Override
     public void copy(WrapperPlayClientInteractEntity wrapper) {
-        this.entityID = wrapper.entityID;
+        this.entityId = wrapper.entityId;
         this.interactAction = wrapper.interactAction;
         this.target = wrapper.target;
         this.interactionHand = wrapper.interactionHand;
@@ -124,47 +131,42 @@ public class WrapperPlayClientInteractEntity extends PacketWrapper<WrapperPlayCl
     }
 
     public int getEntityId() {
-        return entityID;
+        return entityId;
     }
 
-    public void setEntityId(int entityID) {
-        this.entityID = entityID;
+    public void setEntityId(int entityId) {
+        this.entityId = entityId;
     }
 
-    public InteractAction getAction() {
+    public InteractAction getInteractAction() {
         return interactAction;
     }
 
-    public void setAction(InteractAction interactAction) {
+    public void setInteractAction(InteractAction interactAction) {
         this.interactAction = interactAction;
     }
 
-    public InteractionHand getHand() {
-        return interactionHand;
-    }
-
-    public void setHand(InteractionHand interactionHand) {
-        this.interactionHand = interactionHand;
-    }
-
     public Optional<Vector3f> getTarget() {
-        return target;
+        return Optional.ofNullable(target);
     }
 
-    public void setTarget(Optional<Vector3f> target) {
+    public void setTarget(@Nullable Vector3f target) {
         this.target = target;
     }
 
-    public Optional<Boolean> isSneaking() {
+    public InteractionHand getInteractionHand() {
+        return interactionHand;
+    }
+
+    public void setInteractionHand(InteractionHand interactionHand) {
+        this.interactionHand = interactionHand;
+    }
+
+    public boolean isSneaking() {
         return sneaking;
     }
 
-    public void setSneaking(Optional<Boolean> sneaking) {
+    public void setSneaking(boolean sneaking) {
         this.sneaking = sneaking;
-    }
-
-    public enum InteractAction {
-        INTERACT, ATTACK, INTERACT_AT;
-        public static final InteractAction[] VALUES = values();
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
@@ -42,24 +43,18 @@ public class WrapperPlayClientKeepAlive extends PacketWrapper<WrapperPlayClientK
 
     @Override
     public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            this.id = readLong();
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            this.id = readVarInt();
-        } else {
-            this.id = readInt();
-        }
+        this.id = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_12,
+                MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8,
+                PacketWrapper::readLong, PacketWrapper::readVarInt, PacketWrapper::readInt);
     }
 
     @Override
     public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            writeLong(id);
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            writeVarInt((int) id);
-        } else {
-            writeInt((int) id);
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_12,
+                MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8, id,
+                PacketWrapper::writeLong,
+                (packetWrapper, aLong) -> packetWrapper.writeVarInt(Math.toIntExact(aLong)),
+                (packetWrapper, aLong) -> packetWrapper.writeInt(Math.toIntExact(aLong)));
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPlayerAbilities.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPlayerAbilities.java
@@ -19,27 +19,28 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
-import java.util.Optional;
-
 public class WrapperPlayClientPlayerAbilities extends PacketWrapper<WrapperPlayClientPlayerAbilities> {
     private boolean flying;
-    private Optional<Boolean> godMode;
-    private Optional<Boolean> flightAllowed;
-    private Optional<Boolean> creativeMode;
-    private Optional<Float> flySpeed;
-    private Optional<Float> walkSpeed;
+    private boolean godMode;
+    private boolean flightAllowed;
+    private boolean creativeMode;
+    private float flySpeed;
+    private float walkSpeed;
 
     public WrapperPlayClientPlayerAbilities(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientPlayerAbilities(boolean flying, Optional<Boolean> godMode, Optional<Boolean> flightAllowed,
-                                            Optional<Boolean> creativeMode,
-                                            Optional<Float> flySpeed, Optional<Float> walkSpeed) {
+    public WrapperPlayClientPlayerAbilities(boolean flying) {
+        this(flying, false, false, false, 0.0F, 0.0F);
+    }
+
+    public WrapperPlayClientPlayerAbilities(boolean flying, boolean godMode, boolean flightAllowed, boolean creativeMode, float flySpeed, float walkSpeed) {
         super(PacketType.Play.Client.PLAYER_ABILITIES);
         this.flying = flying;
         this.godMode = godMode;
@@ -49,58 +50,47 @@ public class WrapperPlayClientPlayerAbilities extends PacketWrapper<WrapperPlayC
         this.walkSpeed = walkSpeed;
     }
 
-    public WrapperPlayClientPlayerAbilities(boolean flying) {
-        this(flying, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
     @Override
     public void read() {
         byte mask = readByte();
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
+        readMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_16, packetWrapper -> flying = (mask & 0x02) != 0, packetWrapper -> {
+            godMode = (mask & 0x01) != 0;
             flying = (mask & 0x02) != 0;
-            godMode = Optional.empty();
-            flightAllowed = Optional.empty();
-            creativeMode = Optional.empty();
-            flySpeed = Optional.empty();
-            walkSpeed = Optional.empty();
-        } else {
-            godMode = Optional.of((mask & 0x01) != 0);
-            flying = (mask & 0x02) != 0;
-            flightAllowed = Optional.of((mask & 0x04) != 0);
-            creativeMode = Optional.of((mask & 0x08) != 0);
-            flySpeed = Optional.of(readFloat());
-            walkSpeed = Optional.of(readFloat());
-        }
-
+            flightAllowed = (mask & 0x04) != 0;
+            creativeMode = (mask & 0x08) != 0;
+            flySpeed = readFloat();
+            walkSpeed = readFloat();
+        });
     }
 
     @Override
     public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
-            byte mask = (byte) (flying ? 0x02 : 0x00);
-            writeByte(mask);
-        } else {
-            byte mask = 0x00;
-            if (godMode.orElse(false)) {
-                mask |= 0x01;
-            }
+        byte mask = (byte) (flying ? 0x02 : 0x00);
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_16, mask,
+                (packetWrapper, aByte) -> writeByte(aByte),
+                (packetWrapper, aByte) -> {
+                    byte maskNew = aByte.byteValue();
+                    maskNew = 0x00;
+                    if (godMode) {
+                        maskNew |= 0x01;
+                    }
 
-            if (flying) {
-                mask |= 0x02;
-            }
+                    if (flying) {
+                        maskNew |= 0x02;
+                    }
 
-            if (flightAllowed.orElse(false)) {
-                mask |= 0x04;
-            }
+                    if (flightAllowed) {
+                        maskNew |= 0x04;
+                    }
 
-            if (creativeMode.orElse(false)) {
-                mask |= 0x08;
-            }
-            writeByte(mask);
-            //These are my guesses of default values, don't cry, just pass in the fly/walk speed next time :0
-            writeFloat(flySpeed.orElse(0.1f));
-            writeFloat(walkSpeed.orElse(0.2f));
-        }
+                    if (creativeMode) {
+                        maskNew |= 0x08;
+                    }
+                    writeByte(maskNew);
+                    // These are my guesses of default values, don't cry, just pass in the fly/walk speed next time :0
+                    writeFloat(flySpeed == 0.0F ? 0.1F : flySpeed);
+                    writeFloat(walkSpeed == 0.0F ? 0.2F : walkSpeed);
+                });
     }
 
     @Override
@@ -121,43 +111,43 @@ public class WrapperPlayClientPlayerAbilities extends PacketWrapper<WrapperPlayC
         this.flying = flying;
     }
 
-    public Optional<Boolean> isInGodMode() {
+    public boolean isInGodMode() {
         return godMode;
     }
 
-    public void setInGodMode(Optional<Boolean> godMode) {
+    public void setInGodMode(boolean godMode) {
         this.godMode = godMode;
     }
 
-    public Optional<Boolean> isFlightAllowed() {
+    public boolean isFlightAllowed() {
         return flightAllowed;
     }
 
-    public void setFlightAllowed(Optional<Boolean> flightAllowed) {
+    public void setFlightAllowed(boolean flightAllowed) {
         this.flightAllowed = flightAllowed;
     }
 
-    public Optional<Boolean> isInCreativeMode() {
+    public boolean isInCreativeMode() {
         return creativeMode;
     }
 
-    public void setCreativeMode(Optional<Boolean> creativeMode) {
+    public void setCreativeMode(boolean creativeMode) {
         this.creativeMode = creativeMode;
     }
 
-    public Optional<Float> getFlySpeed() {
+    public float getFlySpeed() {
         return flySpeed;
     }
 
-    public void setFlySpeed(Optional<Float> flySpeed) {
+    public void setFlySpeed(float flySpeed) {
         this.flySpeed = flySpeed;
     }
 
-    public Optional<Float> getWalkSpeed() {
+    public float getWalkSpeed() {
         return walkSpeed;
     }
 
-    public void setWalkSpeed(Optional<Float> walkSpeed) {
+    public void setWalkSpeed(float walkSpeed) {
         this.walkSpeed = walkSpeed;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPlayerBlockPlacement.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPlayerBlockPlacement.java
@@ -27,42 +27,46 @@ import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
+// This class still needs to be kind of recoded with our new generic methods, but we currently don't have any method
+// which fits the class needs
 public class WrapperPlayClientPlayerBlockPlacement extends PacketWrapper<WrapperPlayClientPlayerBlockPlacement> {
     private InteractionHand interactionHand;
     private Vector3i blockPosition;
     private BlockFace face;
     private Vector3f cursorPosition;
-    private Optional<ItemStack> itemStack;
-    private Optional<Boolean> insideBlock;
-    int sequence;
+    private @Nullable ItemStack itemStack;
+    private boolean insideBlock;
+    private int sequence;
 
     public WrapperPlayClientPlayerBlockPlacement(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientPlayerBlockPlacement(InteractionHand interactionHand, Vector3i blockPosition, BlockFace face, Vector3f cursorPosition, Optional<Boolean> insideBlock, int sequence) {
+    public WrapperPlayClientPlayerBlockPlacement(InteractionHand interactionHand, Vector3i blockPosition, BlockFace face,
+                                                 Vector3f cursorPosition, @Nullable ItemStack itemStack, boolean insideBlock,
+                                                 int sequence) {
         super(PacketType.Play.Client.PLAYER_BLOCK_PLACEMENT);
         this.interactionHand = interactionHand;
         this.blockPosition = blockPosition;
         this.face = face;
         this.cursorPosition = cursorPosition;
+        this.itemStack = itemStack;
         this.insideBlock = insideBlock;
         this.sequence = sequence;
     }
 
     @Override
     public void read() {
-        itemStack = Optional.empty();
-        insideBlock = Optional.empty();
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_14)) {
             interactionHand = InteractionHand.getById(readVarInt());
             blockPosition = readBlockPosition();
             face = BlockFace.getBlockFaceByValue(readVarInt());
             cursorPosition = new Vector3f(readFloat(), readFloat(), readFloat());
-            insideBlock = Optional.of(readBoolean());
+            insideBlock = readBoolean();
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
                 sequence = readVarInt();
             }
@@ -78,7 +82,7 @@ public class WrapperPlayClientPlayerBlockPlacement extends PacketWrapper<Wrapper
             } else {
                 face = BlockFace.getBlockFaceByValue(readUnsignedByte());
                 //Optional itemstack
-                itemStack = Optional.of(readItemStack());
+                itemStack = readItemStack();
                 interactionHand = InteractionHand.MAIN_HAND;
             }
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11)) {
@@ -98,7 +102,7 @@ public class WrapperPlayClientPlayerBlockPlacement extends PacketWrapper<Wrapper
             writeFloat(cursorPosition.x);
             writeFloat(cursorPosition.y);
             writeFloat(cursorPosition.z);
-            writeBoolean(insideBlock.orElse(false));
+            writeBoolean(insideBlock);
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
                 writeVarInt(sequence);
             }
@@ -115,8 +119,8 @@ public class WrapperPlayClientPlayerBlockPlacement extends PacketWrapper<Wrapper
                 writeVarInt(interactionHand.getId());
             } else {
                 writeByte(face.getFaceValue());
-                writeItemStack(itemStack.orElse(ItemStack.EMPTY));
-                //Hand is always the main hand
+                writeItemStack(itemStack == null ? ItemStack.EMPTY : itemStack);
+                // Hand is always the main hand
             }
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11)) {
                 writeFloat(cursorPosition.x);
@@ -174,18 +178,18 @@ public class WrapperPlayClientPlayerBlockPlacement extends PacketWrapper<Wrapper
     }
 
     public Optional<ItemStack> getItemStack() {
-        return itemStack;
+        return Optional.ofNullable(itemStack);
     }
 
-    public void setItemStack(Optional<ItemStack> itemStack) {
+    public void setItemStack(@Nullable ItemStack itemStack) {
         this.itemStack = itemStack;
     }
 
-    public Optional<Boolean> getInsideBlock() {
+    public boolean getInsideBlock() {
         return insideBlock;
     }
 
-    public void setInsideBlock(Optional<Boolean> insideBlock) {
+    public void setInsideBlock(boolean insideBlock) {
         this.insideBlock = insideBlock;
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientQueryBlockNBT.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientQueryBlockNBT.java
@@ -24,43 +24,43 @@ import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayClientQueryBlockNBT extends PacketWrapper<WrapperPlayClientQueryBlockNBT> {
-    private int transactionID;
+    private int transactionId;
     private Vector3i blockPosition;
 
     public WrapperPlayClientQueryBlockNBT(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientQueryBlockNBT(int transactionID, Vector3i blockPosition) {
+    public WrapperPlayClientQueryBlockNBT(int transactionId, Vector3i blockPosition) {
         super(PacketType.Play.Client.QUERY_BLOCK_NBT);
-        this.transactionID = transactionID;
+        this.transactionId = transactionId;
         this.blockPosition = blockPosition;
     }
 
     @Override
     public void read() {
-        transactionID = readVarInt();
+        transactionId = readVarInt();
         blockPosition = readBlockPosition();
     }
 
     @Override
     public void write() {
-        writeVarInt(transactionID);
+        writeVarInt(transactionId);
         writeBlockPosition(blockPosition);
     }
 
     @Override
     public void copy(WrapperPlayClientQueryBlockNBT wrapper) {
-        transactionID = wrapper.transactionID;
+        transactionId = wrapper.transactionId;
         blockPosition = wrapper.blockPosition;
     }
 
     public int getTransactionId() {
-        return transactionID;
+        return transactionId;
     }
 
-    public void setTransactionId(int transactionID) {
-        this.transactionID = transactionID;
+    public void setTransactionId(int transactionId) {
+        this.transactionId = transactionId;
     }
 
     public Vector3i getBlockPosition() {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientResourcePackStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientResourcePackStatus.java
@@ -21,23 +21,26 @@ package com.github.retrooper.packetevents.wrapper.play.client;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.resourcepack.ResourcePacketResult;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 public class WrapperPlayClientResourcePackStatus extends PacketWrapper<WrapperPlayClientResourcePackStatus> {
-    private String hash;
-    private Result result;
+    private @Nullable String hash;
+    private ResourcePacketResult result;
 
     public WrapperPlayClientResourcePackStatus(PacketReceiveEvent event) {
         super(event);
     }
 
-    public WrapperPlayClientResourcePackStatus(Result result) {
-        super(PacketType.Play.Client.RESOURCE_PACK_STATUS);
-        this.result = result;
+    public WrapperPlayClientResourcePackStatus(ResourcePacketResult result) {
+        this(null, result);
     }
 
     @Deprecated
-    public WrapperPlayClientResourcePackStatus(String hash, Result result) {
+    public WrapperPlayClientResourcePackStatus(@Nullable String hash, ResourcePacketResult result) {
         super(PacketType.Play.Client.RESOURCE_PACK_STATUS);
         this.hash = hash;
         this.result = result;
@@ -46,13 +49,9 @@ public class WrapperPlayClientResourcePackStatus extends PacketWrapper<WrapperPl
     @Override
     public void read() {
         if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
-            //For now ignore hash, maybe make optional
             this.hash = readString(40);
-        } else {
-            this.hash = "";
         }
-        int resultIndex = readVarInt();
-        this.result = Result.VALUES[resultIndex];
+        this.result = ResourcePacketResult.getById(readVarInt());
     }
 
     @Override
@@ -69,28 +68,19 @@ public class WrapperPlayClientResourcePackStatus extends PacketWrapper<WrapperPl
         this.result = wrapper.result;
     }
 
-    public Result getResult() {
+    public ResourcePacketResult getResult() {
         return result;
     }
 
-    public void setResult(Result result) {
+    public void setResult(ResourcePacketResult result) {
         this.result = result;
     }
 
-    public String getHash() {
-        return hash;
+    public Optional<String> getHash() {
+        return Optional.ofNullable(hash);
     }
 
-    public void setHash(String hash) {
+    public void setHash(@Nullable String hash) {
         this.hash = hash;
-    }
-
-    public enum Result {
-        SUCCESSFULLY_LOADED,
-        DECLINED,
-        FAILED_DOWNLOAD,
-        ACCEPTED;
-
-        public static final Result[] VALUES = values();
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientSetBeaconEffect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientSetBeaconEffect.java
@@ -40,8 +40,8 @@ public class WrapperPlayClientSetBeaconEffect extends PacketWrapper<WrapperPlayC
     @Override
     public void read() {
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
-            this.primaryEffect = readOptionalEffect();
-            this.secondaryEffect = readOptionalEffect();
+            this.primaryEffect = readOptional(PacketWrapper::readVarInt);
+            this.secondaryEffect = readOptional(PacketWrapper::readVarInt);
         } else {
             this.primaryEffect = readVarInt();
             this.secondaryEffect = readVarInt();
@@ -51,8 +51,8 @@ public class WrapperPlayClientSetBeaconEffect extends PacketWrapper<WrapperPlayC
     @Override
     public void write() {
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
-            writeOptionalEffect(primaryEffect);
-            writeOptionalEffect(secondaryEffect);
+            writeOptional(primaryEffect, PacketWrapper::writeVarInt);
+            writeOptional(secondaryEffect, PacketWrapper::writeVarInt);
         } else {
             writeVarInt(primaryEffect);
             writeVarInt(secondaryEffect);
@@ -79,19 +79,5 @@ public class WrapperPlayClientSetBeaconEffect extends PacketWrapper<WrapperPlayC
 
     public void setSecondaryEffect(int secondaryEffect) {
         this.secondaryEffect = secondaryEffect;
-    }
-
-    private int readOptionalEffect() {
-        if (readBoolean()) {
-            return readVarInt();
-        }
-        return -1;
-    }
-
-    private void writeOptionalEffect(int effect) {
-        writeBoolean(effect != -1);
-        if (effect != -1) {
-            writeVarInt(effect);
-        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientTabComplete.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientTabComplete.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClientTabComplete> {
-    private int transactionID;
+    private int transactionId;
     private String text;
     private @Nullable Vector3i blockPosition;
 
@@ -38,9 +38,9 @@ public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClien
         super(event);
     }
 
-    public WrapperPlayClientTabComplete(int transactionID, String text, @Nullable Vector3i blockPosition) {
+    public WrapperPlayClientTabComplete(int transactionId, String text, @Nullable Vector3i blockPosition) {
         super(PacketType.Play.Client.TAB_COMPLETE);
-        this.transactionID = transactionID;
+        this.transactionId = transactionId;
         this.text = text;
         this.blockPosition = blockPosition;
     }
@@ -57,7 +57,7 @@ public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClien
                 //1.13 text length
                 textLength = 256;
             }
-            transactionID = readVarInt();
+            transactionId = readVarInt();
             text = readString(textLength);
         } else {
             textLength = 32767;
@@ -83,7 +83,7 @@ public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClien
                 //1.13 text length
                 textLength = 256;
             }
-            writeVarInt(transactionID);
+            writeVarInt(transactionId);
             writeString(text, textLength);
         } else {
             textLength = 32767;
@@ -101,7 +101,7 @@ public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClien
     @Override
     public void copy(WrapperPlayClientTabComplete wrapper) {
         text = wrapper.text;
-        transactionID = wrapper.transactionID;
+        transactionId = wrapper.transactionId;
         blockPosition = wrapper.blockPosition;
     }
 
@@ -114,12 +114,12 @@ public class WrapperPlayClientTabComplete extends PacketWrapper<WrapperPlayClien
     }
 
     public OptionalInt getTransactionId() {
-        return OptionalInt.of(transactionID);
+        return OptionalInt.of(transactionId);
     }
 
-    public void setTransactionId(@Nullable Integer transactionID) {
-        if (transactionID != null) {
-            this.transactionID = transactionID;
+    public void setTransactionId(@Nullable Integer transactionId) {
+        if (transactionId != null) {
+            this.transactionId = transactionId;
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.Vector3i;
@@ -43,14 +44,14 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
 
     @Override
     public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            this.blockPosition = new Vector3i(readLong());
-        } else {
-            int x = readInt();
-            int y = readShort();
-            int z = readInt();
-            this.blockPosition = new Vector3i(x, y, z);
-        }
+        this.blockPosition = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8,
+                PacketWrapper::readBlockPosition,
+                packetWrapper -> {
+                    int x = packetWrapper.readInt();
+                    int y = packetWrapper.readShort();
+                    int z = packetWrapper.readInt();
+                    return new Vector3i(x, y, z);
+                });
         textLines = new String[4];
         for (int i = 0; i < 4; i++) {
             this.textLines[i] = readString(384);
@@ -59,14 +60,13 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
 
     @Override
     public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            long positionVector = blockPosition.getSerializedPosition();
-            writeLong(positionVector);
-        } else {
-            writeInt(blockPosition.x);
-            writeShort(blockPosition.y);
-            writeInt(blockPosition.z);
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8, blockPosition,
+                (packetWrapper, vector3i) -> packetWrapper.writeLong(vector3i.getSerializedPosition()),
+                (packetWrapper, vector3i) -> {
+                    packetWrapper.writeInt(vector3i.x);
+                    packetWrapper.writeShort(vector3i.y);
+                    packetWrapper.writeInt(vector3i.z);
+                });
         for (int i = 0; i < 4; i++) {
             writeString(textLines[i], 384);
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBlockBreakAnimation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBlockBreakAnimation.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.Vector3i;
@@ -43,27 +44,25 @@ public class WrapperPlayServerBlockBreakAnimation extends PacketWrapper<WrapperP
     @Override
     public void read() {
         entityID = readVarInt();
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            int x = readInt();
-            int y = readInt();
-            int z = readInt();
-            blockPosition = new Vector3i(x, y, z);
-        } else {
-            blockPosition = readBlockPosition();
-        }
+        blockPosition = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8, PacketWrapper::readBlockPosition, packetWrapper -> {
+            int x = packetWrapper.readInt();
+            int y = packetWrapper.readInt();
+            int z = packetWrapper.readInt();
+            return new Vector3i(x, y, z);
+        });
         destroyStage = (byte) readUnsignedByte();
     }
 
     @Override
     public void write() {
         writeVarInt(entityID);
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            writeInt(blockPosition.x);
-            writeInt(blockPosition.y);
-            writeInt(blockPosition.z);
-        } else {
-            writeBlockPosition(blockPosition);
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8, blockPosition,
+                PacketWrapper::writeBlockPosition,
+                (packetWrapper, vector3i) -> {
+                    packetWrapper.writeInt(blockPosition.x);
+                    packetWrapper.writeInt(blockPosition.y);
+                    packetWrapper.writeInt(blockPosition.z);
+                });
         writeByte(destroyStage);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerDifficulty.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerDifficulty.java
@@ -45,7 +45,7 @@ public class WrapperPlayServerDifficulty extends PacketWrapper<WrapperPlayServer
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_14)) {
             locked = readBoolean();
         }
-        //TODO: On 1.8 locked theoretically is true? Confirm
+        // TODO: On 1.8 locked theoretically is true? Confirm
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityRelativeMove.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityRelativeMove.java
@@ -19,14 +19,15 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayServerEntityRelativeMove extends PacketWrapper<WrapperPlayServerEntityRelativeMove> {
-    //(Short.MAX_VALUE + 1) / 8.0
+    // (Short.MAX_VALUE + 1) / 8.0
     private static double MODERN_DELTA_DIVISOR = 4096.0;
-    //(Byte.MAX_VALUE + 1) / 4.0
+    // (Byte.MAX_VALUE + 1) / 4.0
     private static double LEGACY_DELTA_DIVISOR = 32.0;
     private int entityID;
     private double deltaX;
@@ -50,16 +51,16 @@ public class WrapperPlayServerEntityRelativeMove extends PacketWrapper<WrapperPl
     @Override
     public void read() {
         entityID = readVarInt();
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
-            deltaX = readShort() / MODERN_DELTA_DIVISOR;
-            deltaY = readShort() / MODERN_DELTA_DIVISOR;
-            deltaZ = readShort() / MODERN_DELTA_DIVISOR;
-        }
-        else {
-            deltaX = readByte() / LEGACY_DELTA_DIVISOR;
-            deltaY = readByte() / LEGACY_DELTA_DIVISOR;
-            deltaZ = readByte() / LEGACY_DELTA_DIVISOR;
-        }
+        readMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9,
+                packetWrapper -> {
+                    deltaX = packetWrapper.readShort() / MODERN_DELTA_DIVISOR;
+                    deltaY = packetWrapper.readShort() / MODERN_DELTA_DIVISOR;
+                    deltaZ = packetWrapper.readShort() / MODERN_DELTA_DIVISOR;
+                }, packetWrapper -> {
+                    deltaX = packetWrapper.readByte() / LEGACY_DELTA_DIVISOR;
+                    deltaY = packetWrapper.readByte() / LEGACY_DELTA_DIVISOR;
+                    deltaZ = packetWrapper.readByte() / LEGACY_DELTA_DIVISOR;
+                });
         onGround = readBoolean();
     }
 
@@ -70,8 +71,7 @@ public class WrapperPlayServerEntityRelativeMove extends PacketWrapper<WrapperPl
             writeShort((short) (deltaX * MODERN_DELTA_DIVISOR));
             writeShort((short) (deltaY * MODERN_DELTA_DIVISOR));
             writeShort((short) (deltaZ * MODERN_DELTA_DIVISOR));
-        }
-        else {
+        } else {
             writeByte((byte) (deltaX * LEGACY_DELTA_DIVISOR));
             writeByte((byte) (deltaY * LEGACY_DELTA_DIVISOR));
             writeByte((byte) (deltaZ * LEGACY_DELTA_DIVISOR));

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerExplosion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerExplosion.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.MathUtil;
@@ -32,7 +33,7 @@ import java.util.List;
 public class WrapperPlayServerExplosion extends PacketWrapper<WrapperPlayServerExplosion> {
     private Vector3f position;
     private float strength;
-    //Chunk posiitons?
+    // Chunk posiitons?
     private List<Vector3i> records;
     private Vector3f playerMotion;
 
@@ -55,7 +56,9 @@ public class WrapperPlayServerExplosion extends PacketWrapper<WrapperPlayServerE
         float z = readFloat();
         position = new Vector3f(x, y, z);
         strength = readFloat();
-        int recordsLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17) ? readVarInt() : readInt();
+        int recordsLength = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_17,
+                PacketWrapper::readVarInt,
+                PacketWrapper::readInt);
         records = new ArrayList<>(recordsLength);
 
         int floorX = (int) Math.floor(position.x);
@@ -82,20 +85,18 @@ public class WrapperPlayServerExplosion extends PacketWrapper<WrapperPlayServerE
         writeFloat(position.z);
         writeFloat(strength);
 
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
-            writeVarInt(records.size());
-        } else {
-            writeInt(records.size());
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_17, records.size(),
+                PacketWrapper::writeVarInt,
+                PacketWrapper::writeInt);
 
         int floorX = MathUtil.floor(position.x);
         int floorY = MathUtil.floor(position.y);
         int floorZ = MathUtil.floor(position.z);
 
-        for (Vector3i record : records) {
-            writeByte(record.x - floorX);
-            writeByte(record.y - floorY);
-            writeByte(record.z - floorZ);
+        for (Vector3i vector3i : records) {
+            writeByte(vector3i.x - floorX);
+            writeByte(vector3i.y - floorY);
+            writeByte(vector3i.z - floorZ);
         }
 
         writeFloat(playerMotion.x);

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerParticle.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerParticle.java
@@ -103,7 +103,7 @@ public class WrapperPlayServerParticle extends PacketWrapper<WrapperPlayServerPa
 
     @Override
     public void write() {
-        //TODO on 1.7 we get particle type by 64 len string
+        // TODO: on 1.7 we get particle type by 64 len string
         if (serverVersion == ServerVersion.V_1_7_10) {
             writeString(particle.getType().getName().getKey(), 64);
         } else {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerParticle.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerParticle.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.particle.Particle;
@@ -59,14 +60,12 @@ public class WrapperPlayServerParticle extends PacketWrapper<WrapperPlayServerPa
     @Override
     public void read() {
         int particleTypeId = 0;
-        ParticleType particleType;
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            String particleName = readString(64);
-            particleType = ParticleTypes.getByName("minecraft:" + particleName);
-        } else {
-            particleTypeId = readInt();
-            particleType = ParticleTypes.getById(serverVersion.toClientVersion(), particleTypeId);
-        }
+        ParticleType particleType = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_19,
+                MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8,
+                packetWrapper -> ParticleTypes.getById(serverVersion.toClientVersion(), packetWrapper.readVarInt()),
+                packetWrapper -> ParticleTypes.getById(serverVersion.toClientVersion(), packetWrapper.readInt()),
+                packetWrapper -> ParticleTypes.getByName("minecraft:" + packetWrapper.readString(64)));
+
         longDistance = readBoolean();
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15)) {
             position = new Vector3d(readDouble(), readDouble(), readDouble());
@@ -103,12 +102,11 @@ public class WrapperPlayServerParticle extends PacketWrapper<WrapperPlayServerPa
 
     @Override
     public void write() {
-        // TODO: on 1.7 we get particle type by 64 len string
-        if (serverVersion == ServerVersion.V_1_7_10) {
-            writeString(particle.getType().getName().getKey(), 64);
-        } else {
-            writeInt(particle.getType().getId(serverVersion.toClientVersion()));
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_19,
+                MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8, particle.getType(),
+                (packetWrapper, particleType) -> packetWrapper.writeVarInt(particleType.getId(serverVersion.toClientVersion())),
+                (packetWrapper, particleType) -> packetWrapper.writeInt(particleType.getId(serverVersion.toClientVersion())),
+                (packetWrapper, particleType) -> packetWrapper.writeString(particleType.getName().getKey(), 64));
         writeBoolean(longDistance);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15)) {
             writeDouble(position.getX());

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerRespawn.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerRespawn.java
@@ -29,9 +29,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
+// TODO: A whole recode is NEEDED
 public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRespawn> {
     private Dimension dimension;
-    private Optional<String> worldName;
+    private @Nullable String worldName;
     private Difficulty difficulty;
     private long hashedSeed;
     private GameMode gameMode;
@@ -41,14 +42,15 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
     private boolean keepingAllPlayerData;
     private WorldBlockPosition lastDeathPosition;
 
-    //This should not be accessed
+    // This should not be accessed
     private String levelType;
 
     public WrapperPlayServerRespawn(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayServerRespawn(Dimension dimension, @Nullable String worldName, Difficulty difficulty, long hashedSeed, GameMode gameMode, @Nullable GameMode previousGameMode, boolean worldDebug, boolean worldFlat, boolean keepingAllPlayerData) {
+    public WrapperPlayServerRespawn(Dimension dimension, @Nullable String worldName, Difficulty difficulty, long hashedSeed,
+                                    GameMode gameMode, @Nullable GameMode previousGameMode, boolean worldDebug, boolean worldFlat, boolean keepingAllPlayerData) {
         super(PacketType.Play.Server.RESPAWN);
         this.dimension = dimension;
         setWorldName(worldName);
@@ -68,7 +70,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
 
         if (v1_15_0) {
             dimension = readDimension();
-            worldName = Optional.of(readString());
+            worldName = readString();
             hashedSeed = readLong();
             gameMode = GameMode.getById(readUnsignedByte());
             int previousMode = readByte();
@@ -89,7 +91,6 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
                 difficulty = Difficulty.NORMAL;
             }
 
-            worldName = Optional.empty();
             hashedSeed = 0L;
 
             //Note: SPECTATOR will not be expected from a 1.7 client.
@@ -109,7 +110,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
 
         if (v1_16_0) {
             writeDimension(dimension);
-            writeString(worldName.orElse(""));
+            writeString(worldName);
             writeLong(hashedSeed);
             writeByte(gameMode.ordinal());
             writeByte(previousGameMode == null ? -1 : previousGameMode.ordinal());
@@ -118,12 +119,14 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
             writeBoolean(keepingAllPlayerData);
             if (v1_19) {
                 writeBoolean(lastDeathPosition != null);
-                if (lastDeathPosition != null) writeWorldBlockPosition(lastDeathPosition);
+                if (lastDeathPosition != null) {
+                    writeWorldBlockPosition(lastDeathPosition);
+                }
             }
         } else {
             writeInt(dimension.getType().getId());
             if (v1_15_0) {
-                writeString(worldName.orElse(""));
+                writeString(worldName);
                 writeLong(hashedSeed);
             } else {
                 if (!v1_14) {
@@ -135,7 +138,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
                 }
             }
 
-            //Note: SPECTATOR will not be expected from a 1.7 client.
+            // Note: SPECTATOR will not be expected from a 1.7 client.
             writeByte(gameMode.ordinal());
 
             if (worldFlat) {
@@ -170,15 +173,11 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
     }
 
     public Optional<String> getWorldName() {
-        return worldName;
+        return Optional.ofNullable(worldName);
     }
 
     public void setWorldName(@Nullable String worldName) {
-        if (worldName == null) {
-            this.worldName = Optional.empty();
-        } else {
-            this.worldName = Optional.of(worldName);
-        }
+        this.worldName = worldName;
     }
 
     public Difficulty getDifficulty() {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSoundEffect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSoundEffect.java
@@ -89,15 +89,6 @@ public class WrapperPlayServerSoundEffect extends PacketWrapper<WrapperPlayServe
         seed = wrapper.seed;
     }
 
-    @Override
-    public void copy(WrapperPlayServerSoundEffect wrapper) {
-        soundID = wrapper.soundID;
-        soundCategory = wrapper.soundCategory;
-        effectPosition = wrapper.effectPosition;
-        volume = wrapper.volume;
-        pitch = wrapper.pitch;
-    }
-
     public int getSoundId() {
         return soundID;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnEntity.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnEntity.java
@@ -19,6 +19,7 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
@@ -26,6 +27,7 @@ import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.MathUtil;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -33,138 +35,130 @@ import java.util.UUID;
 public class WrapperPlayServerSpawnEntity extends PacketWrapper<WrapperPlayServerSpawnEntity> {
     private static final float ROTATION_FACTOR = 256.0F / 360.0F;
     private static final double VELOCITY_FACTOR = 8000.0;
-    private int entityID;
-    private Optional<UUID> uuid;
+    private int entityId;
+    private @Nullable UUID uuid;
     private EntityType entityType;
     private Vector3d position;
     private float pitch;
     private float yaw;
     private float headYaw;
     private int data;
-    private Optional<Vector3d> velocity;
+    private @Nullable Vector3d velocity;
 
     public WrapperPlayServerSpawnEntity(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayServerSpawnEntity(int entityID, Optional<UUID> uuid, EntityType entityType, Vector3d position, float pitch, float yaw, float headYaw, int data, Optional<Vector3d> velocity) {
+    public WrapperPlayServerSpawnEntity(int entityId, EntityType entityType, Vector3d position, float pitch,
+                                        float yaw, float headYaw, int data) {
+        this(entityId, null, entityType, position, pitch, yaw, headYaw, data, null);
+    }
+
+    public WrapperPlayServerSpawnEntity(int entityId, @Nullable UUID uuid, EntityType entityType, Vector3d position, float pitch,
+                                        float yaw, float headYaw, int data, @Nullable Vector3d velocity) {
         super(PacketType.Play.Server.SPAWN_ENTITY);
-        this.entityID = entityID;
+        this.entityId = entityId;
         this.uuid = uuid;
         this.entityType = entityType;
         this.position = position;
         this.pitch = pitch;
         this.yaw = yaw;
+        this.headYaw = headYaw;
         this.data = data;
         this.velocity = velocity;
     }
 
     @Override
     public void read() {
-        entityID = readVarInt();
         boolean v1_9 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9);
-        boolean v1_15 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15);
-        boolean v1_19 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19);
+
+        entityId = readVarInt();
         if (v1_9) {
-            uuid = Optional.of(readUUID());
-        } else {
-            uuid = Optional.empty();
-        }
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_14)) {
-            entityType = EntityTypes.getById(serverVersion.toClientVersion(), readVarInt());
-        } else {
-            int id = readByte();
-            entityType = EntityTypes.getByLegacyId(serverVersion.toClientVersion(), id);
-            if (entityType == null) // Should not happen but anyway
-                entityType = EntityTypes.getById(serverVersion.toClientVersion(), id);
-        }
-        double x;
-        double y;
-        double z;
-        if (v1_9) {
-            x = readDouble();
-            y = readDouble();
-            z = readDouble();
-        } else {
-            x = readInt() / 32.0;
-            y = readInt() / 32.0;
-            z = readInt() / 32.0;
-        }
-        position = new Vector3d(x, y, z);
-
-        if (v1_15) {
-            pitch = readByte() / ROTATION_FACTOR;
-            yaw = readByte() / ROTATION_FACTOR;
-        } else {
-            yaw = readByte() / ROTATION_FACTOR;
-            pitch = readByte() / ROTATION_FACTOR;
+            uuid = readUUID();
         }
 
-        if (v1_19) {
-            headYaw = readByte() / ROTATION_FACTOR;
-            data = readVarInt();
-        } else {
-            data = readInt();
-        }
+        entityType = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_14, packetWrapper -> EntityTypes.getById(serverVersion.toClientVersion(), packetWrapper.readVarInt()), packetWrapper -> EntityTypes.getById(serverVersion.toClientVersion(), packetWrapper.readByte()));
 
-        //On 1.8 check if data > 0 before reading, or it won't be in the packet
+        position = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9, packetWrapper -> {
+            double x = packetWrapper.readDouble();
+            double y = packetWrapper.readDouble();
+            double z = packetWrapper.readDouble();
+            return new Vector3d(x, y, z);
+        }, packetWrapper -> {
+            double x = packetWrapper.readDouble() / 32.0;
+            double y = packetWrapper.readDouble() / 32.0;
+            double z = packetWrapper.readDouble() / 32.0;
+            return new Vector3d(x, y, z);
+        });
+
+        readMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_15, packetWrapper -> {
+            pitch = packetWrapper.readByte() / ROTATION_FACTOR;
+            yaw = packetWrapper.readByte() / ROTATION_FACTOR;
+        }, packetWrapper -> {
+            yaw = packetWrapper.readByte() / ROTATION_FACTOR;
+            pitch = packetWrapper.readByte() / ROTATION_FACTOR;
+        });
+
+        readMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_19, packetWrapper -> {
+            headYaw = packetWrapper.readByte() / ROTATION_FACTOR;
+            data = packetWrapper.readVarInt();
+        }, packetWrapper -> data = packetWrapper.readInt());
+
+        // On 1.8 check if data > 0 before reading, or it won't be in the packet
         if (v1_9 || data > 0) {
             double velX = readShort() / VELOCITY_FACTOR;
             double velY = readShort() / VELOCITY_FACTOR;
             double velZ = readShort() / VELOCITY_FACTOR;
-            velocity = Optional.of(new Vector3d(velX, velY, velZ));
-        } else {
-            velocity = Optional.empty();
+            velocity = new Vector3d(velX, velY, velZ);
         }
     }
 
     @Override
     public void write() {
-        writeVarInt(entityID);
         boolean v1_9 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9);
-        boolean v1_15 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15);
-        boolean v1_19 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19);
+
+        writeVarInt(entityId);
         if (v1_9) {
-            writeUUID(uuid.orElse(new UUID(0L, 0L)));
-        }
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_14)) {
-            writeVarInt(entityType.getId(serverVersion.toClientVersion()));
-        } else {
-            if (entityType.getLegacyId(serverVersion.toClientVersion()) != -1) { // Will always be true if they use correct EntityTypes for this packet
-                writeByte(entityType.getLegacyId(serverVersion.toClientVersion()));
-            } else {
-                writeByte(entityType.getId(serverVersion.toClientVersion()));
-            }
+            writeUUID(uuid);
         }
 
-        if (v1_9) {
-            writeDouble(position.x);
-            writeDouble(position.y);
-            writeDouble(position.z);
-        } else {
-            writeInt(MathUtil.floor(position.x * 32.0));
-            writeInt(MathUtil.floor(position.y * 32.0));
-            writeInt(MathUtil.floor(position.z * 32.0));
-        }
+        writeMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_14, entityType,
+                (packetWrapper, fieldType) -> packetWrapper.writeVarInt(fieldType.getId(serverVersion.toClientVersion())),
+                (packetWrapper, type) -> {
+                    // Will always be true if they use correct EntityTypes for this packet
+                    if (type.getLegacyId(serverVersion.toClientVersion()) != -1) {
+                        packetWrapper.writeByte(type.getLegacyId(serverVersion.toClientVersion()));
+                    } else {
+                        packetWrapper.writeByte(type.getId(serverVersion.toClientVersion()));
+                    }
+                });
 
-        if (v1_15) {
-            writeByte(MathUtil.floor(pitch * ROTATION_FACTOR));
-            writeByte(MathUtil.floor(yaw * ROTATION_FACTOR));
-        } else {
-            writeByte(MathUtil.floor(yaw * ROTATION_FACTOR));
-            writeByte(MathUtil.floor(pitch * ROTATION_FACTOR));
-        }
+        writeMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_9, packetWrapper -> {
+            packetWrapper.writeDouble(position.x);
+            packetWrapper.writeDouble(position.y);
+            packetWrapper.writeDouble(position.z);
+        }, packetWrapper -> {
+            packetWrapper.writeInt(MathUtil.floor(position.x * 32.0));
+            packetWrapper.writeInt(MathUtil.floor(position.y * 32.0));
+            packetWrapper.writeInt(MathUtil.floor(position.z * 32.0));
+        });
 
-        if (v1_19) {
-            writeByte(MathUtil.floor(headYaw * ROTATION_FACTOR));
-            writeVarInt(data);
-        } else {
-            writeInt(data);
-        }
+        writeMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_15, packetWrapper -> {
+            packetWrapper.writeByte(MathUtil.floor(pitch * ROTATION_FACTOR));
+            packetWrapper.writeByte(MathUtil.floor(yaw * ROTATION_FACTOR));
+        }, packetWrapper -> {
+            packetWrapper.writeByte(MathUtil.floor(yaw * ROTATION_FACTOR));
+            packetWrapper.writeByte(MathUtil.floor(pitch * ROTATION_FACTOR));
+        });
 
-        //On 1.8 check if data > 0 before reading, or it won't be in the packet
+        writeMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_19, packetWrapper -> {
+            packetWrapper.writeByte(MathUtil.floor(headYaw * ROTATION_FACTOR));
+            packetWrapper.writeVarInt(data);
+        }, packetWrapper -> packetWrapper.writeInt(data));
+
+        // On 1.8 check if data > 0 before reading, or it won't be in the packet
         if (v1_9 || data > 0) {
-            Vector3d vel = velocity.orElse(new Vector3d(-1, -1, -1));
+            Vector3d vel = velocity == null ? new Vector3d(-1, -1, -1) : velocity;
             int velX = (int) (vel.x * VELOCITY_FACTOR);
             int velY = (int) (vel.y * VELOCITY_FACTOR);
             int velZ = (int) (vel.z * VELOCITY_FACTOR);
@@ -176,7 +170,7 @@ public class WrapperPlayServerSpawnEntity extends PacketWrapper<WrapperPlayServe
 
     @Override
     public void copy(WrapperPlayServerSpawnEntity wrapper) {
-        entityID = wrapper.entityID;
+        entityId = wrapper.entityId;
         uuid = wrapper.uuid;
         entityType = wrapper.entityType;
         position = wrapper.position;
@@ -188,18 +182,18 @@ public class WrapperPlayServerSpawnEntity extends PacketWrapper<WrapperPlayServe
     }
 
     public int getEntityId() {
-        return entityID;
+        return entityId;
     }
 
-    public void setEntityId(int entityID) {
-        this.entityID = entityID;
+    public void setEntityId(int entityId) {
+        this.entityId = entityId;
     }
 
     public Optional<UUID> getUUID() {
-        return uuid;
+        return Optional.ofNullable(uuid);
     }
 
-    public void setUUID(Optional<UUID> uuid) {
+    public void setUUID(@Nullable UUID uuid) {
         this.uuid = uuid;
     }
 
@@ -244,10 +238,10 @@ public class WrapperPlayServerSpawnEntity extends PacketWrapper<WrapperPlayServe
     }
 
     public Optional<Vector3d> getVelocity() {
-        return velocity;
+        return Optional.ofNullable(velocity);
     }
 
-    public void setVelocity(Optional<Vector3d> velocity) {
+    public void setVelocity(@Nullable Vector3d velocity) {
         this.velocity = velocity;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.java
@@ -19,8 +19,10 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.scoreboard.*;
 import com.github.retrooper.packetevents.util.AdventureSerializer;
 import com.github.retrooper.packetevents.util.ColorUtil;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
@@ -32,100 +34,28 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
+// TODO: This also needs a whole recode
 public class WrapperPlayServerTeams extends PacketWrapper<WrapperPlayServerTeams> {
     private String teamName;
     private TeamMode teamMode;
+    private @Nullable TeamInfo teamInfo;
     private Collection<String> players;
-    private Optional<ScoreBoardTeamInfo> teamInfo;
-
-    public enum OptionData {
-        NONE((byte) 0x00), FRIENDLY_FIRE((byte) 0x01), FRIENDLY_CAN_SEE_INVISIBLE((byte) 0x02), ALL((byte) 0x03);
-
-        private static final OptionData[] VALUES = values();
-        private final byte byteValue;
-
-        OptionData(byte value) {
-            byteValue = value;
-        }
-
-        public byte getByteValue() {
-            return byteValue;
-        }
-
-        @Nullable
-        public static OptionData fromValue(byte value) {
-            for (OptionData data : VALUES) {
-                if (data.getByteValue() == value) {
-                    return data;
-                }
-            }
-            return null;
-        }
-    }
-
-    public enum NameTagVisibility {
-        ALWAYS("always"), NEVER("never"), HIDE_FOR_OTHER_TEAMS("hideForOtherTeams"), HIDE_FOR_OWN_TEAM("hideForOwnTeam");
-
-        private final String id;
-
-        NameTagVisibility(String id) {
-            this.id = id;
-        }
-
-        @Nullable
-        public static NameTagVisibility fromID(String id) {
-            for (NameTagVisibility value : NameTagVisibility.values()) {
-                if (value.id.equalsIgnoreCase(id)) {
-                    return value;
-                }
-            }
-            return null;
-        }
-
-        public String getId() {
-            return id;
-        }
-    }
-
-    public enum CollisionRule {
-        ALWAYS("always"), NEVER("never"), PUSH_OTHER_TEAMS("pushOtherTeams"), PUSH_OWN_TEAM("pushOwnTeam");
-
-        private final String id;
-
-        CollisionRule(String id) {
-            this.id = id;
-        }
-
-        @Nullable
-        public static CollisionRule fromID(String id) {
-            for (CollisionRule value : CollisionRule.values()) {
-                if (value.id.equalsIgnoreCase(id)) {
-                    return value;
-                }
-            }
-            return null;
-        }
-
-        public String getId() {
-            return id;
-        }
-
-    }
-
-    public enum TeamMode {
-        CREATE, REMOVE, UPDATE, ADD_ENTITIES, REMOVE_ENTITIES;
-    }
 
     public WrapperPlayServerTeams(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayServerTeams(String teamName, TeamMode teamMode, Optional<ScoreBoardTeamInfo> teamInfo, String... entities) {
+    public WrapperPlayServerTeams(String teamName, TeamMode teamMode, String... entities) {
+        this(teamName, teamMode, null, Arrays.asList(entities));
+    }
+
+    public WrapperPlayServerTeams(String teamName, TeamMode teamMode, @Nullable TeamInfo teamInfo, String... entities) {
         this(teamName, teamMode, teamInfo, Arrays.asList(entities));
     }
 
-    public WrapperPlayServerTeams(String teamName, TeamMode teamMode, Optional<ScoreBoardTeamInfo> teamInfo, Collection<String> entities) {
+    public WrapperPlayServerTeams(String teamName, TeamMode teamMode, @Nullable TeamInfo teamInfo, Collection<String> entities) {
         super(PacketType.Play.Server.TEAMS);
         this.teamName = teamName;
         this.teamMode = teamMode;
@@ -136,48 +66,49 @@ public class WrapperPlayServerTeams extends PacketWrapper<WrapperPlayServerTeams
     @Override
     public void read() {
         teamName = readString(16);
-        teamMode = TeamMode.values()[readByte()];
-        ScoreBoardTeamInfo info = null;
+        teamMode = TeamMode.getById(readByte());
+        AtomicReference<TeamInfo> info = null;
         if (teamMode == TeamMode.CREATE || teamMode == TeamMode.UPDATE) {
-            Component displayName, prefix, suffix;
-            OptionData optionData;
-            NameTagVisibility nameTagVisibility;
-            CollisionRule collisionRule = null;
-            NamedTextColor color;
-            if (serverVersion.isOlderThanOrEquals(ServerVersion.V_1_12_2)) {
-                displayName = AdventureSerializer.fromLegacyFormat(readString());
-                prefix = AdventureSerializer.fromLegacyFormat(readString());
-                suffix = AdventureSerializer.fromLegacyFormat(readString());
-                optionData = OptionData.values()[readByte()];
-                if (serverVersion == ServerVersion.V_1_7_10) {
-                    nameTagVisibility = NameTagVisibility.ALWAYS;
-                    color = NamedTextColor.WHITE;
-                } else {
-                    nameTagVisibility = NameTagVisibility.fromID(readString());
-                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9))
-                        collisionRule = CollisionRule.fromID(readString());
-                    color = ColorUtil.fromId(readByte());
-                }
-            } else {
-                displayName = readComponent();
-                optionData = OptionData.fromValue(readByte());
-                nameTagVisibility = NameTagVisibility.fromID(readString());
-                collisionRule = CollisionRule.fromID(readString());
-                color = ColorUtil.fromId(readByte());
-                prefix = readComponent();
-                suffix = readComponent();
-            }
-            info = new ScoreBoardTeamInfo(displayName, prefix, suffix, nameTagVisibility, collisionRule == null ? CollisionRule.ALWAYS : collisionRule, color, optionData);
+            readMulti(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_13,
+                    packetWrapper -> {
+                        Component displayName = readComponent();
+                        OptionData optionData = OptionData.fromValue(readByte());
+                        NameTagVisibility nameTagVisibility = NameTagVisibility.getById(readString());
+                        CollisionRule collisionRule = CollisionRule.getById(readString());
+                        NamedTextColor color = ColorUtil.fromId(readByte());
+                        Component prefix = readComponent();
+                        Component suffix = readComponent();
+                        info.set(new TeamInfo(displayName, prefix, suffix, nameTagVisibility,
+                                collisionRule == null ? CollisionRule.ALWAYS : collisionRule, color, optionData));
+                    }, packetWrapper -> {
+                        Component displayName = AdventureSerializer.fromLegacyFormat(readString());
+                        Component prefix = AdventureSerializer.fromLegacyFormat(readString());
+                        Component suffix = AdventureSerializer.fromLegacyFormat(readString());
+                        OptionData optionData = OptionData.fromValue(readByte());
+                        NameTagVisibility nameTagVisibility;
+                        NamedTextColor color;
+                        CollisionRule collisionRule = null;
+                        if (serverVersion == ServerVersion.V_1_7_10) {
+                            nameTagVisibility = NameTagVisibility.ALWAYS;
+                            color = NamedTextColor.WHITE;
+                        } else {
+                            nameTagVisibility = NameTagVisibility.getById(readString());
+                            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
+                                collisionRule = CollisionRule.getById(readString());
+                            }
+                            color = ColorUtil.fromId(readByte());
+                        }
+                        info.set(new TeamInfo(displayName, prefix, suffix, nameTagVisibility,
+                                collisionRule == null ? CollisionRule.ALWAYS : collisionRule, color, optionData));
+                    });
         }
-        teamInfo = Optional.ofNullable(info);
+
+        teamInfo = info.get();
         players = new ArrayList<>();
         if (teamMode == TeamMode.CREATE || teamMode == TeamMode.ADD_ENTITIES || teamMode == TeamMode.REMOVE_ENTITIES) {
-            int size;
-            if (serverVersion == ServerVersion.V_1_7_10) {
-                size = readShort();
-            } else {
-                size = readVarInt();
-            }
+            int size = readMultiVersional(MultiVersion.NEWER_THAN_OR_EQUALS, ServerVersion.V_1_8,
+                    PacketWrapper::readVarInt,
+                    PacketWrapper::readShort);
             for (int i = 0; i < size; i++) {
                 players.add(readString());
             }
@@ -189,28 +120,29 @@ public class WrapperPlayServerTeams extends PacketWrapper<WrapperPlayServerTeams
         writeString(teamName, 16);
         writeByte(teamMode.ordinal());
         if (teamMode == TeamMode.CREATE || teamMode == TeamMode.UPDATE) {
-            ScoreBoardTeamInfo info = teamInfo.orElse(new ScoreBoardTeamInfo(Component.empty(), Component.empty(), Component.empty(), NameTagVisibility.ALWAYS, CollisionRule.ALWAYS, NamedTextColor.WHITE, OptionData.NONE));
+            TeamInfo info = teamInfo == null ? new TeamInfo(null, null, null,
+                    NameTagVisibility.ALWAYS, CollisionRule.ALWAYS, NamedTextColor.WHITE, OptionData.NONE) : teamInfo;
             if (serverVersion.isOlderThanOrEquals(ServerVersion.V_1_12_2)) {
-                writeString(AdventureSerializer.asVanilla(info.displayName));
-                writeString(AdventureSerializer.asVanilla(info.prefix));
-                writeString(AdventureSerializer.asVanilla(info.suffix));
-                writeByte(info.optionData.ordinal());
+                writeString(AdventureSerializer.asVanilla(info.getDisplayName()));
+                writeString(AdventureSerializer.asVanilla(info.getPrefix()));
+                writeString(AdventureSerializer.asVanilla(info.getSuffix()));
+                writeByte(info.getOptionData().ordinal());
                 if (serverVersion == ServerVersion.V_1_7_10) {
                     writeString(NameTagVisibility.ALWAYS.getId());
                     writeByte(15);
                 } else {
-                    writeString(info.tagVisibility.id);
-                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) writeString(info.collisionRule.getId());
-                    writeByte(ColorUtil.getId(info.color));
+                    writeString(info.getTagVisibility().getId());
+                    if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) writeString(info.getCollisionRule().getId());
+                    writeByte(ColorUtil.getId(info.getColor()));
                 }
             } else {
-                writeComponent(info.displayName);
-                writeByte(info.optionData.getByteValue());
-                writeString(info.tagVisibility.id);
-                writeString(info.collisionRule.getId());
-                writeByte(ColorUtil.getId(info.color));
-                writeComponent(info.prefix);
-                writeComponent(info.suffix);
+                writeComponent(info.getDisplayName());
+                writeByte(info.getOptionData().getByteValue());
+                writeString(info.getTagVisibility().getId());
+                writeString(info.getCollisionRule().getId());
+                writeByte(ColorUtil.getId(info.getColor()));
+                writeComponent(info.getPrefix());
+                writeComponent(info.getSuffix());
             }
         }
 
@@ -230,14 +162,13 @@ public class WrapperPlayServerTeams extends PacketWrapper<WrapperPlayServerTeams
     public void copy(WrapperPlayServerTeams wrapper) {
         teamName = wrapper.teamName;
         teamMode = wrapper.teamMode;
-        players = wrapper.players;
         teamInfo = wrapper.teamInfo;
+        players = wrapper.players;
     }
 
     public String getTeamName() {
         return teamName;
     }
-
 
     public void setTeamName(String teamName) {
         this.teamName = teamName;
@@ -259,96 +190,11 @@ public class WrapperPlayServerTeams extends PacketWrapper<WrapperPlayServerTeams
         this.players = players;
     }
 
-    public Optional<ScoreBoardTeamInfo> getTeamInfo() {
-        return teamInfo;
+    public Optional<TeamInfo> getTeamInfo() {
+        return Optional.ofNullable(teamInfo);
     }
 
-    public void setTeamInfo(Optional<ScoreBoardTeamInfo> teamInfo) {
+    public void setTeamInfo(@Nullable TeamInfo teamInfo) {
         this.teamInfo = teamInfo;
     }
-
-    public static class ScoreBoardTeamInfo {
-
-        private Component displayName;
-        private Component prefix;
-        private Component suffix;
-        private NameTagVisibility tagVisibility;
-        private CollisionRule collisionRule;
-        private NamedTextColor color;
-        private OptionData optionData;
-
-        public ScoreBoardTeamInfo(Component displayName, @Nullable Component prefix, @Nullable Component suffix, NameTagVisibility tagVisibility, CollisionRule collisionRule, NamedTextColor color, OptionData optionData) {
-            this.displayName = displayName;
-            if (prefix == null) {
-                prefix = Component.empty();
-            }
-            if (suffix == null) {
-                suffix = Component.empty();
-            }
-            this.prefix = prefix;
-            this.suffix = suffix;
-            this.tagVisibility = tagVisibility;
-            this.collisionRule = collisionRule;
-            this.color = color;
-            this.optionData = optionData;
-        }
-
-        public Component getDisplayName() {
-            return displayName;
-        }
-
-        public void setDisplayName(Component displayName) {
-            this.displayName = displayName;
-        }
-
-        public Component getPrefix() {
-            return prefix;
-        }
-
-        public void setPrefix(Component prefix) {
-            this.prefix = prefix;
-        }
-
-        public Component getSuffix() {
-            return suffix;
-        }
-
-        public void setSuffix(Component suffix) {
-            this.suffix = suffix;
-        }
-
-        public NameTagVisibility getTagVisibility() {
-            return tagVisibility;
-        }
-
-        public void setTagVisibility(NameTagVisibility tagVisibility) {
-            this.tagVisibility = tagVisibility;
-        }
-
-        public CollisionRule getCollisionRule() {
-            return collisionRule;
-        }
-
-        public void setCollisionRule(CollisionRule collisionRule) {
-            this.collisionRule = collisionRule;
-        }
-
-        public NamedTextColor getColor() {
-            return color;
-        }
-
-        public void setColor(NamedTextColor color) {
-            this.color = color;
-        }
-
-        public OptionData getOptionData() {
-            return optionData;
-        }
-
-        public void setOptionData(OptionData optionData) {
-            this.optionData = optionData;
-        }
-
-    }
-
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWindowConfirmation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWindowConfirmation.java
@@ -86,16 +86,16 @@ public class WrapperPlayServerWindowConfirmation extends PacketWrapper<WrapperPl
         return windowId;
     }
 
-    public void setWindowId(int windowID) {
-        this.windowId = windowID;
+    public void setWindowId(int windowId) {
+        this.windowId = windowId;
     }
 
     public short getActionId() {
         return actionId;
     }
 
-    public void setActionId(short actionID) {
-        this.actionId = actionID;
+    public void setActionId(short actionId) {
+        this.actionId = actionId;
     }
 
     public boolean isAccepted() {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWindowItems.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWindowItems.java
@@ -30,29 +30,34 @@ import java.util.List;
 import java.util.Optional;
 
 public class WrapperPlayServerWindowItems extends PacketWrapper<WrapperPlayServerWindowItems> {
-    private int windowID;
-    private int stateID;
+    private int windowId;
+    private int stateId;
     private List<ItemStack> items;
-    private Optional<ItemStack> carriedItem;
+    private @Nullable ItemStack carriedItem;
 
     public WrapperPlayServerWindowItems(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayServerWindowItems(int windowID, int stateID, List<ItemStack> items, @Nullable ItemStack carriedItem) {
+    public WrapperPlayServerWindowItems(int windowId, int stateId, List<ItemStack> items) {
+        this(windowId, stateId, items, null);
+    }
+
+    public WrapperPlayServerWindowItems(int windowId, int stateId, List<ItemStack> items, @Nullable ItemStack carriedItem) {
         super(PacketType.Play.Server.WINDOW_ITEMS);
-        this.windowID = windowID;
-        this.stateID = stateID;
+        this.windowId = windowId;
+        this.stateId = stateId;
         this.items = items;
-        this.carriedItem = Optional.ofNullable(carriedItem);
+        this.carriedItem = carriedItem;
     }
 
     @Override
     public void read() {
-        windowID = readUnsignedByte();
         boolean v1_17_1 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17_1);
+
+        windowId = readUnsignedByte();
         if (v1_17_1) {
-            stateID = readVarInt();
+            stateId = readVarInt();
         }
 
         int count = v1_17_1 ? readVarInt() : readShort();
@@ -61,21 +66,18 @@ public class WrapperPlayServerWindowItems extends PacketWrapper<WrapperPlayServe
             items.add(readItemStack());
         }
 
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17_1)) {
-            carriedItem = Optional.of(readItemStack());
-        } else {
-            carriedItem = Optional.empty();
+        if (v1_17_1) {
+            carriedItem = readItemStack();
         }
     }
 
     @Override
     public void write() {
-        writeByte(windowID);
         boolean v1_17_1 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17_1);
+
+        writeByte(windowId);
         if (v1_17_1) {
-            writeVarInt(stateID);
-        }
-        if (v1_17_1) {
+            writeVarInt(stateId);
             writeVarInt(items.size());
         } else {
             writeShort(items.size());
@@ -84,32 +86,32 @@ public class WrapperPlayServerWindowItems extends PacketWrapper<WrapperPlayServe
             writeItemStack(item);
         }
         if (v1_17_1) {
-            writeItemStack(carriedItem.orElse(ItemStack.EMPTY));
+            writeItemStack(carriedItem == null ? ItemStack.EMPTY : carriedItem);
         }
     }
 
     @Override
     public void copy(WrapperPlayServerWindowItems wrapper) {
-        windowID = wrapper.windowID;
-        stateID = wrapper.stateID;
+        windowId = wrapper.windowId;
+        stateId = wrapper.stateId;
         items = wrapper.items;
         carriedItem = wrapper.carriedItem;
     }
 
     public int getWindowId() {
-        return windowID;
+        return windowId;
     }
 
-    public void setWindowId(int windowID) {
-        this.windowID = windowID;
+    public void setWindowId(int windowId) {
+        this.windowId = windowId;
     }
 
     public int getStateId() {
-        return stateID;
+        return stateId;
     }
 
-    public void setStateId(int stateID) {
-        this.stateID = stateID;
+    public void setStateId(int stateId) {
+        this.stateId = stateId;
     }
 
     public List<ItemStack> getItems() {
@@ -121,10 +123,10 @@ public class WrapperPlayServerWindowItems extends PacketWrapper<WrapperPlayServe
     }
 
     public Optional<ItemStack> getCarriedItem() {
-        return carriedItem;
+        return Optional.ofNullable(carriedItem);
     }
 
     public void setCarriedItem(@Nullable ItemStack carriedItem) {
-        this.carriedItem = Optional.ofNullable(carriedItem);
+        this.carriedItem = carriedItem;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayWorldBorderWarningDelay.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayWorldBorderWarningDelay.java
@@ -19,8 +19,8 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.MultiVersion;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.manager.server.ServerVersion.MultiVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 


### PR DESCRIPTION
### Breaking API-Changes
- Moved `api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.MultiVersion.java` to `api/src/main/java/com/github/retrooper/packetevents/manager/server/MultiVersion.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTabComplete.CommandMatch.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandMatch.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTabComplete.CommandRange.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/command/CommandRange.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClickWindow.WindowClickType.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/window/WindowClickType.java`
- Moved and renamed `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientEntityAction.Action.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityAction.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientInteractEntity.InteractAction.java` `api/src/main/java/com/github/retrooper/packetevents/protocol/entity/EntityInteractAction.java`
- Moved and renamed `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientResourcePackStatus.Result.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/resourcepack/ResourcePacketResult.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientSettings.ChatVisibility.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatVisibility.java`
- Moved and renamed `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerUpdateScore.Action.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/UpdateScore.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.CollisionRule.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/CollisionRule.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.NameTagVisibility.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/NameTagVisibility.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.OptionData.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/OptionData.java`
- Moved and renamed `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.ScoreBoardTeamInfo.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamInfo.java`
- Moved `api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTeams.TeamMode.java` to `api/src/main/java/com/github/retrooper/packetevents/protocol/scoreboard/TeamMode.java`

### Changes
- Removed plain `Optional` fields from every Wrapper
- Renamed `ID` fields to `Id`
- Unexposed `VALUES` from HumanoidArm class
- Unexposed `VALUES` from Operation class
- Deprecated `public static EquipmentSlot getById(ServerVersion version, int id)`

### Additions
- Added `EQUALS` to `MultiVersion` and `$is` in ServerVersion class
- Added missing `$getActionNumber` and `$setActionNumber(int actionNumber)` methods in WrapperPlayClientClickWindow

- Added:
##### PacketWrapper
  ```java
  public <U, V, R, X> U readMultiVersional(MultiVersion version, ServerVersion target,
                                             MultiVersion versionSecond, ServerVersion targetSecond,
                                             Reader<V> first, Reader<R> second, Reader<X> third);
  public <V> void writeMultiVersional(MultiVersion version, ServerVersion target,
                                        MultiVersion versionSecond, ServerVersion targetSecond, V value,
                                        Writer<V> first, Writer<V> second, Writer<V> third);
  public void readMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,
                          Consumer<PacketWrapper<?>> second);
  public void writeMulti(MultiVersion version, ServerVersion target, Consumer<PacketWrapper<?>> first,
                          Consumer<PacketWrapper<?>> second);
  ```
##### EquipmentSlot
```java
public static Optional<EquipmentSlot> byId(@Range(from = 0, to = 4) int id);
```

### Removed
- Removed internal used `$readOptionalEffect` and `writeOptionalEffect` methods in WrapperPlayClientSetBeaconEffect class

The general purpose of this pull-request was to cleanup some wrappers which still were kind of unclean or didn't use our new methods.
Meanwhile, I cleaned up some classes and moved some stuff around.