### PR TITLE
Make entity mappings unload after types load

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
@@ -54,12 +54,6 @@ public class EntityTypes {
             ClientVersion.V_1_12,
             ClientVersion.V_1_13);
 
-
-    static {
-        TYPES_BUILDER.unloadFileMappings();
-        LEGACY_TYPES_BUILDER.unloadFileMappings();
-    }
-
     public static EntityType define(String key, @Nullable EntityType parent) {
         TypesBuilderData data = TYPES_BUILDER.define(key);
         TypesBuilderData legacyData = LEGACY_TYPES_BUILDER.define(key);
@@ -308,4 +302,10 @@ public class EntityTypes {
     public static final EntityType TEXT_DISPLAY = define("text_display", DISPLAY);
     public static final EntityType INTERACTION = define("interaction", DISPLAY);
     public static final EntityType SNIFFER = define("sniffer", ABSTRACT_ANIMAL);
+
+    // This HAS to be at the end of the file so the types load properly, please do not move it
+    static {
+        TYPES_BUILDER.unloadFileMappings();
+        LEGACY_TYPES_BUILDER.unloadFileMappings();
+    }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
@@ -303,7 +303,7 @@ public class EntityTypes {
     public static final EntityType INTERACTION = define("interaction", DISPLAY);
     public static final EntityType SNIFFER = define("sniffer", ABSTRACT_ANIMAL);
 
-    // This HAS to be at the end of the file so the types load properly, please do not move it
+    // This HAS to be at the end of the file so the types unload properly, please do not move it
     static {
         TYPES_BUILDER.unloadFileMappings();
         LEGACY_TYPES_BUILDER.unloadFileMappings();


### PR DESCRIPTION
Currently the static block that unloads the entity id mappings in the EntityTypes class is ran before any of the types are defined, this moves it down to the end of the file and adds a comment telling others not to move it.