### PR TITLE
Properly read isFrontText in sign edit wrappers

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
@@ -30,7 +30,7 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClientUpdateSign> {
     private Vector3i blockPosition;
     private String[] textLines;
-    private boolean isFrontText = true;
+    private boolean isFrontText;
 
     public WrapperPlayClientUpdateSign(PacketReceiveEvent event) {
         super(event);
@@ -55,6 +55,8 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20)) {
             isFrontText = readBoolean();
+        } else {
+            isFrontText = true;
         }
         textLines = new String[4];
         for (int i = 0; i < 4; i++) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerOpenSignEditor.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerOpenSignEditor.java
@@ -26,7 +26,7 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayServerOpenSignEditor extends PacketWrapper<WrapperPlayServerOpenSignEditor> {
     private Vector3i position;
-    private boolean isFrontText = true;
+    private boolean isFrontText;
 
     public WrapperPlayServerOpenSignEditor(PacketSendEvent event) {
         super(event);
@@ -50,6 +50,8 @@ public class WrapperPlayServerOpenSignEditor extends PacketWrapper<WrapperPlaySe
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20)) {
             isFrontText = readBoolean();
+        } else {
+            isFrontText = true;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/retrooper/packetevents/issues/656

WrapperPlayServerOpenSignEditor and WrapperPlayClientUpdateSign break editing the back of signs by simply calling the wrapper. The initializers for these `isFrontText` fields to `true` ran AFTER the wrappers' superclass constructor, which means that the initializers would overwrite the value set by the `read` method.

This should not impact anyone using the wrapper, since `isFrontText` is still initialized to `true` for pre-1.20 server versions.

Validated on a fresh Paper 1.20.4 install with code using the wrapper. 