### PR TITLE
Fix VillagerLevel being invalid

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/villager/VillagerData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/villager/VillagerData.java
@@ -23,20 +23,22 @@ import com.github.retrooper.packetevents.protocol.entity.villager.profession.Vil
 import com.github.retrooper.packetevents.protocol.entity.villager.profession.VillagerProfessions;
 import com.github.retrooper.packetevents.protocol.entity.villager.type.VillagerType;
 import com.github.retrooper.packetevents.protocol.entity.villager.type.VillagerTypes;
+import org.jetbrains.annotations.Nullable;
 
 public class VillagerData {
+
     private VillagerType type;
     private VillagerProfession profession;
-    private VillagerLevel level;
+    private int level;
 
     public VillagerData(VillagerType type, VillagerProfession profession, VillagerLevel level) {
-        this.type = type;
-        this.profession = profession;
-        this.level = level;
+        this(type, profession, level.getId());
     }
 
     public VillagerData(VillagerType type, VillagerProfession profession, int level) {
-        this(type, profession, VillagerLevel.getById(level));
+        this.type = type;
+        this.profession = profession;
+        this.level = level;
     }
 
     public VillagerData(int typeId, int professionId, int level) {
@@ -60,18 +62,18 @@ public class VillagerData {
     }
 
     public int getLevel() {
-        return level.getId();
+        return this.level;
     }
 
-    public VillagerLevel getVillagerLevel() {
-        return level;
+    public @Nullable VillagerLevel getVillagerLevel() {
+        return VillagerLevel.getById(this.level);
     }
 
     public void setLevel(int level) {
-        this.level = VillagerLevel.getById(level);
+        this.level = level;
     }
 
     public void setLevel(VillagerLevel level) {
-        this.level = level;
+        this.level = level.getId();
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/villager/level/VillagerLevel.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/villager/level/VillagerLevel.java
@@ -18,7 +18,9 @@
 
 package com.github.retrooper.packetevents.protocol.entity.villager.level;
 
-public enum VillagerLevel  {
+import org.jetbrains.annotations.Nullable;
+
+public enum VillagerLevel {
 
     NOVICE,
     APPRENTICE,
@@ -28,13 +30,15 @@ public enum VillagerLevel  {
 
     private static final VillagerLevel[] VALUES = values();
 
-    public static VillagerLevel getById(int id) {
-        return VALUES[id];
+    public static @Nullable VillagerLevel getById(int id) {
+        if (id >= 1 && id <= VALUES.length) {
+            return VALUES[id - 1];
+        }
+        return null;
     }
 
     public int getId() {
-        return ordinal();
+        return this.ordinal() + 1;
     }
-
 }
 


### PR DESCRIPTION
Fixes the VillagerLevel introduced in #647. Villager levels >4 would cause issues, even though accepted by the vanilla client.

This still retains the newly introduced named VillagerLevel API, but the internal representation of villager levels has been reverted to an int.

---

Closes #662