### PR TITLE
Fix WrapperPlayServerResourcePackSend in 1.16

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackSend.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackSend.java
@@ -67,7 +67,7 @@ public class WrapperPlayServerResourcePackSend extends PacketWrapper<WrapperPlay
 
         url = readString();
         hash = readString(MAX_HASH_LENGTH);
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
             required = readBoolean();
             boolean hasPrompt = readBoolean();
             if (hasPrompt) {
@@ -84,7 +84,7 @@ public class WrapperPlayServerResourcePackSend extends PacketWrapper<WrapperPlay
 
         writeString(url);
         writeString(hash, MAX_HASH_LENGTH);
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
             writeBoolean(required);
             writeBoolean(prompt != null);
             if (prompt != null) {


### PR DESCRIPTION
The required & prompt was added in 1.17, not 1.16.

https://minecraft.wiki/w/Server.properties
![image](https://github.com/retrooper/packetevents/assets/11319274/a4b2ef01-72d8-4e93-be58-837e32782995)
