### PR TITLE
Request signatures from Mojang API

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/MojangAPIUtil.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/MojangAPIUtil.java
@@ -39,7 +39,7 @@ public class MojangAPIUtil {
         String uuidStr = UUIDUtil.toStringWithoutDashes(uuid);
         try {
             List<TextureProperty> textureProperties = new ArrayList<>();
-            URL url = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuidStr);
+            URL url = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + uuidStr + "?unsigned=false");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             //Bad request, this UUID is not valid


### PR DESCRIPTION
The Mojang API doesn't provide signatures by default, so it's impossible currently to get the signature of a texture using the Mojang API utility.

This pull request resolves this.