### PR TITLE
Add missing EntityPose

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
@@ -31,6 +31,7 @@ public enum EntityPose {
     DYING,
     CROAKING,
     USING_TONGUE,
+    SITTING,
     ROARING,
     SNIFFING,
     EMERGING,


### PR DESCRIPTION
Error:

```
java.lang.ArrayIndexOutOfBoundsException: Index 14 out of bounds for length 14
	at ac.grim.grimac.shaded.com.github.retrooper.packetevents.protocol.entity.pose.EntityPose.getById(EntityPose.java:51) ~[Grim.jar:?]
```

1.19.3 NMS:

```
package net.minecraft.world.entity;

public enum Pose {
    STANDING,
    FALL_FLYING,
    SLEEPING,
    SWIMMING,
    SPIN_ATTACK,
    CROUCHING,
    LONG_JUMPING,
    DYING,
    CROAKING,
    USING_TONGUE,
    SITTING,
    ROARING,
    SNIFFING,
    EMERGING,
    DIGGING;
}
```