### PR TITLE
Relocate only the gson and legacy

### DIFF
--- a/bungeecord/build.gradle
+++ b/bungeecord/build.gradle
@@ -6,7 +6,8 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'net.kyori.adventure.text.serializer', 'io.github.retrooper.packetevents.adventure.serializer'
+    relocate 'net.kyori.adventure.text.serializer.gson', 'io.github.retrooper.packetevents.adventure.serializer.gson'
+    relocate 'net.kyori.adventure.text.serializer.legacy', 'io.github.retrooper.packetevents.adventure.serializer.legacy'
     relocate 'net.kyori.adventure.util.Codec', 'io.github.retrooper.packetevents.adventure.util.Codec'
     dependencies {
         exclude(dependency('com.google.code.gson:gson:2.8.0'))

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -8,7 +8,8 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
 shadowJar {
-    relocate 'net.kyori.adventure.text.serializer', 'io.github.retrooper.packetevents.adventure.serializer'
+    relocate 'net.kyori.adventure.text.serializer.gson', 'io.github.retrooper.packetevents.adventure.serializer.gson'
+    relocate 'net.kyori.adventure.text.serializer.legacy', 'io.github.retrooper.packetevents.adventure.serializer.legacy'
     dependencies {
         exclude(dependency('com.google.code.gson:gson:2.8.0'))
         exclude(dependency('com.google.code.gson:gson:2.8.5'))


### PR DESCRIPTION
This pull request addresses issue #621, which arises from the net.kyori.adventure.text.serializer being part of the API. However, only net.kyori.adventure.text.serializer.gson and net.kyori.adventure.text.serializer.legacy are additional packages for text serialization.

The core issue occurs when a plugin relies on PacketEvents and utilizes Kyori Adventure (for example creating a packet wrapper that uses it). It needs to include and distribute a Text Serializer (like legacy). During runtime, an error is thrown due to the non-discovery of the base interface from the API, as it's relocated.

Notably, this problem is specific to Spigot/BungeeCord environments and does not occur on Paper servers.