### PR TITLE
Bump max length for serverAddress

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -372,8 +372,8 @@ public class PacketWrapper<T extends PacketWrapper> {
         } else {
             String s = ByteBufHelper.toString(buffer, ByteBufHelper.readerIndex(buffer), j, StandardCharsets.UTF_8);
             ByteBufHelper.readerIndex(buffer, ByteBufHelper.readerIndex(buffer) + j);
-            if (s.length() > maxLen) {
-                throw new RuntimeException("The received string length is longer than maximum allowed (" + j + " > " + maxLen + ")");
+            if (s.length() > maxLen * 4) {
+                throw new RuntimeException("The received string length is longer than maximum allowed (" + s.length() + " > " + maxLen + ")");
             } else {
                 return s;
             }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -372,8 +372,8 @@ public class PacketWrapper<T extends PacketWrapper> {
         } else {
             String s = ByteBufHelper.toString(buffer, ByteBufHelper.readerIndex(buffer), j, StandardCharsets.UTF_8);
             ByteBufHelper.readerIndex(buffer, ByteBufHelper.readerIndex(buffer) + j);
-            if (s.length() > maxLen * 4) {
-                throw new RuntimeException("The received string length is longer than maximum allowed (" + s.length() + " > " + maxLen + ")");
+            if (s.length() > maxLen) {
+                throw new RuntimeException("The received string length is longer than maximum allowed (" + j + " > " + maxLen + ")");
             } else {
                 return s;
             }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
@@ -52,7 +52,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     public void read() {
         this.protocolVersion = readVarInt();
         this.clientVersion = ClientVersion.getById(protocolVersion);
-        this.serverAddress = readString(255);
+        this.serverAddress = readString(350);
         this.serverPort = readUnsignedShort();
         int nextStateIndex = readVarInt();
         this.nextConnectionState = ConnectionState.getById(nextStateIndex);
@@ -61,7 +61,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     @Override
     public void write() {
         writeVarInt(protocolVersion);
-        writeString(serverAddress, 255);
+        writeString(serverAddress, 350);
         writeShort(serverPort);
         writeVarInt(nextConnectionState.ordinal());
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
@@ -52,7 +52,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     public void read() {
         this.protocolVersion = readVarInt();
         this.clientVersion = ClientVersion.getById(protocolVersion);
-        this.serverAddress = readString(1300); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
+        this.serverAddress = readString(1500); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         this.serverPort = readUnsignedShort();
         int nextStateIndex = readVarInt();
         this.nextConnectionState = ConnectionState.getById(nextStateIndex);
@@ -61,7 +61,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     @Override
     public void write() {
         writeVarInt(protocolVersion);
-        writeString(serverAddress, 1300); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
+        writeString(serverAddress, 1500); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         writeShort(serverPort);
         writeVarInt(nextConnectionState.ordinal());
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
@@ -52,7 +52,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     public void read() {
         this.protocolVersion = readVarInt();
         this.clientVersion = ClientVersion.getById(protocolVersion);
-        this.serverAddress = readString(350);
+        this.serverAddress = readString(375); // TCPShield increases this past default value of 255.
         this.serverPort = readUnsignedShort();
         int nextStateIndex = readVarInt();
         this.nextConnectionState = ConnectionState.getById(nextStateIndex);
@@ -61,7 +61,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     @Override
     public void write() {
         writeVarInt(protocolVersion);
-        writeString(serverAddress, 350);
+        writeString(serverAddress, 375); // TCPShield increases this past default value of 255.
         writeShort(serverPort);
         writeVarInt(nextConnectionState.ordinal());
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
@@ -52,7 +52,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     public void read() {
         this.protocolVersion = readVarInt();
         this.clientVersion = ClientVersion.getById(protocolVersion);
-        this.serverAddress = readString(375); // TCPShield increases this past default value of 255.
+        this.serverAddress = readString(450); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         this.serverPort = readUnsignedShort();
         int nextStateIndex = readVarInt();
         this.nextConnectionState = ConnectionState.getById(nextStateIndex);
@@ -61,7 +61,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     @Override
     public void write() {
         writeVarInt(protocolVersion);
-        writeString(serverAddress, 375); // TCPShield increases this past default value of 255.
+        writeString(serverAddress, 450); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         writeShort(serverPort);
         writeVarInt(nextConnectionState.ordinal());
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/handshaking/client/WrapperHandshakingClientHandshake.java
@@ -52,7 +52,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     public void read() {
         this.protocolVersion = readVarInt();
         this.clientVersion = ClientVersion.getById(protocolVersion);
-        this.serverAddress = readString(450); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
+        this.serverAddress = readString(1300); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         this.serverPort = readUnsignedShort();
         int nextStateIndex = readVarInt();
         this.nextConnectionState = ConnectionState.getById(nextStateIndex);
@@ -61,7 +61,7 @@ public class WrapperHandshakingClientHandshake extends PacketWrapper<WrapperHand
     @Override
     public void write() {
         writeVarInt(protocolVersion);
-        writeString(serverAddress, 450); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
+        writeString(serverAddress, 1300); // Velocity's legacy player-info-forwarding-mode increases this past default value of 255.
         writeShort(serverPort);
         writeVarInt(nextConnectionState.ordinal());
     }


### PR DESCRIPTION
After this commit I can no longer connect to my server:
https://github.com/retrooper/packetevents/commit/5f49f63e8fad548ebeb5ef7a58a2bacb1d7644c5#diff-6e61ed83ab8d18aa7c13046c2cb4db8354217fb1ef7b1745b5f4f8227cbef7e9R55

I'm behind TCPShield and Velocity so one of those might be the cause of big server addresses... but I'm not entirely sure. 

Fixes https://github.com/retrooper/packetevents/issues/440