### PR TITLE
Updater updates

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -79,7 +79,7 @@ public class WrappedBlockState {
                     this.data.put(value, value.getParser().apply(split[1].toUpperCase(Locale.ROOT)));
                 } catch (Exception e) {
                     e.printStackTrace();
-                    System.out.println("Failed to parse block state: " + s);
+                    PacketEvents.getAPI().getLogManager().warn("Failed to parse block state: " + s);
                 }
             }
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
@@ -61,17 +61,17 @@ public class UpdateChecker {
         try {
             newVersion = new PEVersion(checkLatestReleasedVersion());
         } catch (Exception ex) {
-            PacketEvents.getAPI().getLogManager().warn("Failed to parse packetevents version! " + ex.getMessage());
-            newVersion = null;
+            PacketEvents.getAPI().getLogManager().warn("Failed to check for updates. " + (ex.getCause() != null ? ex.getCause().getClass().getName()+ ": " + ex.getCause().getMessage() : ex.getMessage()));
+            return UpdateCheckerStatus.FAILED;
         }
-        if (newVersion != null && localVersion.isOlderThan(newVersion)) {
+        if (localVersion.isOlderThan(newVersion)) {
             PacketEvents.getAPI().getLogManager().warn("There is an update available for packetevents! Your build: ("
                     + ColorUtil.toString(NamedTextColor.YELLOW) + localVersion
                     + ColorUtil.toString(NamedTextColor.WHITE) + ") | Latest released build: ("
                     + ColorUtil.toString(NamedTextColor.GREEN) + newVersion
                     + ColorUtil.toString(NamedTextColor.RED) + ")");
             return UpdateCheckerStatus.OUTDATED;
-        } else if (newVersion != null && localVersion.isNewerThan(newVersion)) {
+        } else if (localVersion.isNewerThan(newVersion)) {
             PacketEvents.getAPI().getLogManager().info("You are on a dev or pre released build of packetevents. Your build: ("
                     + ColorUtil.toString(NamedTextColor.AQUA) + localVersion
                     + ColorUtil.toString(NamedTextColor.WHITE) + ") | Latest released build: ("
@@ -83,20 +83,20 @@ public class UpdateChecker {
                     + ColorUtil.toString(NamedTextColor.GREEN) + newVersion + ColorUtil.toString(NamedTextColor.WHITE) + ")");
             return UpdateCheckerStatus.UP_TO_DATE;
         } else {
-            PacketEvents.getAPI().getLogManager().warn("Something went wrong while checking for an update. Your build: (" + localVersion + ")");
+            PacketEvents.getAPI().getLogManager().warn("Failed to check for updates. Your build: (" + localVersion + ")");
             return UpdateCheckerStatus.FAILED;
         }
     }
 
     public void handleUpdateCheck() {
         Thread thread = new Thread(() -> {
-            PacketEvents.getAPI().getLogManager().info("Checking for an update, please wait...");
+            PacketEvents.getAPI().getLogManager().info("Checking for updates, please wait...");
             UpdateChecker.UpdateCheckerStatus status = checkForUpdate();
             int waitTimeInSeconds = 5;
             int maxRetryCount = 3;
             int retries = 0;
             while (retries < maxRetryCount && status == UpdateChecker.UpdateCheckerStatus.FAILED) {
-                PacketEvents.getAPI().getLogManager().warn("Checking for an update again in " + waitTimeInSeconds + " seconds...");
+                PacketEvents.getAPI().getLogManager().warn("Checking for updates again in " + waitTimeInSeconds + " seconds...");
                 try {
                     Thread.sleep(waitTimeInSeconds * 1000L);
                 } catch (InterruptedException e) {
@@ -108,7 +108,7 @@ public class UpdateChecker {
                 status = checkForUpdate();
 
                 if (retries == (maxRetryCount - 1)) {
-                    PacketEvents.getAPI().getLogManager().warn("packetevents failed to check for an update.");
+                    PacketEvents.getAPI().getLogManager().severe("Failed to check for updates after " + maxRetryCount + " times.");
                     break;
                 }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
@@ -61,7 +61,7 @@ public class UpdateChecker {
         try {
             newVersion = new PEVersion(checkLatestReleasedVersion());
         } catch (Exception ex) {
-            ex.printStackTrace();
+            PacketEvents.getAPI().getLogManager().warn("Failed to parse packetevents version! " + ex.getMessage());
             newVersion = null;
         }
         if (newVersion != null && localVersion.isOlderThan(newVersion)) {
@@ -79,7 +79,7 @@ public class UpdateChecker {
                     + ColorUtil.toString(NamedTextColor.WHITE) + ")");
             return UpdateCheckerStatus.PRE_RELEASE;
         } else if (localVersion.equals(newVersion)) {
-            PacketEvents.getAPI().getLogManager().info("You are on the latest released version of packetevents. ("
+            PacketEvents.getAPI().getLogManager().info("You are on the latest released version of packetevents. Your build: ("
                     + ColorUtil.toString(NamedTextColor.GREEN) + newVersion + ColorUtil.toString(NamedTextColor.WHITE) + ")");
             return UpdateCheckerStatus.UP_TO_DATE;
         } else {
@@ -93,13 +93,10 @@ public class UpdateChecker {
             PacketEvents.getAPI().getLogManager().info("Checking for an update, please wait...");
             UpdateChecker.UpdateCheckerStatus status = checkForUpdate();
             int waitTimeInSeconds = 5;
-            int maxRetryCount = 5;
+            int maxRetryCount = 3;
             int retries = 0;
-            while (retries < maxRetryCount) {
-                if (status != UpdateChecker.UpdateCheckerStatus.FAILED) {
-                    break;
-                }
-                PacketEvents.getAPI().getLogManager().warn("[Checking for an update again in " + waitTimeInSeconds + " seconds...");
+            while (retries < maxRetryCount && status == UpdateChecker.UpdateCheckerStatus.FAILED) {
+                PacketEvents.getAPI().getLogManager().warn("Checking for an update again in " + waitTimeInSeconds + " seconds...");
                 try {
                     Thread.sleep(waitTimeInSeconds * 1000L);
                 } catch (InterruptedException e) {
@@ -111,7 +108,7 @@ public class UpdateChecker {
                 status = checkForUpdate();
 
                 if (retries == (maxRetryCount - 1)) {
-                    PacketEvents.getAPI().getLogManager().warn("packetevents failed to check for an update. No longer retrying.");
+                    PacketEvents.getAPI().getLogManager().warn("packetevents failed to check for an update.");
                     break;
                 }
 

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/bungee/factory/BungeePacketEventsBuilder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/bungee/factory/BungeePacketEventsBuilder.java
@@ -129,7 +129,7 @@ public class BungeePacketEventsBuilder {
                     }
 
                     if (user == null) {
-                        System.out.println("User null???");
+                        PacketEvents.getAPI().getLogManager().warn("User is null?");
                         user = new User(channel, ConnectionState.PLAY, null, new UserProfile(p.getUniqueId(), p.getName()));
 
                         synchronized (channel) {

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
@@ -115,7 +115,7 @@ public class SpigotChannelInjector implements ChannelInjector {
                     try {
                         ServerConnectionInitializer.initChannel(channel, ConnectionState.PLAY);
                     } catch (Exception e) {
-                        System.out.println("Spigot injector failed to inject into an existing channel.");
+                        PacketEvents.getAPI().getLogManager().severe("Spigot injector failed to inject into an existing channel.");
                         e.printStackTrace();
                     }
                 }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -858,7 +858,7 @@ public final class SpigotReflectionUtil {
                     }
                 }
             } catch (Exception ex) {
-                System.out.println("Failed to find entity by id on 1.19.3!");
+                PacketEvents.getAPI().getLogManager().warn("Failed to find entity by id on 1.19.3!");
                 throw ex;
                 //We are retrying below
             }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionUtil.java
@@ -18,6 +18,7 @@
 
 package io.github.retrooper.packetevents.util.viaversion;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
 import io.netty.channel.Channel;
@@ -79,7 +80,7 @@ public class ViaVersionUtil {
             Object protocolInfo = Reflection.getField(connection.getClass(), "protocolInfo").get(connection);
             return (int) Reflection.getField(protocolInfo.getClass(), "protocolVersion").get(protocolInfo);
         } catch (Exception e) {
-            System.out.println("Unable to grab ViaVersion client version for player!");
+            PacketEvents.getAPI().getLogManager().warn("Unable to grab ViaVersion client version for player!");
             return -1;
         }
     }


### PR DESCRIPTION
I think at the moment, the updater is designed in a way which isn't entirely useful for a user. Currently, it will try for a total of 160 seconds before giving up, producing stack traces each time, which is not great for readability.
**_Before_**
![before](https://github.com/retrooper/packetevents/assets/126017687/9441973a-8718-4459-852c-6abb41c787e0)
_**After**_
![after](https://github.com/retrooper/packetevents/assets/126017687/8d5d9e4f-1133-4080-bd0c-b09456f9ed39)

Also changed some uses of System.out.println to the log manager, so people know the message is from packetevents