### PR TITLE
Assume protocols higher or lower than the supported versions as closest protocol versions

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
@@ -90,8 +90,10 @@ public enum ClientVersion {
     V_1_20_3(765),
     //TODO UPDATE Add new protocol version field
 
+    @Deprecated
     LOWER_THAN_SUPPORTED_VERSIONS(V_1_7_10.protocolVersion - 1, true),
     //TODO UPDATE Update HIGHER_THAN_SUPPORTED_VERSIONS field
+    @Deprecated
     HIGHER_THAN_SUPPORTED_VERSIONS(V_1_20_3.protocolVersion + 1, true),
 
     UNKNOWN(-1, true);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
@@ -163,9 +163,9 @@ public enum ClientVersion {
     @NotNull
     public static ClientVersion getById(int protocolVersion) {
         if (protocolVersion < LOWEST_SUPPORTED_PROTOCOL_VERSION) {
-            return LOWER_THAN_SUPPORTED_VERSIONS;
+            return V_1_7_10;
         } else if (protocolVersion > HIGHEST_SUPPORTED_PROTOCOL_VERSION) {
-            return HIGHER_THAN_SUPPORTED_VERSIONS;
+            return V_1_20_3;
         } else {
             for (ClientVersion version : VALUES) {
                 if (version.protocolVersion > protocolVersion) {


### PR DESCRIPTION
The reason why i did this change is to fix my issue #654 , and it does a great job in doing so. I am using the jar with this change on production, no issues so far, the API also works perfectly fine, and server status works like normally again.

As mentioned, this pull request fixes #654 .