### PR TITLE
Add missing entity poses for 1.20.4

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
@@ -36,6 +36,7 @@ public enum EntityPose {
     SNIFFING,
     EMERGING,
     DIGGING,
+    //Added in 1.20.4
     SLIDING,
     SHOOTING,
     INHALING;

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/pose/EntityPose.java
@@ -35,7 +35,10 @@ public enum EntityPose {
     ROARING,
     SNIFFING,
     EMERGING,
-    DIGGING;
+    DIGGING,
+    SLIDING,
+    SHOOTING,
+    INHALING;
 
    public int getId(ClientVersion version) {
        if (this == DYING && version.isOlderThan(ClientVersion.V_1_17)) {


### PR DESCRIPTION
With the addition of the breeze mob, 3 new poses have been added which weren't added during the initial 1.20.4 packetevents update.