### PR TITLE
Implement settings for printing packet exception stacktraces and kicking the player for packet exceptions

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
@@ -37,6 +37,8 @@ public class PacketEventsSettings {
     private boolean downsampleColors = true;
     private boolean bStatsEnabled = true;
     private boolean debugEnabled = false;
+    private boolean fullStackTraceEnabled = false;
+    private boolean kickOnPacketExceptionEnabled = true;
     private Function<String, InputStream> resourceProvider = path -> PacketEventsSettings.class
             .getClassLoader()
             .getResourceAsStream(path);
@@ -114,6 +116,28 @@ public class PacketEventsSettings {
     }
 
     /**
+     * This decides if PacketEvents should print packets error stacktrace
+     *
+     * @param fullStackTraceEnabled Value
+     * @return Settings instance.
+     */
+    public PacketEventsSettings fullStackTrace(boolean fullStackTraceEnabled) {
+        this.fullStackTraceEnabled = fullStackTraceEnabled;
+        return this;
+    }
+
+    /**
+     * This decides if PacketEvents should kick the player in case a packet exception occurs.
+     *
+     * @param kickOnPacketExceptionEnabled Value
+     * @return Settings instance.
+     */
+    public PacketEventsSettings kickOnPacketException(boolean kickOnPacketExceptionEnabled) {
+        this.kickOnPacketExceptionEnabled = kickOnPacketExceptionEnabled;
+        return this;
+    }
+
+    /**
      * Some projects may want to implement a CDN with resources like asset mappings
      * By default, all resources are retrieved from the ClassLoader
      *
@@ -168,6 +192,24 @@ public class PacketEventsSettings {
      */
     public boolean isDebugEnabled() {
         return debugEnabled;
+    }
+
+    /**
+     * Should packetevents send packet exception Stacktraces to the console?
+     *
+     * @return Getter for {@link #fullStackTrace}
+     */
+    public boolean isFullStackTraceEnabled() {
+        return fullStackTraceEnabled;
+    }
+
+    /**
+     * Should packetevents kick the player due to an packet exception?
+     *
+     * @return Getter for {@link #kickOnPacketException}
+     */
+    public boolean isKickOnPacketExceptionEnabled() {
+        return kickOnPacketExceptionEnabled;
     }
 
     /**

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -24,12 +24,16 @@ import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.ExceptionUtil;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
 import io.github.retrooper.packetevents.injector.connection.ServerConnectionInitializer;
+import io.github.retrooper.packetevents.util.FoliaCompatUtil;
 import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 import java.util.List;
 
@@ -68,10 +72,22 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
         if (ExceptionUtil.isException(cause, PacketProcessException.class)
                 && !SpigotReflectionUtil.isMinecraftServerInstanceDebugging()
                 && (user != null && user.getDecoderState() != ConnectionState.HANDSHAKING)) {
-            if (PacketEvents.getAPI().getSettings().isDebugEnabled()) {
+            if (PacketEvents.getAPI().getSettings().isFullStackTraceEnabled()) {
                 cause.printStackTrace();
             } else {
                 PacketEvents.getAPI().getLogManager().warn(cause.getMessage());
+            }
+
+            if (PacketEvents.getAPI().getSettings().isKickOnPacketExceptionEnabled()) {
+                try {
+                    user.sendPacket(new WrapperPlayServerDisconnect(Component.empty()));
+                } catch (Exception ignored) { // There may (?) be an exception if the player is in the wrong state...
+                    PacketEvents.getAPI().getLogManager().warn("Failed to send disconnect packet to disconnect " + user.getProfile().getName() + " due to invalid packet! Disconnecting anyways.");
+                }
+                user.closeConnection();
+                if (player != null) {
+                    FoliaCompatUtil.runTaskForEntity(player, (Plugin) PacketEvents.getAPI().getPlugin(), () -> player.kickPlayer(""), null, 1);
+                }
             }
         }
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -80,14 +80,16 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
 
             if (PacketEvents.getAPI().getSettings().isKickOnPacketExceptionEnabled()) {
                 try {
-                    user.sendPacket(new WrapperPlayServerDisconnect(Component.empty()));
+                    user.sendPacket(new WrapperPlayServerDisconnect(Component.text("Invalid packet")));
                 } catch (Exception ignored) { // There may (?) be an exception if the player is in the wrong state...
-                    PacketEvents.getAPI().getLogManager().warn("Failed to send disconnect packet to disconnect " + user.getProfile().getName() + " due to invalid packet! Disconnecting anyways.");
+                    // Do nothing.
                 }
                 user.closeConnection();
                 if (player != null) {
-                    FoliaCompatUtil.runTaskForEntity(player, (Plugin) PacketEvents.getAPI().getPlugin(), () -> player.kickPlayer(""), null, 1);
+                    FoliaCompatUtil.runTaskForEntity(player, (Plugin) PacketEvents.getAPI().getPlugin(), () -> player.kickPlayer("Invalid packet"), null, 1);
                 }
+
+                PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to invalid packet!");
             }
         }
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -18,6 +18,7 @@
 
 package io.github.retrooper.packetevents.injector.handlers;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.exception.PacketProcessException;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
@@ -67,7 +68,11 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
         if (ExceptionUtil.isException(cause, PacketProcessException.class)
                 && !SpigotReflectionUtil.isMinecraftServerInstanceDebugging()
                 && (user != null && user.getDecoderState() != ConnectionState.HANDSHAKING)) {
-            cause.printStackTrace();
+            if (PacketEvents.getAPI().getSettings().isDebugEnabled()) {
+                cause.printStackTrace();
+            } else {
+                PacketEvents.getAPI().getLogManager().warn(cause.getMessage());
+            }
         }
     }
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -117,7 +117,7 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
 
         if (didWeCauseThis && user != null && user.getEncoderState() != ConnectionState.HANDSHAKING) {
             // Ignore handshaking exceptions
-            if (PacketEvents.getAPI().getSettings().isDebugEnabled()) {
+            if (PacketEvents.getAPI().getSettings().isFullStackTraceEnabled()) {
                 cause.printStackTrace();
             } else {
                 PacketEvents.getAPI().getLogManager().warn(cause.getMessage());

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -117,7 +117,11 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
 
         if (didWeCauseThis && user != null && user.getEncoderState() != ConnectionState.HANDSHAKING) {
             // Ignore handshaking exceptions
-            cause.printStackTrace();
+            if (PacketEvents.getAPI().getSettings().isDebugEnabled()) {
+                cause.printStackTrace();
+            } else {
+                PacketEvents.getAPI().getLogManager().warn(cause.getMessage());
+            }
             return;
         }
 


### PR DESCRIPTION
This should fix a vanilla inconsistency on protocol handling Thanks AoElite for the settings ideas

I took the disconnection code from Grim so if there's any change you would like please let me know.

The stacktrace printing is disabled by default to prevent the high CPU usage and the kick is enabled by default to match with Vanilla behavior.