### PR TITLE
NPE + ConcurrentModification Exception Fix

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -22,13 +22,15 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public class EventManager {
-    private final Map<Byte, HashSet<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
+    private final Map<Byte, Set<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
 
     /**
      * Call the PacketEvent.
@@ -45,7 +47,7 @@ public class EventManager {
 
     public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
         for (byte priority = PacketListenerPriority.LOWEST.getId(); priority <= PacketListenerPriority.MONITOR.getId(); priority++) {
-            HashSet<PacketListenerCommon> listeners = listenersMap.get(priority);
+            Set<PacketListenerCommon> listeners = listenersMap.get(priority);
             if (listeners != null) {
                 for (PacketListenerCommon listener : listeners) {
                     try {
@@ -80,9 +82,9 @@ public class EventManager {
      */
     public PacketListenerCommon registerListener(PacketListenerCommon listener) {
         byte priority = listener.getPriority().getId();
-        HashSet<PacketListenerCommon> listenerSet = listenersMap.get(priority);
+        Set<PacketListenerCommon> listenerSet = listenersMap.get(priority);
         if (listenerSet == null) {
-            listenerSet = new HashSet<>();
+            listenerSet = Collections.synchronizedSet(new HashSet<>());
         }
         listenerSet.add(listener);
         listenersMap.put(priority, listenerSet);
@@ -102,7 +104,7 @@ public class EventManager {
     }
 
     public void unregisterListener(PacketListenerCommon listener) {
-        HashSet<PacketListenerCommon> listenerSet = listenersMap.get(listener.getPriority().getId());
+        Set<PacketListenerCommon> listenerSet = listenersMap.get(listener.getPriority().getId());
         if (listenerSet == null) return;
         listenerSet.remove(listener);
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -84,7 +84,7 @@ public class EventManager {
         byte priority = listener.getPriority().getId();
         Set<PacketListenerCommon> listenerSet = listenersMap.get(priority);
         if (listenerSet == null) {
-            listenerSet = Collections.synchronizedSet(new HashSet<>());
+            listenerSet = ConcurrentHashMap.newKeySet();
         }
         listenerSet.add(listener);
         listenersMap.put(priority, listenerSet);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/data/provider/EntityDataProvider.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/data/provider/EntityDataProvider.java
@@ -202,7 +202,7 @@ public class EntityDataProvider implements DataProvider {
         List<EntityData> metadata = new ArrayList<>(8);
         metadata.add(new EntityData(0, EntityDataTypes.BYTE, mask));
         metadata.add(new EntityData(1, EntityDataTypes.INT, airTicks));
-        metadata.add(new EntityData(2, EntityDataTypes.OPTIONAL_COMPONENT, customName == null ? null : AdventureSerializer.toJson(customName)));
+        metadata.add(new EntityData(2, EntityDataTypes.OPTIONAL_COMPONENT, Optional.ofNullable(customName == null ? null : AdventureSerializer.toJson(customName))));
         metadata.add(new EntityData(3, EntityDataTypes.BOOLEAN, customNameVisible));
         metadata.add(new EntityData(4, EntityDataTypes.BOOLEAN, silent));
         metadata.add(new EntityData(5, EntityDataTypes.BOOLEAN, !hasGravity));

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -681,6 +681,9 @@ public class PacketWrapper<T extends PacketWrapper> {
     }
 
     public void writeEntityMetadata(List<EntityData> list) {
+        if (list == null) {
+            list = new ArrayList<>();
+        }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_9)) {
             boolean v1_10 = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_10);
             for (EntityData entityData : list) {


### PR DESCRIPTION
Attempts to fix this error
```[07:35:00] [Netty Epoll Server IO #2/WARN]: io.netty.handler.codec.EncoderException: java.lang.NullPointerException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:106)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.github.retrooper.packetevents.injector.handlers.PacketEventsEncoder.write(PacketEventsEncoder.java:129)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:106)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.github.repooper.packetevents.Vulcan_kw.write(Vulcan_kw.java:60)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:730)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:816)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:723)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:106)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:801)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:814)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:794)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1066)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:305)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:227)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:233)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at net.minecraft.server.v1_12_R1.NetworkManager$4.run(NetworkManager.java:215)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.lambda$proxyRunnable$2(NettyEventLoopProxy.java:48)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:309)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at java.lang.Thread.run(Thread.java:750)
[07:35:00] [Netty Epoll Server IO #2/WARN]: Caused by: java.lang.NullPointerException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at com.github.retrooper.packetevents.wrapper.PacketWrapper.writeEntityMetadata(PacketWrapper.java:686)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnPlayer.write(WrapperPlayServerSpawnPlayer.java:116)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.github.retrooper.packetevents.injector.handlers.PacketEventsEncoder.handleClientBoundPacket(PacketEventsEncoder.java:95)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.github.retrooper.packetevents.injector.handlers.PacketEventsEncoder.encode(PacketEventsEncoder.java:65)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.github.retrooper.packetevents.injector.handlers.PacketEventsEncoder.encode(PacketEventsEncoder.java:44)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:88)
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	... 37 more
[07:35:00] [Netty Epoll Server IO #2/WARN]: java.nio.channels.ClosedChannelException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(...)(Unknown Source)
[07:35:00] [Netty Epoll Server IO #2/WARN]: java.nio.channels.ClosedChannelException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(...)(Unknown Source)
[07:35:00] [Netty Epoll Server IO #2/WARN]: java.nio.channels.ClosedChannelException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(...)(Unknown Source)
[07:35:00] [Netty Epoll Server IO #2/WARN]: java.nio.channels.ClosedChannelException
[07:35:00] [Netty Epoll Server IO #2/WARN]: 	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(...)(Unknown Source)```
