### PR TITLE
Added CommonPacketWrapper

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
@@ -201,6 +201,11 @@ public final class PacketType {
             public PacketSide getSide() {
                 return PacketSide.CLIENT;
             }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.HANDSHAKING;
+            }
         }
 
         public enum Server implements PacketTypeConstant, ClientBoundPacket {
@@ -224,6 +229,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.SERVER;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.HANDSHAKING;
             }
         }
     }
@@ -259,6 +269,11 @@ public final class PacketType {
             public PacketSide getSide() {
                 return PacketSide.CLIENT;
             }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.STATUS;
+            }
         }
 
         public enum Server implements PacketTypeConstant, ClientBoundPacket {
@@ -289,6 +304,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.SERVER;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.STATUS;
             }
         }
     }
@@ -330,6 +350,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.CLIENT;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.LOGIN;
             }
         }
 
@@ -373,6 +398,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.SERVER;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.LOGIN;
             }
         }
     }
@@ -422,6 +452,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.CLIENT;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.CONFIGURATION;
             }
         }
 
@@ -498,6 +533,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.SERVER;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.CONFIGURATION;
             }
         }
     }
@@ -635,6 +675,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.CLIENT;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.PLAY;
             }
         }
 
@@ -824,6 +869,11 @@ public final class PacketType {
             @Override
             public PacketSide getSide() {
                 return PacketSide.SERVER;
+            }
+
+            @Override
+            public ConnectionState getState() {
+                return ConnectionState.PLAY;
             }
 
             private static void loadPacketIds(Enum<?>[] enumConstants) {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketTypeCommon.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketTypeCommon.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.protocol.packettype;
 
+import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.PacketSide;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 
@@ -30,4 +31,6 @@ public interface PacketTypeCommon {
     int getId(ClientVersion version);
 
     PacketSide getSide();
+
+    ConnectionState getState();
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/CommonPacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/CommonPacketWrapper.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+
+public abstract class CommonPacketWrapper<T extends CommonPacketWrapper<T>> extends PacketWrapper<T> {
+
+    private final ConnectionState state;
+
+    public CommonPacketWrapper(ConnectionState state, ClientVersion clientVersion, ServerVersion serverVersion, int packetID) {
+        super(clientVersion, serverVersion, packetID);
+        this.state = state;
+    }
+
+    public CommonPacketWrapper(PacketReceiveEvent event) {
+        this(event, false);
+    }
+
+    public CommonPacketWrapper(PacketReceiveEvent event, boolean readData) {
+        super(event, false);
+        this.state = event.getConnectionState();
+        if (readData) {
+            readEvent(event);
+        }
+    }
+
+    public CommonPacketWrapper(PacketSendEvent event) {
+        this(event, false);
+    }
+
+    public CommonPacketWrapper(PacketSendEvent event, boolean readData) {
+        super(event, false);
+        state = event.getConnectionState();
+        if (readData) {
+            readEvent(event);
+        }
+    }
+
+    public CommonPacketWrapper(PacketTypeCommon packetType) {
+        super(packetType);
+        this.state = packetType.getState();
+    }
+
+    public static CommonPacketWrapper<?> createUniversalPacketWrapper(ConnectionState state, Object byteBuf) {
+        CommonPacketWrapper<?> wrapper = new CommonPacketWrapper(state, ClientVersion.UNKNOWN, PacketEvents.getAPI().getServerManager().getVersion(), -2) {
+            @Override
+            public CommonPacketWrapper<?> copy(ConnectionState state) {
+                return CommonPacketWrapper.createUniversalPacketWrapper(state, byteBuf);
+            }
+        };
+        wrapper.buffer = byteBuf;
+        return wrapper;
+    }
+
+    public ConnectionState getState() {
+        return state;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T as(ConnectionState state) {
+        if (this.state == state) {
+            return (T) this;
+        }
+        return copy(state);
+    }
+
+    public abstract T copy(ConnectionState state);
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientKeepAlive.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.client;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+
+/**
+ * This is the client-bound keep-alive packet.
+ * The server will frequently send out a (client-bound) keep-alive, each containing a random ID.
+ * The client is expected to respond with a (server-bound) keep-alive, containing the same ID that the server sent out.
+ */
+public class WrapperClientKeepAlive extends CommonPacketWrapper<WrapperClientKeepAlive> {
+    private long id;
+
+    public WrapperClientKeepAlive(PacketReceiveEvent event) {
+        super(event);
+    }
+
+    public WrapperClientKeepAlive(ConnectionState state, long id) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Client.KEEP_ALIVE : PacketType.Play.Client.KEEP_ALIVE);
+        this.id = id;
+    }
+
+    @Override
+    public void read() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+            this.id = readLong();
+        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+            this.id = readVarInt();
+        } else {
+            this.id = readInt();
+        }
+    }
+
+    @Override
+    public void write() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+            writeLong(id);
+        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+            writeVarInt((int) id);
+        } else {
+            writeInt((int) id);
+        }
+    }
+
+    @Override
+    public void copy(WrapperClientKeepAlive wrapper) {
+        this.id = wrapper.id;
+    }
+
+    @Override
+    public WrapperClientKeepAlive copy(ConnectionState state) {
+        return new WrapperClientKeepAlive(state, this.id);
+    }
+
+    public long getId() {
+        return this.id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientPong.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientPong.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.client;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerPing;
+
+/**
+ * A response to the ping packet.
+ * The vanilla server doesn't seem to send the Ping packet.
+ * Most likely added as a replacement to the removed Window Confirmation packet.
+ *
+ * @see WrapperServerPing
+ */
+public class WrapperClientPong extends CommonPacketWrapper<WrapperClientPong> {
+    private int id;
+
+    public WrapperClientPong(PacketReceiveEvent event) {
+        super(event);
+    }
+
+    public WrapperClientPong(ConnectionState state, int id) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Client.PONG : PacketType.Play.Client.PONG);
+        this.id = id;
+    }
+
+    @Override
+    public void read() {
+        this.id = readInt();
+    }
+
+    @Override
+    public void write() {
+        writeInt(id);
+    }
+
+    @Override
+    public void copy(WrapperClientPong wrapper) {
+        this.id = wrapper.id;
+    }
+
+    @Override
+    public WrapperClientPong copy(ConnectionState state) {
+        return new WrapperClientPong(state, this.id);
+    }
+
+    /**
+     * ID of the last sent Ping packet.
+     *
+     * @return ID
+     */
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientResourcePackStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientResourcePackStatus.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.client;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+
+import java.util.UUID;
+
+public class WrapperClientResourcePackStatus extends CommonPacketWrapper<WrapperClientResourcePackStatus> {
+
+    private UUID packId;
+    private String hash;
+    private Result result;
+
+    public WrapperClientResourcePackStatus(PacketReceiveEvent event) {
+        super(event);
+    }
+
+    public WrapperClientResourcePackStatus(ConnectionState state, Result result) {
+        this(state, null, null, result);
+    }
+
+    public WrapperClientResourcePackStatus(ConnectionState state, UUID packId, Result result) {
+        this(state, packId, null, result);
+    }
+
+    @Deprecated
+    public WrapperClientResourcePackStatus(String hash, Result result) {
+        this(ConnectionState.PLAY, null, hash, result);
+    }
+
+    WrapperClientResourcePackStatus(ConnectionState state, UUID packId, String hash, Result result) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Client.RESOURCE_PACK_STATUS : PacketType.Play.Client.RESOURCE_PACK_STATUS);
+        this.packId = packId;
+        this.hash = hash;
+        this.result = result;
+    }
+
+    @Override
+    public void read() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
+            this.packId = this.readUUID();
+        }
+
+        if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
+            //For now ignore hash, maybe make optional
+            this.hash = readString(40);
+        } else {
+            this.hash = "";
+        }
+        int resultIndex = readVarInt();
+        this.result = Result.VALUES[resultIndex];
+    }
+
+    @Override
+    public void write() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
+            this.writeUUID(this.packId);
+        }
+
+        if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
+            writeString(hash, 40);
+        }
+        writeVarInt(result.ordinal());
+    }
+
+    @Override
+    public void copy(WrapperClientResourcePackStatus wrapper) {
+        this.packId = wrapper.packId;
+        this.hash = wrapper.hash;
+        this.result = wrapper.result;
+    }
+
+    @Override
+    public WrapperClientResourcePackStatus copy(ConnectionState state) {
+        return new WrapperClientResourcePackStatus(state, this.packId, this.hash, this.result);
+    }
+
+    public UUID getPackId() {
+        return this.packId;
+    }
+
+    public void setPackId(UUID packId) {
+        this.packId = packId;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    public enum Result {
+
+        SUCCESSFULLY_LOADED,
+        DECLINED,
+        FAILED_DOWNLOAD,
+        ACCEPTED,
+        DOWNLOADED,
+        INVALID_URL,
+        FAILED_RELOAD,
+        DISCARDED;
+
+        public static final Result[] VALUES = values();
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientResourcePackStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperClientResourcePackStatus.java
@@ -81,7 +81,7 @@ public class WrapperClientResourcePackStatus extends CommonPacketWrapper<Wrapper
         if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
             writeString(hash, 40);
         }
-        writeVarInt(result.ordinal());
+        writeVarInt(getResultOrdinal());
     }
 
     @Override
@@ -108,6 +108,13 @@ public class WrapperClientResourcePackStatus extends CommonPacketWrapper<Wrapper
         return result;
     }
 
+    public int getResultOrdinal() {
+        if (result.ordinal() >= 4 && serverVersion.isOlderThan(ServerVersion.V_1_20_3)) {
+            return result.getFallback();
+        }
+        return result.ordinal();
+    }
+
     public void setResult(Result result) {
         this.result = result;
     }
@@ -126,11 +133,25 @@ public class WrapperClientResourcePackStatus extends CommonPacketWrapper<Wrapper
         DECLINED,
         FAILED_DOWNLOAD,
         ACCEPTED,
-        DOWNLOADED,
-        INVALID_URL,
-        FAILED_RELOAD,
-        DISCARDED;
+        DOWNLOADED(0),
+        INVALID_URL(2),
+        FAILED_RELOAD(2),
+        DISCARDED(1);
 
         public static final Result[] VALUES = values();
+
+        private final int fallback;
+
+        Result() {
+            this.fallback = 0;
+        }
+
+        Result(int fallback) {
+            this.fallback = fallback;
+        }
+
+        public int getFallback() {
+            return fallback;
+        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerDisconnect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerDisconnect.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+import net.kyori.adventure.text.Component;
+
+public class WrapperServerDisconnect extends CommonPacketWrapper<WrapperServerDisconnect> {
+
+    private Component reason;
+
+    public WrapperServerDisconnect(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperServerDisconnect(ConnectionState state, Component reason) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Server.DISCONNECT : PacketType.Play.Server.DISCONNECT);
+        this.reason = reason;
+    }
+
+    @Override
+    public void read() {
+        this.reason = this.readComponent();
+    }
+
+    @Override
+    public void write() {
+        this.writeComponent(this.reason);
+    }
+
+    @Override
+    public void copy(WrapperServerDisconnect wrapper) {
+        this.reason = wrapper.reason;
+    }
+
+    @Override
+    public WrapperServerDisconnect copy(ConnectionState state) {
+        return new WrapperServerDisconnect(state, reason);
+    }
+
+    public Component getReason() {
+        return this.reason;
+    }
+
+    public void setReason(Component reason) {
+        this.reason = reason;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerKeepAlive.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+
+/**
+ * This is the server-bound keep-alive packet.
+ * The server will frequently send out a (client-bound) keep-alive, each containing a random ID.
+ * The client is expected to respond with a (server-bound) keep-alive, containing the same ID that the server sent out.
+ */
+public class WrapperServerKeepAlive extends CommonPacketWrapper<WrapperServerKeepAlive> {
+    private long id;
+
+    public WrapperServerKeepAlive(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperServerKeepAlive(ConnectionState state, long id) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Server.KEEP_ALIVE : PacketType.Play.Server.KEEP_ALIVE);
+        this.id = id;
+    }
+
+    @Override
+    public void read() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+            this.id = readLong();
+        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+            this.id = readVarInt();
+        } else {
+            this.id = readInt();
+        }
+    }
+
+    @Override
+    public void write() {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+            writeLong(id);
+        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+            writeVarInt((int) id);
+        } else {
+            writeInt((int) id);
+        }
+    }
+
+    @Override
+    public void copy(WrapperServerKeepAlive wrapper) {
+        this.id = wrapper.id;
+    }
+
+    @Override
+    public WrapperServerKeepAlive copy(ConnectionState state) {
+        return new WrapperServerKeepAlive(state, this.id);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerPing.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerPing.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientPong;
+
+/**
+ * This packet is currently used by mods to synchronize the client with the server.
+ * It is not used by the vanilla server.
+ * Most likely added as a replacement to the removed Window Confirmation packet.
+ *
+ * @see WrapperClientPong
+ */
+public class WrapperServerPing extends CommonPacketWrapper<WrapperServerPing> {
+    private int id;
+
+    public WrapperServerPing(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperServerPing(ConnectionState state, int id) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Server.PING : PacketType.Play.Server.PING);
+        this.id = id;
+    }
+
+    @Override
+    public void read() {
+        this.id = readInt();
+    }
+
+    @Override
+    public void write() {
+        writeInt(id);
+    }
+
+    @Override
+    public void copy(WrapperServerPing wrapper) {
+        this.id = wrapper.id;
+    }
+
+    @Override
+    public WrapperServerPing copy(ConnectionState state) {
+        return new WrapperServerPing(state, this.id);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerResourcePackRemove.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerResourcePackRemove.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public class WrapperServerResourcePackRemove extends CommonPacketWrapper<WrapperServerResourcePackRemove> {
+
+    private @Nullable UUID packId;
+
+    public WrapperServerResourcePackRemove(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperServerResourcePackRemove(ConnectionState state, @Nullable UUID packId) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Server.RESOURCE_PACK_REMOVE : PacketType.Play.Server.RESOURCE_PACK_REMOVE);
+        this.packId = packId;
+    }
+
+    @Override
+    public void read() {
+        this.packId = this.readOptional(PacketWrapper::readUUID);
+    }
+
+    @Override
+    public void write() {
+        this.writeOptional(this.packId, PacketWrapper::writeUUID);
+    }
+
+    @Override
+    public void copy(WrapperServerResourcePackRemove wrapper) {
+        this.packId = wrapper.packId;
+    }
+
+    @Override
+    public WrapperServerResourcePackRemove copy(ConnectionState state) {
+        return new WrapperServerResourcePackRemove(state, this.packId);
+    }
+
+    public @Nullable UUID getPackId() {
+        return this.packId;
+    }
+
+    public void setPackId(@Nullable UUID packId) {
+        this.packId = packId;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerResourcePackSend.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/server/WrapperServerResourcePackSend.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.common.server;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.CommonPacketWrapper;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public class WrapperServerResourcePackSend extends CommonPacketWrapper<WrapperServerResourcePackSend> {
+
+    public static final int MAX_HASH_LENGTH = 40;
+
+    private UUID packId;
+    private String url;
+    private String hash;
+    private boolean required;
+    private Component prompt;
+
+    public WrapperServerResourcePackSend(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperServerResourcePackSend(ConnectionState state, String url, String hash, boolean required, @Nullable Component prompt) {
+        this(state, null, url, hash, required, prompt);
+    }
+
+    public WrapperServerResourcePackSend(ConnectionState state, UUID packId, String url, String hash, boolean required, @Nullable Component prompt) {
+        super(state == ConnectionState.CONFIGURATION ? PacketType.Configuration.Server.RESOURCE_PACK_SEND : PacketType.Play.Server.RESOURCE_PACK_SEND);
+
+        if (hash.length() > MAX_HASH_LENGTH) {
+            throw new IllegalArgumentException("Hash is too long (max " + MAX_HASH_LENGTH + ", was " + hash.length() + ")");
+        }
+
+        this.packId = packId;
+        this.url = url;
+        this.hash = hash;
+        this.required = required;
+        this.prompt = prompt;
+    }
+
+    @Override
+    public void read() {
+        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
+            this.packId = this.readUUID();
+        }
+
+        url = readString();
+        hash = readString(MAX_HASH_LENGTH);
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
+            required = readBoolean();
+            boolean hasPrompt = readBoolean();
+            if (hasPrompt) {
+                prompt = readComponent();
+            }
+        }
+    }
+
+    @Override
+    public void write() {
+        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
+            this.writeUUID(this.packId);
+        }
+
+        writeString(url);
+        writeString(hash, MAX_HASH_LENGTH);
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
+            writeBoolean(required);
+            writeBoolean(prompt != null);
+            if (prompt != null) {
+                writeComponent(prompt);
+            }
+        }
+    }
+
+    @Override
+    public void copy(WrapperServerResourcePackSend wrapper) {
+        packId = wrapper.packId;
+        url = wrapper.url;
+        hash = wrapper.hash;
+        required = wrapper.required;
+        prompt = wrapper.prompt;
+    }
+
+    @Override
+    public WrapperServerResourcePackSend copy(ConnectionState state) {
+        return new WrapperServerResourcePackSend(state, this.packId, this.url, this.hash, this.required, this.prompt);
+    }
+
+    public UUID getPackId() {
+        return this.packId;
+    }
+
+    public void setPackId(UUID packId) {
+        this.packId = packId;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public Component getPrompt() {
+        return prompt;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientKeepAlive.java
@@ -19,42 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.configuration.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientKeepAlive;
 
-public class WrapperConfigClientKeepAlive extends PacketWrapper<WrapperConfigClientKeepAlive> {
-
-    private long id;
+@Deprecated
+public class WrapperConfigClientKeepAlive extends WrapperClientKeepAlive {
 
     public WrapperConfigClientKeepAlive(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperConfigClientKeepAlive(long id) {
-        super(PacketType.Configuration.Client.KEEP_ALIVE);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        this.id = this.readLong();
-    }
-
-    @Override
-    public void write() {
-        this.writeLong(this.id);
-    }
-
-    @Override
-    public void copy(WrapperConfigClientKeepAlive wrapper) {
-        this.id = wrapper.id;
-    }
-
-    public long getId() {
-        return this.id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
+        super(ConnectionState.CONFIGURATION, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientPong.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientPong.java
@@ -19,42 +19,16 @@
 package com.github.retrooper.packetevents.wrapper.configuration.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientPong;
 
-public class WrapperConfigClientPong extends PacketWrapper<WrapperConfigClientPong> {
-
-    private int id;
+public class WrapperConfigClientPong extends WrapperClientPong {
 
     public WrapperConfigClientPong(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperConfigClientPong(int id) {
-        super(PacketType.Configuration.Client.PONG);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        this.id = this.readInt();
-    }
-
-    @Override
-    public void write() {
-        this.writeInt(this.id);
-    }
-
-    @Override
-    public void copy(WrapperConfigClientPong wrapper) {
-        this.id = wrapper.id;
-    }
-
-    public int getId() {
-        return this.id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
+        super(ConnectionState.CONFIGURATION, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientPong.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientPong.java
@@ -22,6 +22,7 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientPong;
 
+@Deprecated
 public class WrapperConfigClientPong extends WrapperClientPong {
 
     public WrapperConfigClientPong(PacketReceiveEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientResourcePackStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientResourcePackStatus.java
@@ -19,81 +19,23 @@
 package com.github.retrooper.packetevents.wrapper.configuration.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientResourcePackStatus;
 
-import java.security.Provider;
 import java.util.UUID;
 
-public class WrapperConfigClientResourcePackStatus extends PacketWrapper<WrapperConfigClientResourcePackStatus> {
-
-    private UUID packId;
-    private Result result;
+@Deprecated
+public class WrapperConfigClientResourcePackStatus extends WrapperClientResourcePackStatus {
 
     public WrapperConfigClientResourcePackStatus(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperConfigClientResourcePackStatus(Result result) {
-        this(UUID.randomUUID(), result);
+        super(ConnectionState.CONFIGURATION, result);
     }
 
     public WrapperConfigClientResourcePackStatus(UUID packId, Result result) {
-        super(PacketType.Configuration.Client.RESOURCE_PACK_STATUS);
-        this.packId = packId;
-        this.result = result;
-    }
-
-    @Override
-    public void read() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.packId = this.readUUID();
-        }
-        this.result = Result.VALUES[this.readVarInt()];
-    }
-
-    @Override
-    public void write() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.writeUUID(this.packId);
-        }
-        this.writeVarInt(this.result.ordinal());
-    }
-
-    @Override
-    public void copy(WrapperConfigClientResourcePackStatus wrapper) {
-        this.packId = wrapper.packId;
-        this.result = wrapper.result;
-    }
-
-    public UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(UUID packId) {
-        this.packId = packId;
-    }
-
-    public Result getResult() {
-        return this.result;
-    }
-
-    public void setResult(Result result) {
-        this.result = result;
-    }
-
-    public enum Result {
-
-        SUCCESSFULLY_LOADED,
-        DECLINED,
-        FAILED_DOWNLOAD,
-        ACCEPTED,
-        DOWNLOADED,
-        INVALID_URL,
-        FAILED_RELOAD,
-        DISCARDED;
-
-        public static final Result[] VALUES = values();
+        super(ConnectionState.CONFIGURATION, packId, result);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerDisconnect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerDisconnect.java
@@ -19,43 +19,18 @@
 package com.github.retrooper.packetevents.wrapper.configuration.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerDisconnect;
 import net.kyori.adventure.text.Component;
 
-public class WrapperConfigServerDisconnect extends PacketWrapper<WrapperConfigServerDisconnect> {
-
-    private Component reason;
+@Deprecated
+public class WrapperConfigServerDisconnect extends WrapperServerDisconnect {
 
     public WrapperConfigServerDisconnect(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperConfigServerDisconnect(Component reason) {
-        super(PacketType.Configuration.Server.DISCONNECT);
-        this.reason = reason;
-    }
-
-    @Override
-    public void read() {
-        this.reason = this.readComponent();
-    }
-
-    @Override
-    public void write() {
-        this.writeComponent(this.reason);
-    }
-
-    @Override
-    public void copy(WrapperConfigServerDisconnect wrapper) {
-        this.reason = wrapper.reason;
-    }
-
-    public Component getReason() {
-        return this.reason;
-    }
-
-    public void setReason(Component reason) {
-        this.reason = reason;
+        super(ConnectionState.CONFIGURATION, reason);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerKeepAlive.java
@@ -19,42 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.configuration.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerKeepAlive;
 
-public class WrapperConfigServerKeepAlive extends PacketWrapper<WrapperConfigServerKeepAlive> {
-
-    private long id;
+@Deprecated
+public class WrapperConfigServerKeepAlive extends WrapperServerKeepAlive {
 
     public WrapperConfigServerKeepAlive(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperConfigServerKeepAlive(long id) {
-        super(PacketType.Configuration.Server.KEEP_ALIVE);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        this.id = this.readLong();
-    }
-
-    @Override
-    public void write() {
-        this.writeLong(this.id);
-    }
-
-    @Override
-    public void copy(WrapperConfigServerKeepAlive wrapper) {
-        this.id = wrapper.id;
-    }
-
-    public long getId() {
-        return this.id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
+        super(ConnectionState.CONFIGURATION, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerResourcePackRemove.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerResourcePackRemove.java
@@ -19,45 +19,20 @@
 package com.github.retrooper.packetevents.wrapper.configuration.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerResourcePackRemove;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class WrapperConfigServerResourcePackRemove extends PacketWrapper<WrapperConfigServerResourcePackRemove> {
-
-    private @Nullable UUID packId;
+@Deprecated
+public class WrapperConfigServerResourcePackRemove extends WrapperServerResourcePackRemove {
 
     public WrapperConfigServerResourcePackRemove(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperConfigServerResourcePackRemove(@Nullable UUID packId) {
-        super(PacketType.Configuration.Server.RESOURCE_PACK_REMOVE);
-        this.packId = packId;
-    }
-
-    @Override
-    public void read() {
-        this.packId = this.readOptional(PacketWrapper::readUUID);
-    }
-
-    @Override
-    public void write() {
-        this.writeOptional(this.packId, PacketWrapper::writeUUID);
-    }
-
-    @Override
-    public void copy(WrapperConfigServerResourcePackRemove wrapper) {
-        this.packId = wrapper.packId;
-    }
-
-    public @Nullable UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(@Nullable UUID packId) {
-        this.packId = packId;
+        super(ConnectionState.CONFIGURATION, packId);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerResourcePackSend.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerResourcePackSend.java
@@ -19,123 +19,27 @@
 package com.github.retrooper.packetevents.wrapper.configuration.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerResourcePackSend;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class WrapperConfigServerResourcePackSend extends PacketWrapper<WrapperConfigServerResourcePackSend> {
+@Deprecated
+public class WrapperConfigServerResourcePackSend extends WrapperServerResourcePackSend {
 
     public static final int MAX_HASH_LENGTH = 40;
-
-    private UUID packId;
-    private String url;
-    private String hash;
-    private boolean required;
-    private Component prompt;
 
     public WrapperConfigServerResourcePackSend(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperConfigServerResourcePackSend(String url, String hash, boolean required, @Nullable Component prompt) {
-        this(UUID.randomUUID(), url, hash, required, prompt);
+        super(ConnectionState.CONFIGURATION, url, hash, required, prompt);
     }
 
     public WrapperConfigServerResourcePackSend(UUID packId, String url, String hash, boolean required, @Nullable Component prompt) {
-        super(PacketType.Configuration.Server.RESOURCE_PACK_SEND);
-
-        if (hash.length() > MAX_HASH_LENGTH) {
-            throw new IllegalArgumentException("Hash is too long (max " + MAX_HASH_LENGTH + ", was " + hash.length() + ")");
-        }
-
-        this.packId = packId;
-        this.url = url;
-        this.hash = hash;
-        this.required = required;
-        this.prompt = prompt;
-    }
-
-    @Override
-    public void read() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.packId = this.readUUID();
-        }
-
-        this.url = this.readString();
-        this.hash = this.readString(MAX_HASH_LENGTH);
-        this.required = this.readBoolean();
-        if (this.readBoolean()) {
-            this.prompt = this.readComponent();
-        }
-    }
-
-    @Override
-    public void write() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.writeUUID(this.packId);
-        }
-
-        this.writeString(this.url);
-        this.writeString(this.hash, MAX_HASH_LENGTH);
-        this.writeBoolean(this.required);
-        if (this.prompt != null) {
-            this.writeBoolean(true);
-            this.writeComponent(this.prompt);
-        } else {
-            this.writeBoolean(false);
-        }
-    }
-
-    @Override
-    public void copy(WrapperConfigServerResourcePackSend wrapper) {
-        this.packId = wrapper.packId;
-        this.url = wrapper.url;
-        this.hash = wrapper.hash;
-        this.required = wrapper.required;
-        this.prompt = wrapper.prompt;
-    }
-
-    public UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(UUID packId) {
-        this.packId = packId;
-    }
-
-    public String getUrl() {
-        return this.url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getHash() {
-        return this.hash;
-    }
-
-    public void setHash(String hash) {
-        this.hash = hash;
-    }
-
-    public boolean isRequired() {
-        return this.required;
-    }
-
-    public void setRequired(boolean required) {
-        this.required = required;
-    }
-
-    public Component getPrompt() {
-        return this.prompt;
-    }
-
-    public void setPrompt(Component prompt) {
-        this.prompt = prompt;
+        super(ConnectionState.CONFIGURATION, packId, url, hash, required, prompt);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
@@ -19,64 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientKeepAlive;
 
-/**
- * This is the server-bound keep-alive packet.
- * The server will frequently send out a (client-bound) keep-alive, each containing a random ID.
- * The client is expected to respond with a (server-bound) keep-alive, containing the same ID that the server sent out.
- */
-public class WrapperPlayClientKeepAlive extends PacketWrapper<WrapperPlayClientKeepAlive> {
-    private long id;
+@Deprecated
+public class WrapperPlayClientKeepAlive extends WrapperClientKeepAlive {
 
     public WrapperPlayClientKeepAlive(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperPlayClientKeepAlive(long id) {
-        super(PacketType.Play.Client.KEEP_ALIVE);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            this.id = readLong();
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            this.id = readVarInt();
-        } else {
-            this.id = readInt();
-        }
-    }
-
-    @Override
-    public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            writeLong(id);
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            writeVarInt((int) id);
-        } else {
-            writeInt((int) id);
-        }
-    }
-
-    @Override
-    public void copy(WrapperPlayClientKeepAlive wrapper) {
-        this.id = wrapper.id;
-    }
-
-    /**
-     * Keep-Alive ID.
-     *
-     * @return ID
-     */
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
+        super(ConnectionState.PLAY, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPong.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPong.java
@@ -19,54 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPing;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientPong;
 
-/**
- * A response to the ping packet.
- * The vanilla server doesn't seem to send the Ping packet.
- * Most likely added as a replacement to the removed Window Confirmation packet.
- *
- * @see WrapperPlayServerPing
- */
-public class WrapperPlayClientPong extends PacketWrapper<WrapperPlayClientPong> {
-    private int id;
+@Deprecated
+public class WrapperPlayClientPong extends WrapperClientPong {
 
     public WrapperPlayClientPong(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperPlayClientPong(int id) {
-        super(PacketType.Play.Client.PONG);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        this.id = readInt();
-    }
-
-    @Override
-    public void write() {
-        writeInt(id);
-    }
-
-    @Override
-    public void copy(WrapperPlayClientPong wrapper) {
-        this.id = wrapper.id;
-    }
-
-    /**
-     * ID of the last sent Ping packet.
-     *
-     * @return ID
-     */
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
+        super(ConnectionState.PLAY, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientResourcePackStatus.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientResourcePackStatus.java
@@ -19,109 +19,28 @@
 package com.github.retrooper.packetevents.wrapper.play.client;
 
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.client.WrapperClientResourcePackStatus;
 
 import java.util.UUID;
 
-public class WrapperPlayClientResourcePackStatus extends PacketWrapper<WrapperPlayClientResourcePackStatus> {
-
-    private UUID packId;
-    private String hash;
-    private Result result;
+@Deprecated
+public class WrapperPlayClientResourcePackStatus extends WrapperClientResourcePackStatus {
 
     public WrapperPlayClientResourcePackStatus(PacketReceiveEvent event) {
         super(event);
     }
 
     public WrapperPlayClientResourcePackStatus(Result result) {
-        this(UUID.randomUUID(), result);
+        super(ConnectionState.PLAY, result);
     }
 
     public WrapperPlayClientResourcePackStatus(UUID packId, Result result) {
-        super(PacketType.Play.Client.RESOURCE_PACK_STATUS);
-        this.packId = packId;
-        this.result = result;
+        super(ConnectionState.PLAY, packId, result);
     }
 
     @Deprecated
     public WrapperPlayClientResourcePackStatus(String hash, Result result) {
-        super(PacketType.Play.Client.RESOURCE_PACK_STATUS);
-        this.hash = hash;
-        this.result = result;
-    }
-
-    @Override
-    public void read() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.packId = this.readUUID();
-        }
-
-        if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
-            //For now ignore hash, maybe make optional
-            this.hash = readString(40);
-        } else {
-            this.hash = "";
-        }
-        int resultIndex = readVarInt();
-        this.result = Result.VALUES[resultIndex];
-    }
-
-    @Override
-    public void write() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.writeUUID(this.packId);
-        }
-
-        if (serverVersion.isOlderThan(ServerVersion.V_1_10)) {
-            writeString(hash, 40);
-        }
-        writeVarInt(result.ordinal());
-    }
-
-    @Override
-    public void copy(WrapperPlayClientResourcePackStatus wrapper) {
-        this.packId = wrapper.packId;
-        this.hash = wrapper.hash;
-        this.result = wrapper.result;
-    }
-
-    public UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(UUID packId) {
-        this.packId = packId;
-    }
-
-    public Result getResult() {
-        return result;
-    }
-
-    public void setResult(Result result) {
-        this.result = result;
-    }
-
-    public String getHash() {
-        return hash;
-    }
-
-    public void setHash(String hash) {
-        this.hash = hash;
-    }
-
-    public enum Result {
-
-        SUCCESSFULLY_LOADED,
-        DECLINED,
-        FAILED_DOWNLOAD,
-        ACCEPTED,
-        DOWNLOADED,
-        INVALID_URL,
-        FAILED_RELOAD,
-        DISCARDED;
-
-        public static final Result[] VALUES = values();
+        super(hash, result);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerDisconnect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerDisconnect.java
@@ -19,42 +19,18 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerDisconnect;
 import net.kyori.adventure.text.Component;
 
-public class WrapperPlayServerDisconnect extends PacketWrapper<WrapperPlayServerDisconnect> {
-    private Component reason;
+@Deprecated
+public class WrapperPlayServerDisconnect extends WrapperServerDisconnect {
 
     public WrapperPlayServerDisconnect(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperPlayServerDisconnect(Component reason) {
-        super(PacketType.Play.Server.DISCONNECT);
-        this.reason = reason;
-    }
-
-    @Override
-    public void read() {
-        reason = readComponent();
-    }
-
-    @Override
-    public void write() {
-        writeComponent(reason);
-    }
-
-    @Override
-    public void copy(WrapperPlayServerDisconnect wrapper) {
-        this.reason = wrapper.reason;
-    }
-
-    public Component getReason() {
-        return reason;
-    }
-
-    public void setReason(Component reason) {
-        this.reason = reason;
+        super(ConnectionState.PLAY, reason);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerKeepAlive.java
@@ -19,59 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerKeepAlive;
 
-/**
- * This is the server-bound keep-alive packet.
- * The server will frequently send out a (client-bound) keep-alive, each containing a random ID.
- * The client is expected to respond with a (server-bound) keep-alive, containing the same ID that the server sent out.
- */
-public class WrapperPlayServerKeepAlive extends PacketWrapper<WrapperPlayServerKeepAlive> {
-    private long id;
+@Deprecated
+public class WrapperPlayServerKeepAlive extends WrapperServerKeepAlive {
 
     public WrapperPlayServerKeepAlive(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperPlayServerKeepAlive(long id) {
-        super(PacketType.Play.Server.KEEP_ALIVE);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            this.id = readLong();
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            this.id = readVarInt();
-        } else {
-            this.id = readInt();
-        }
-    }
-
-    @Override
-    public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
-            writeLong(id);
-        } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
-            writeVarInt((int) id);
-        } else {
-            writeInt((int) id);
-        }
-    }
-
-    @Override
-    public void copy(WrapperPlayServerKeepAlive wrapper) {
-        this.id = wrapper.id;
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
+        super(ConnectionState.PLAY, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerPing.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerPing.java
@@ -19,49 +19,17 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPong;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerPing;
 
-/**
- * This packet is currently used by mods to synchronize the client with the server.
- * It is not used by the vanilla server.
- * Most likely added as a replacement to the removed Window Confirmation packet.
- *
- * @see WrapperPlayClientPong
- */
-public class WrapperPlayServerPing extends PacketWrapper<WrapperPlayServerPing> {
-    private int id;
+@Deprecated
+public class WrapperPlayServerPing extends WrapperServerPing {
 
     public WrapperPlayServerPing(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperPlayServerPing(int id) {
-        super(PacketType.Play.Server.PING);
-        this.id = id;
-    }
-
-    @Override
-    public void read() {
-        this.id = readInt();
-    }
-
-    @Override
-    public void write() {
-        writeInt(id);
-    }
-
-    @Override
-    public void copy(WrapperPlayServerPing wrapper) {
-        this.id = wrapper.id;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
+        super(ConnectionState.PLAY, id);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackRemove.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackRemove.java
@@ -19,45 +19,20 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerResourcePackRemove;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class WrapperPlayServerResourcePackRemove extends PacketWrapper<WrapperPlayServerResourcePackRemove> {
-
-    private @Nullable UUID packId;
+@Deprecated
+public class WrapperPlayServerResourcePackRemove extends WrapperServerResourcePackRemove {
 
     public WrapperPlayServerResourcePackRemove(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperPlayServerResourcePackRemove(@Nullable UUID packId) {
-        super(PacketType.Play.Server.RESOURCE_PACK_REMOVE);
-        this.packId = packId;
-    }
-
-    @Override
-    public void read() {
-        this.packId = this.readOptional(PacketWrapper::readUUID);
-    }
-
-    @Override
-    public void write() {
-        this.writeOptional(this.packId, PacketWrapper::writeUUID);
-    }
-
-    @Override
-    public void copy(WrapperPlayServerResourcePackRemove wrapper) {
-        this.packId = wrapper.packId;
-    }
-
-    public @Nullable UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(@Nullable UUID packId) {
-        this.packId = packId;
+        super(ConnectionState.PLAY, packId);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackSend.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerResourcePackSend.java
@@ -19,122 +19,27 @@
 package com.github.retrooper.packetevents.wrapper.play.server;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.manager.server.ServerVersion;
-import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerResourcePackSend;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class WrapperPlayServerResourcePackSend extends PacketWrapper<WrapperPlayServerResourcePackSend> {
+@Deprecated
+public class WrapperPlayServerResourcePackSend extends WrapperServerResourcePackSend {
 
     public static final int MAX_HASH_LENGTH = 40;
-
-    private UUID packId;
-    private String url;
-    private String hash;
-    private boolean required;
-    private Component prompt;
 
     public WrapperPlayServerResourcePackSend(PacketSendEvent event) {
         super(event);
     }
 
     public WrapperPlayServerResourcePackSend(String url, String hash, boolean required, @Nullable Component prompt) {
-        this(UUID.randomUUID(), url, hash, required, prompt);
+        super(ConnectionState.PLAY, url, hash, required, prompt);
     }
 
     public WrapperPlayServerResourcePackSend(UUID packId, String url, String hash, boolean required, @Nullable Component prompt) {
-        super(PacketType.Play.Server.RESOURCE_PACK_SEND);
-
-        if (hash.length() > MAX_HASH_LENGTH) {
-            throw new IllegalArgumentException("Hash is too long (max " + MAX_HASH_LENGTH + ", was " + hash.length() + ")");
-        }
-
-        this.packId = packId;
-        this.url = url;
-        this.hash = hash;
-        this.required = required;
-        this.prompt = prompt;
-    }
-
-    @Override
-    public void read() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.packId = this.readUUID();
-        }
-
-        url = readString();
-        hash = readString(MAX_HASH_LENGTH);
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
-            required = readBoolean();
-            boolean hasPrompt = readBoolean();
-            if (hasPrompt) {
-                prompt = readComponent();
-            }
-        }
-    }
-
-    @Override
-    public void write() {
-        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
-            this.writeUUID(this.packId);
-        }
-
-        writeString(url);
-        writeString(hash, MAX_HASH_LENGTH);
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
-            writeBoolean(required);
-            writeBoolean(prompt != null);
-            if (prompt != null) {
-                writeComponent(prompt);
-            }
-        }
-    }
-
-    @Override
-    public void copy(WrapperPlayServerResourcePackSend wrapper) {
-        packId = wrapper.packId;
-        url = wrapper.url;
-        hash = wrapper.hash;
-        required = wrapper.required;
-        prompt = wrapper.prompt;
-    }
-
-    public UUID getPackId() {
-        return this.packId;
-    }
-
-    public void setPackId(UUID packId) {
-        this.packId = packId;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getHash() {
-        return hash;
-    }
-
-    public void setHash(String hash) {
-        this.hash = hash;
-    }
-
-    public boolean isRequired() {
-        return required;
-    }
-
-    public void setRequired(boolean required) {
-        this.required = required;
-    }
-
-    public Component getPrompt() {
-        return prompt;
+        super(ConnectionState.PLAY, packId, url, hash, required, prompt);
     }
 }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -24,7 +24,7 @@ import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.ExceptionUtil;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
+import com.github.retrooper.packetevents.wrapper.common.server.WrapperServerDisconnect;
 import io.github.retrooper.packetevents.injector.connection.ServerConnectionInitializer;
 import io.github.retrooper.packetevents.util.FoliaCompatUtil;
 import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
@@ -80,7 +80,7 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
 
             if (PacketEvents.getAPI().getSettings().isKickOnPacketExceptionEnabled()) {
                 try {
-                    user.sendPacket(new WrapperPlayServerDisconnect(Component.text("Invalid packet")));
+                    user.sendPacket(new WrapperServerDisconnect(ConnectionState.PLAY, Component.text("Invalid packet")));
                 } catch (Exception ignored) { // There may (?) be an exception if the player is in the wrong state...
                     // Do nothing.
                 }


### PR DESCRIPTION
This pull request is intended to make the code similar to Mojang code

I tried my best to avoid any API break, but some interactions require to change them completely (see breaking changes below)

### Additions

* Method to get `ConnectionState` from `PacketType`
* `CommonPacketWrapper` class, same has `PacketWrapper` but stores a `ConnectionState` to wrap different packets with the same structure but different protocol state
* Any wrapper previously covered by PacketEvents code as its common type (for example `WrapperClientPong` to replace `WrapperConfigClientPong` and `WrapperPlayClientPong`)
* Fallback ordinal value for `WrapperClientResourcePackStatus.Result`

### Changes

* All the wrappers replaced by its common wrapper type, now are marked as `Deprecated`

### Breaking changes

* `WrapperConfigClientResourcePackStatus` and `WrapperPlayClientResourcePackStatus` no longer have `Result` enum, use `WrapperClientResourcePackStatus.Result` instead

### Notes

* `WrapperServerDisconnect` can also replace `WrapperLoginServerDisconnect` but Mojang still maintain two separated classes for those packets
* `WrapperServerPing` can also create a wrapper for `WrapperPlayServerPing` on `CONFIGURATION` state