### PR TITLE
Fix merchant offers always being empty

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerMerchantOffers.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerMerchantOffers.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 public class WrapperPlayServerMerchantOffers extends PacketWrapper<WrapperPlayServerMerchantOffers> {
     private int containerId;
-    private List<MerchantOffer> merchantOffers = new ArrayList<>();
+    private List<MerchantOffer> merchantOffers;
     private int villagerLevel;
     private int villagerXp;
     private boolean showProgress;


### PR DESCRIPTION
Constructor already initializes the list with some values. The line seems to always take priority over it making offer list always empty.

Example listener to reproduce:
```java
@Override
public void onPacketSend(PacketSendEvent event) {
    if (event.getPacketType() == PacketType.Play.Server.MERCHANT_OFFERS) {
        WrapperPlayServerMerchantOffers wrapper = new WrapperPlayServerMerchantOffers(event);
    }
}
```
If you join the game with this and open any villager offers will be empty.