### PR TITLE
Correct NBT component style serialization

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -73,6 +73,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
                 throw new IllegalStateException("Don't know how to deserialize " + nbt.getType() + " to text");
             }
         };
+
         String text = reader.read("text", textFunction);
         if (text == null) text = reader.read("", textFunction);
 
@@ -89,7 +90,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
         Key nbtStorage = reader.readUTF("storage", Key::key);
         List<Component> extra = reader.readList("extra", this::deserializeComponentList);
         Component separator = reader.read("separator", this::deserialize);
-        Style style = reader.readCompound("style", this::deserializeStyle);
+        Style style = this.deserializeStyle(compound);
 
         // build component from read values
         ComponentBuilder<?, ?> builder;
@@ -129,13 +130,12 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             throw new IllegalStateException("Illegal nbt component, component type could not be determined");
         }
 
-        if (style != null) {
-            builder.style(style);
-        }
+        builder.style(style);
 
         if (extra != null) {
             builder.append(extra);
         }
+
         return builder.build();
     }
 
@@ -222,7 +222,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
         }
 
         if (component.hasStyling()) {
-            writer.writeCompound("style", serializeStyle(component.style()));
+            serializeStyle(component.style()).getTags().forEach(writer::write);
         }
 
         // component children


### PR DESCRIPTION
During development of one of our plugins we've noticed that display name components in the PLAYER_INFO_UPDATE packets were not colored correctly. Turns out it's a small error in the component style NBT serialization - the code expected the style to be in the `style` compound (I think adventure holds it that way in its components, maybe that's why it was written that way), when in fact the styling elements are directly in the component compound.

You can see the NBT styling description [here](https://wiki.vg/Text_formatting#Styling_fields) - as you can see it's e.g. just a `color` tag, it's not inside any other styling tag.

This PR just simply gets rid of the additional `style` compound, the styling data is read directly from the main component compound, and is written directly into the component compound.