### PR TITLE
1.19.1 Update (PE 1.8)

### DIFF
--- a/src/main/java/io/github/retrooper/packetevents/packetwrappers/login/in/start/WrappedPacketLoginInStart.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetwrappers/login/in/start/WrappedPacketLoginInStart.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
 import java.util.UUID;
 
+// TODO: This wrapper needs Signature data @retrooper
 public class WrappedPacketLoginInStart extends WrappedPacket {
     public WrappedPacketLoginInStart(NMSPacket packet) {
         super(packet);
@@ -69,6 +70,24 @@ public class WrappedPacketLoginInStart extends WrappedPacket {
         }
         else {
             throw new IllegalAccessException("Please use the setGameProfile method in the WrappedPacketLoginInStart wrapper to change the username!");
+        }
+    }
+
+    public @Nullable UUID getPlayerUUID() {
+        if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+            return readObject(0, UUID.class);
+        }
+        else {
+            return GameProfileUtil.getWrappedGameProfile(readObject(0, NMSUtils.gameProfileClass)).getId();
+        }
+    }
+
+    public void setPlayerUUID(UUID playerUUID) throws IllegalAccessException {
+        if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+            writeObject(0, playerUUID);
+        }
+        else {
+            throw new IllegalAccessException("Please use the setGameProfile method in the WrappedPacketLoginInStart wrapper to change the uuid!");
         }
     }
 

--- a/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/playerinfo/WrappedPacketOutPlayerInfo.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/playerinfo/WrappedPacketOutPlayerInfo.java
@@ -114,6 +114,7 @@ public class WrappedPacketOutPlayerInfo extends WrappedPacket implements Sendabl
         }
     }
 
+    //TODO Technically we would need to support profile signiture data for complete 1.19.1 support.
     public PlayerInfo[] getPlayerInfo() {
         if (packet != null) {
             PlayerInfo[] playerInfoArray = new PlayerInfo[1];

--- a/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/systemchat/WrappedPacketOutSystemChat.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/systemchat/WrappedPacketOutSystemChat.java
@@ -5,6 +5,7 @@ import io.github.retrooper.packetevents.packetwrappers.NMSPacket;
 import io.github.retrooper.packetevents.packetwrappers.WrappedPacket;
 import io.github.retrooper.packetevents.packetwrappers.api.SendableWrapper;
 import io.github.retrooper.packetevents.packetwrappers.play.out.chat.WrappedPacketOutChat;
+import io.github.retrooper.packetevents.utils.server.ServerVersion;
 
 import java.lang.reflect.Constructor;
 
@@ -12,6 +13,7 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
     private static Constructor<?> packetConstructor;
     private String message;
     private WrappedPacketOutChat.ChatPosition position;
+
     public WrappedPacketOutSystemChat(final NMSPacket packet) {
         super(packet);
     }
@@ -49,7 +51,7 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
 
     public WrappedPacketOutChat.ChatPosition getPosition() {
         if (packet != null) {
-            return WrappedPacketOutChat.ChatPosition.values()[readInt(0)];
+            return WrappedPacketOutChat.ChatPosition.getById(version, readInt(0));
         }
         else {
             return position;

--- a/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/systemchat/WrappedPacketOutSystemChat.java
+++ b/src/main/java/io/github/retrooper/packetevents/packetwrappers/play/out/systemchat/WrappedPacketOutSystemChat.java
@@ -26,7 +26,12 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
     @Override
     protected void load() {
         try {
-            packetConstructor = PacketTypeClasses.Play.Server.SYSTEM_CHAT.getConstructor(String.class, int.class);
+            if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+                packetConstructor = PacketTypeClasses.Play.Server.SYSTEM_CHAT.getConstructor(String.class, boolean.class);
+            }
+            else {
+                packetConstructor = PacketTypeClasses.Play.Server.SYSTEM_CHAT.getConstructor(String.class, int.class);
+            }
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }
@@ -51,6 +56,9 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
 
     public WrappedPacketOutChat.ChatPosition getPosition() {
         if (packet != null) {
+            if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+                return readBoolean(1) ? WrappedPacketOutChat.ChatPosition.GAME_INFO : WrappedPacketOutChat.ChatPosition.SYSTEM;
+            }
             return WrappedPacketOutChat.ChatPosition.getById(version, readInt(0));
         }
         else {
@@ -60,6 +68,10 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
 
     public void setPosition(WrappedPacketOutChat.ChatPosition position) {
         if (packet != null) {
+            if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+                writeBoolean(1, position == WrappedPacketOutChat.ChatPosition.GAME_INFO);
+                return;
+            }
             writeInt(0, position.ordinal());
         }
         else {
@@ -69,6 +81,12 @@ public class WrappedPacketOutSystemChat extends WrappedPacket implements Sendabl
 
     @Override
     public Object asNMSPacket() throws Exception {
-        return packetConstructor.newInstance(getMessageJSON(), getPosition().ordinal());
+        if (version.isNewerThanOrEquals(ServerVersion.v_1_19_1)) {
+            return packetConstructor.newInstance(getMessageJSON(), getPosition() == WrappedPacketOutChat.ChatPosition.GAME_INFO);
+
+        }
+        else {
+            return packetConstructor.newInstance(getMessageJSON(), getPosition().ordinal());
+        }
     }
 }

--- a/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
@@ -94,11 +94,11 @@ public enum ClientVersion {
 
     v_1_18_2(758),
 
-    v_1_19(759),
+    v_1_19(759), v_1_19_1(760),
     //TODO Update(checkpoint for things to look out for when updating)
 
     LOWER_THAN_SUPPORTED_VERSIONS(v_1_7_10.protocolVersion - 1),
-    HIGHER_THAN_SUPPORTED_VERSIONS(v_1_19.protocolVersion + 1),
+    HIGHER_THAN_SUPPORTED_VERSIONS(v_1_19_1.protocolVersion + 1),
     /**
      * Pre releases just aren't supported, we would end up with so many enum constants.
      * This constant assures you they are on a pre-release.

--- a/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/player/ClientVersion.java
@@ -118,7 +118,7 @@ public enum ClientVersion {
     private static final Map<Integer, ClientVersion> CLIENT_VERSION_CACHE = new IdentityHashMap<>();
     private static final int[] CLIENT_VERSIONS = new int[]{5, 47, 107, 108, 109, 110, 210, 315, 316, 335, 338,
             340, 393, 401, 404, 477, 480, 485, 490, 498, 573,
-            575, 578, 735, 736, 751, 753, 754, 755, 756, 757, 758, 759};
+            575, 578, 735, 736, 751, 753, 754, 755, 756, 757, 758, 759, 760};
     private int protocolVersion;
 
     ClientVersion(int protocolVersion) {

--- a/src/main/java/io/github/retrooper/packetevents/utils/server/ServerVersion.java
+++ b/src/main/java/io/github/retrooper/packetevents/utils/server/ServerVersion.java
@@ -45,7 +45,7 @@ public enum ServerVersion {
     v_1_17(755), v_1_17_1(756),
     v_1_18(757), v_1_18_1(757), v_1_18_2(758),
     //TODO Update (checkpoint)
-    v_1_19(759),
+    v_1_19(759), v_1_19_1(760),
     ERROR(-1);
 
     private static final String NMS_VERSION_SUFFIX = Bukkit.getServer().getClass().getPackage().getName()


### PR DESCRIPTION
## 1.19.1 Update

### Additions
#### We only add the wrappers when we want to. But since we have announced that we will no longer add new features, they will not be added if they are not needed.
- [ ] Create [ChatCompletionAction](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatCompletionAction.java) enum
- [ ] Create [LastSeenMessages](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/LastSeenMessages.java) class
- [ ] Create [ClientAckChat](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatAck.java) wrapper
- [ ] Create [CustomChatCompletions](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerCustomChatCompletions.java) wrapper
- [ ] Create [DeleteChat](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerDeleteChat.java) wrapper
- [ ] Create [PlayerChatHeader](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerPlayerChatHeader.java) wrapper
- [ ] Add new [Serverbound](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/serverbound/ServerboundPacketType_1_19_1.java) and [Clientbound](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19_1.java) packets

### Changes
- [x] Update the current [`ChatPosition`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatType.java) enums for modern and legacy support
- [ ] Change the current [`ChatPosition`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/ChatType.java) handling as 1.19.1 removed some types and added new ones
- [x] The [`ClientLoginStart`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/client/WrapperLoginClientLoginStart.java) wrapper now also has a `playerUUID` field which is nullable (due to cross versions support)
- [ ] The [`ClientChatCommand`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatCommand.java) and [`ClientChatMessage`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java) wrappers now also have `LastSeenMessages` fields which are nullable (due to cross versions support)
- [ ] The [`ServerChatMessage`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChatMessage.java) wrapper changes the plain ChatContent (first field) from a Component to a plain String with a limit of 256 characters
- [ ] The [`ServerServerData`](https://github.com/retrooper/packetevents/blob/27e9d44b9a19cc9126cc73c6d5468f9856e6a7d7/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerServerData.java) wrapper now also has a `enforceSecureChat` (boolean) field which is always false on legacy versions
- [ ] The [`ServerSystemChatMessage`](https://github.com/retrooper/packetevents/blob/d482d5391b74bb0f8ea22962894d8ad11c951b0a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSystemChatMessage.java) wrapper needs an overhaul to support the new `ChatPosition` enum
  and because 1.19.1 no longer supports overlays we need to take care of that