### PR TITLE
Add SITTING pose to EntityPose

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
@@ -31,6 +31,7 @@ public enum EntityPose {
     DYING,
     CROAKING,
     USING_TONGUE,
+    SITTING,
     ROARING,
     SNIFFING,
     EMERGING,
@@ -40,6 +41,9 @@ public enum EntityPose {
        if (this == DYING && version.isOlderThan(ClientVersion.V_1_17)) {
            return 6;
        }
+       if (this.ordinal() >= 11 && version.isOlderThan(ClientVersion.V_1_19_3)) {
+           return this.ordinal() - 1;
+       }
        return ordinal();
    }
 
@@ -47,6 +51,10 @@ public enum EntityPose {
        // The LONG_JUMPING pose was added in 1.17, shifting things by 1
        if (id == 6 && version.isOlderThan(ClientVersion.V_1_17)) {
            return DYING;
+       }
+       // The SITTING pose was added in 1.19.3, shifting Warden's poses by 1
+       if (id >= 10 && version.isOlderThan(ClientVersion.V_1_19_3)) {
+           id++;
        }
        return values()[id];
    }


### PR DESCRIPTION
This fixes the issue that caused Warden's poses being shifted by 1 and ArrayIndexOutOfBoundsException on the server when server sends a packet with DIGGING pose on 1.19.3 server.

The issue is fixed server-side, but if you're using any of Via* plugins, you also need to update them to at least 4.5.2 (this is a not yet released -SNAPSHOT version at the moment) to fix a client-side disconnection for <1.19.3 clients

Probably closes #509 