### PR TITLE
Log getDefaultState in Config Level

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -130,7 +130,7 @@ public class WrappedBlockState {
         byte mappingsIndex = getMappingsIndex(version);
         WrappedBlockState state = DEFAULT_STATES.get(mappingsIndex).get(type);
         if (state == null) {
-            PacketEvents.getAPI().getLogger().warning("Default state for " + type.getName() + " is null. Returning AIR");
+            PacketEvents.getAPI().getLogger().config("Default state for " + type.getName() + " is null. Returning AIR");
             return AIR;
         }
         return state.clone();


### PR DESCRIPTION
Prevent spamming the console with:
[ac.grim.grimac.shaded.com.github.retrooper.packetevents.PacketEventsAPI] Default state for lantern is null. Returning AIR