### PR TITLE
Fix re-encode for new bytebufs that were bigger than the received one

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -243,6 +243,9 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
         return buffer;
     }
 
+    public void setBuffer(Object buffer) {
+        this.buffer = buffer;
+    }
 
     /**
      * Gets the Packet ID for the current platform version

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -20,6 +20,7 @@ package io.github.retrooper.packetevents.injector.handlers;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.exception.PacketProcessException;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.ExceptionUtil;
@@ -53,8 +54,8 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public void read(ChannelHandlerContext ctx, ByteBuf input, List<Object> out) throws Exception {
-        PacketEventsImplHelper.handleServerBoundPacket(ctx.channel(), user, player, input, true);
-        out.add(input.retain());
+        Object buffer = PacketEventsImplHelper.handleServerBoundPacket(ctx.channel(), user, player, input, true);
+        out.add(ByteBufHelper.retain(buffer));
     }
 
     @Override


### PR DESCRIPTION
If you tried to mark for re-encode a packet containing ItemStack and the received ByteBuf didn't have enough capacity to write the new data an error occurred. Allocating a new ByteBuf will allow us to always write the required bytes