### PR TITLE
Fixed Adventure API & Build Issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ subprojects {
 
     tasks {
         shadowJar {
+            relocate 'net.kyori.adventure.text.serializer.gson.legacyimpl', 'io.github.retrooper.packetevents.adventure.serializer.gson.legacyimpl'
+            relocate 'net.kyori.adventure.util.Codec', 'io.github.retrooper.packetevents.adventure.util.Codec'
             archiveFileName.set("packetevents-${project.name}-${project.version}.jar")
         }
 

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -1,7 +1,7 @@
 repositories {
     mavenCentral()
     maven {
-        url 'https://repo.velocitypowered.com/snapshots/'
+        url 'https://papermc.io/repo/repository/maven-public/'
     }
 }
 


### PR DESCRIPTION
Two changes are made in this PR:
* Relocation of the adventure API so PacketEvents does not cause issues with different versions of adventure API that might exist on the server.
* Fixed Velocity Repository URL since https://repo.velocitypowered.com/snapshots/ was merged with the paper repo.