### PR TITLE
Expose block id to BaseChunk

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/BaseChunk.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/BaseChunk.java
@@ -32,7 +32,11 @@ import com.github.retrooper.packetevents.protocol.world.chunk.storage.LegacyFlex
 import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
 
 public interface BaseChunk {
-    WrappedBlockState get(ClientVersion version, int x, int y, int z);
+    int getBlockId(int x, int y, int z);
+
+    default WrappedBlockState get(ClientVersion version, int x, int y, int z) {
+        return WrappedBlockState.getByGlobalId(version, getBlockId(x, y, z));
+    }
 
     default WrappedBlockState get(int x, int y, int z) {
         return get(PacketEvents.getAPI().getServerManager().getVersion().toClientVersion(), x, y, z);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_16/Chunk_v1_9.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_16/Chunk_v1_9.java
@@ -84,8 +84,8 @@ public class Chunk_v1_9 implements BaseChunk {
     }
 
     @Override
-    public WrappedBlockState get(ClientVersion version, int x, int y, int z) {
-        return WrappedBlockState.getByGlobalId(version, this.dataPalette.get(x, y, z));
+    public int getBlockId(int x, int y, int z) {
+        return this.dataPalette.get(x, y, z);
     }
 
     public void set(int x, int y, int z, int state) {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_7/Chunk_v1_7.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_7/Chunk_v1_7.java
@@ -44,9 +44,8 @@ public class Chunk_v1_7 implements BaseChunk {
     }
 
     @Override
-    public WrappedBlockState get(ClientVersion version, int x, int y, int z) {
-        int combinedID = blocks.get(x, y, z) | (extendedBlocks.get(x, y, z) << 12);
-        return WrappedBlockState.getByGlobalId(version, combinedID);
+    public int getBlockId(int x, int y, int z) {
+        return blocks.get(x, y, z) | (extendedBlocks.get(x, y, z) << 12);
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_8/Chunk_v1_8.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v1_8/Chunk_v1_8.java
@@ -52,9 +52,8 @@ public class Chunk_v1_8 implements BaseChunk {
     }
 
     @Override
-    public WrappedBlockState get(ClientVersion version, int x, int y, int z) {
-        int combinedID = this.blocks.get(x, y, z);
-        return WrappedBlockState.getByGlobalId(version, combinedID);
+    public int getBlockId(int x, int y, int z) {
+        return this.blocks.get(x, y, z);
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
@@ -61,8 +61,8 @@ public class Chunk_v1_18 implements BaseChunk {
     }
 
     @Override
-    public WrappedBlockState get(ClientVersion version, int x, int y, int z) {
-        return WrappedBlockState.getByGlobalId(version, this.chunkData.get(x, y, z));
+    public int getBlockId(int x, int y, int z) {
+        return this.chunkData.get(x, y, z);
     }
 
     @Override


### PR DESCRIPTION
Exposes getting block state id in BaseChunk.

I wasn't sure on how to name the method (the codebase uses at least `blockId`, `globalId` and `combinedId`), so since it's (chunk data) usually used alongside other block packets, I went with how it's called in them ([WrapperPlayServerBlockChange](https://github.com/retrooper/packetevents/blob/363931875fe619711ddc2646a596355a30648246/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBlockChange.java#L83) and [WrapperPlayServerMultiBlockChange](https://github.com/retrooper/packetevents/blob/363931875fe619711ddc2646a596355a30648246/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerMultiBlockChange.java#L177)), but it can be renamed upon request.