### PR TITLE
Added WrapperPlayServerSetActionBarText

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerActionBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerActionBar.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of packetevents - https://github.com/retrooper/packetevents
- * Copyright (C) 2022 retrooper and contributors
+ * Copyright (C) 2024 retrooper and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,56 +24,39 @@ import com.github.retrooper.packetevents.util.adventure.AdventureSerializer;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import net.kyori.adventure.text.Component;
 
-public class WrapperPlayServerSetActionBarText extends PacketWrapper<WrapperPlayServerSetActionBarText> {
+public class WrapperPlayServerActionBar extends PacketWrapper<WrapperPlayServerActionBar> {
 
-    @Deprecated
-    public static boolean HANDLE_JSON = true;
+    private Component actionBarText;
 
-    private Component actionBar;
-
-    public WrapperPlayServerSetActionBarText(PacketSendEvent event) {
+    public WrapperPlayServerActionBar(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayServerSetActionBarText(String actionBarJson) {
-        this(AdventureSerializer.parseComponent(actionBarJson));
-    }
-
-    public WrapperPlayServerSetActionBarText(Component actionBar) {
+    public WrapperPlayServerActionBar(Component actionBarText) {
         super(PacketType.Play.Server.ACTION_BAR);
-        this.actionBar = actionBar;
+        this.actionBarText = actionBarText;
     }
 
     @Override
     public void read() {
-        this.actionBar = this.readComponent();
+        this.actionBarText = this.readComponent();
     }
 
     @Override
     public void write() {
-        this.writeComponent(this.actionBar);
+        this.writeComponent(this.actionBarText);
     }
 
     @Override
-    public void copy(WrapperPlayServerSetActionBarText wrapper) {
-        this.actionBar = wrapper.actionBar;
+    public void copy(WrapperPlayServerActionBar wrapper) {
+        this.actionBarText = wrapper.actionBarText;
     }
 
-    public Component getActionBar() {
-        return actionBar;
+    public Component getActionBarText() {
+        return actionBarText;
     }
 
-    public void setActionBar(Component actionBar) {
-        this.actionBar = actionBar;
-    }
-
-    @Deprecated
-    public String getActionBarJson() {
-        return AdventureSerializer.toJson(this.getActionBar());
-    }
-
-    @Deprecated
-    public void setActionBarJson(String titleJson) {
-        this.setActionBar(AdventureSerializer.parseComponent(titleJson));
+    public void setActionBarText(Component actionBarText) {
+        this.actionBarText = actionBarText;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerActionBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerActionBar.java
@@ -25,7 +25,6 @@ import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import net.kyori.adventure.text.Component;
 
 public class WrapperPlayServerActionBar extends PacketWrapper<WrapperPlayServerActionBar> {
-
     private Component actionBarText;
 
     public WrapperPlayServerActionBar(PacketSendEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSetActionBarText.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSetActionBarText.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.play.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.util.adventure.AdventureSerializer;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import net.kyori.adventure.text.Component;
+
+public class WrapperPlayServerSetActionBarText extends PacketWrapper<WrapperPlayServerSetActionBarText> {
+
+    @Deprecated
+    public static boolean HANDLE_JSON = true;
+
+    private Component actionBar;
+
+    public WrapperPlayServerSetActionBarText(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperPlayServerSetActionBarText(String actionBarJson) {
+        this(AdventureSerializer.parseComponent(actionBarJson));
+    }
+
+    public WrapperPlayServerSetActionBarText(Component actionBar) {
+        super(PacketType.Play.Server.ACTION_BAR);
+        this.actionBar = actionBar;
+    }
+
+    @Override
+    public void read() {
+        this.actionBar = this.readComponent();
+    }
+
+    @Override
+    public void write() {
+        this.writeComponent(this.actionBar);
+    }
+
+    @Override
+    public void copy(WrapperPlayServerSetActionBarText wrapper) {
+        this.actionBar = wrapper.actionBar;
+    }
+
+    public Component getActionBar() {
+        return actionBar;
+    }
+
+    public void setActionBar(Component actionBar) {
+        this.actionBar = actionBar;
+    }
+
+    @Deprecated
+    public String getActionBarJson() {
+        return AdventureSerializer.toJson(this.getActionBar());
+    }
+
+    @Deprecated
+    public void setActionBarJson(String titleJson) {
+        this.setActionBar(AdventureSerializer.parseComponent(titleJson));
+    }
+}


### PR DESCRIPTION
Create a wrapper for the [Set Action Bar Text Packet](https://wiki.vg/Protocol#Set_Action_Bar_Text). Fixing #671.

It is mostly a copy of [WrapperPlayServerSetTitleText](https://github.com/retrooper/packetevents/blob/2.0/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerTitle.java) as the packets have the same fields.