### PR TITLE
Fix bits overflowing when using global palette with bit storage

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
@@ -27,7 +27,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DataPalette {
-    public static final int GLOBAL_PALETTE_BITS_PER_ENTRY = 14;
+
+    // this is the amount of bits required to store the biggest state id number
+    public static final int GLOBAL_PALETTE_BITS_PER_ENTRY = 15;
 
     public @NotNull Palette palette;
     public BaseStorage storage;

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/storage/BitStorage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/storage/BitStorage.java
@@ -107,6 +107,10 @@ public class BitStorage extends BaseStorage {
 
     @Override
     public int get(int index) {
+        if (index < 0 || index > this.size - 1L) {
+            throw new IllegalStateException("Illegal index: " + index + " < 0 || " + index + " > " + this.size + " - 1");
+        }
+
         int cellIndex = cellIndex(index);
         int bitIndex = bitIndex(index, cellIndex);
         return (int) (this.data[cellIndex] >> bitIndex & this.maxValue);
@@ -114,6 +118,13 @@ public class BitStorage extends BaseStorage {
 
     @Override
     public void set(int index, int value) {
+        if (index < 0 || index > this.size - 1L) {
+            throw new IllegalStateException("Illegal index: " + index + " < 0 || " + index + " > " + this.size + " - 1");
+        }
+        if (value < 0 || value > this.maxValue) {
+            throw new IllegalStateException("Illegal value: " + value + " < 0 || " + value + " > " + this.maxValue);
+        }
+
         int cellIndex = cellIndex(index);
         int bitIndex = bitIndex(index, cellIndex);
         this.data[cellIndex] = this.data[cellIndex] & ~(this.maxValue << bitIndex) | ((long) value & this.maxValue) << bitIndex;


### PR DESCRIPTION
This fixes an issue present with newer versions. The global palette index is 1:1 the blockstate id, so new blocks overflow in the `BitStorage` (because of the bits-limit set for the `GlobalPalette`) and become other wrong blocks.
I've also added a check to make sure this issue is more obvious when this limit is reached again.