### PR TITLE
Fix ViaVersion version check

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
@@ -188,7 +188,7 @@ public class SpigotPacketEventsBuilder {
                     String[] ver = viaPlugin.getDescription().getVersion().split("\\.", 3);
                     int major = Integer.parseInt(ver[0]);
                     int minor = Integer.parseInt(ver[1]);
-                    if (major < 4 || minor < 5) {
+                    if (major < 4 || major == 4 && minor < 5) {
                         PacketEvents.getAPI().getLogManager().severe("You are attempting to combine 2.0 PacketEvents with a " +
                                 "ViaVersion older than 4.5.0, please update your ViaVersion!");
                         Plugin ourPlugin = getPlugin();


### PR DESCRIPTION
The previous check was passing every minor version < 5 as versions older than 4.5.0. It means in the future versions like 5.0 would've been detected as older than 4.5.0