### PR TITLE
Added the ability to set a custom resourceProvider

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -7,8 +7,6 @@ import com.github.retrooper.packetevents.protocol.world.states.enums.*;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateValue;
-import com.github.retrooper.packetevents.util.MappingHelper;
-import com.google.gson.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
@@ -148,7 +146,7 @@ public class WrappedBlockState {
         Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
         Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new HashMap<>();
         try {
-            InputStream mappings = WrappedBlockState.class.getClassLoader().getResourceAsStream("assets/mappings/block/legacy_block_mappings.txt");
+            InputStream mappings = PacketEvents.getAPI().getSettings().getResourceProvider().apply("assets/mappings/block/legacy_block_mappings.txt");
             BufferedReader reader = new BufferedReader(new InputStreamReader(mappings));
 
             while ((line = reader.readLine()) != null) {
@@ -204,7 +202,7 @@ public class WrappedBlockState {
             return;
         }
 
-        InputStream mappings = WrappedBlockState.class.getClassLoader().getResourceAsStream("assets/mappings/block/modern_block_mappings.txt");
+        InputStream mappings = PacketEvents.getAPI().getSettings().getResourceProvider().apply("assets/mappings/block/modern_block_mappings.txt");
         BufferedReader reader = new BufferedReader(new InputStreamReader(mappings));
 
         Map<Integer, WrappedBlockState> stateByIdMap = new HashMap<>();

--- a/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
@@ -18,9 +18,10 @@
 
 package com.github.retrooper.packetevents.settings;
 
-
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.util.TimeStampMode;
+
+import java.io.InputStream;
+import java.util.function.Function;
 
 /**
  * Packet Events' settings.
@@ -35,6 +36,9 @@ public class PacketEventsSettings {
     private boolean checkForUpdates = true;
     private boolean bStatsEnabled = true;
     private boolean debugEnabled = false;
+    private Function<String, InputStream> resourceProvider = path -> PacketEventsSettings.class
+            .getClassLoader()
+            .getResourceAsStream(path);
 
     /**
      * Time stamp mode. How precise should the timestamps in the events be.
@@ -98,6 +102,18 @@ public class PacketEventsSettings {
     }
 
     /**
+     * Some projects may want to implement a CDN with resources like asset mappings
+     * By default, all resources are retrieved from the ClassLoader
+     *
+     * @param resourceProvider Function
+     * @return Settings instance.
+     */
+    public PacketEventsSettings customResourceProvider(Function<String, InputStream> resourceProvider) {
+        this.resourceProvider = resourceProvider;
+        return this;
+    }
+
+    /**
      * Should the packet listeners be read only?
      * @return Getter for {@link #readOnlyListeners}
      */
@@ -131,5 +147,14 @@ public class PacketEventsSettings {
      */
     public boolean isDebugEnabled() {
         return debugEnabled;
+    }
+
+    /**
+     * As described above, this method retrieves the function that acquires the InputStream
+     * of a desired resource by its path.
+     * @return Getter for {@link #resourceProvider}
+     */
+    public Function<String, InputStream> getResourceProvider() {
+        return resourceProvider;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/MappingHelper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/MappingHelper.java
@@ -18,7 +18,7 @@
 
 package com.github.retrooper.packetevents.util;
 
-import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
+import com.github.retrooper.packetevents.PacketEvents;
 import com.google.gson.JsonObject;
 
 import java.io.BufferedReader;
@@ -26,13 +26,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 public class MappingHelper {
     public static JsonObject getJSONObject(String id) {
         StringBuilder sb = new StringBuilder();
-        try (InputStream inputStream = ItemTypes.class.getClassLoader().getResourceAsStream("assets/mappings/" + id + ".json");
+        try (InputStream inputStream = PacketEvents.getAPI().getSettings().getResourceProvider().apply("assets/mappings/" + id + ".json");
              InputStreamReader streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
              BufferedReader reader = new BufferedReader(streamReader)) {
 


### PR DESCRIPTION
Currently, the retrieval of external resources (json files, such as block mappings) is hard-coded to be through `ClassLoader#getResourceAsStream`.
This PR proposes to add the ability for the end user to change the retrieval algorithm by passing their own `Function<String, InputStream>` to PacketEventsSettings. The function is then called whenever a resource needs to be retrieved.