### PR TITLE
Add 1.20.1 server version

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
@@ -47,7 +47,8 @@ public enum ServerVersion {
     V_1_18(757), V_1_18_1(757), V_1_18_2(758),
     //1.19.1 and 1.19.2 have the same protocol version
     V_1_19(759), V_1_19_1(760), V_1_19_2(760), V_1_19_3(761), V_1_19_4(762),
-    V_1_20(763),
+    //1.20 and 1.20.1 have the same protocol version
+    V_1_20(763), V_1_20_1(763),
     //TODO UPDATE Add server version constant
     ERROR(-1, true);
 


### PR DESCRIPTION
The client version for 1.20.1 doesn't need to be created, as they to my understanding only reflect protocol versions.