### PR TITLE
Forcibly close unhandled connections

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerConnectionInitializer.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerConnectionInitializer.java
@@ -87,7 +87,7 @@ public class ServerConnectionInitializer {
              * Taken the above into account, here we just drop all unhandled connections.
              */
             if (channel.pipeline().get("splitter") == null) {
-                channel.unsafe().closeForcibly();
+                channel.close();
                 return;
             }
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerConnectionInitializer.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerConnectionInitializer.java
@@ -79,6 +79,18 @@ public class ServerConnectionInitializer {
         User user = new User(channel, connectionState, null, new UserProfile(null, null));
 
         synchronized (channel) {
+            /*
+             * This is a rather rare one, BUT!
+             * If the plugin takes a while to initialize and handshakes/pings pile up,
+             * some may not be handled completely, thus, not having a 'splitter' ChannelHandler.
+             * We can, of course, wait for them to be handled, but this complexes the algorithm.
+             * Taken the above into account, here we just drop all unhandled connections.
+             */
+            if (channel.pipeline().get("splitter") == null) {
+                channel.unsafe().closeForcibly();
+                return;
+            }
+
             UserConnectEvent connectEvent = new UserConnectEvent(user);
             PacketEvents.getAPI().getEventManager().callEvent(connectEvent);
             if (connectEvent.isCancelled()) {


### PR DESCRIPTION
This is a rather rare one, BUT!
If a plugin using the API takes a while to initialize and handshakes pile up, some connections may not be handled completely, thus, not having the 'splitter' ChannelHandler at the moment PE is initialized.
This PR proposes to drop all such connections.

An example of such behavior would be:
1. A player sends a handshake to the server before PE is initialized
2. Some desync causes Bukkit not to add `splitter` to the channel pipeline before plugins are loaded
3. Once PE loads, a NoSuchElementException is caught in `io.github.retrooper.packetevents.injector.connection.ServerConnectionInitializer`.
The current pipeline handlers in the channel are `[DefaultChannelPipeline$TailContext#0]`