### PR TITLE
Fix UUID serialization on < 1.20.3 servers with Adventure 4.15+

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureReflectionUtil.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureReflectionUtil.java
@@ -70,8 +70,15 @@ public class AdventureReflectionUtil {
             final Object optionState;
             if (IS_4_15_0_OR_NEWER) {
                 // adventure >= v4.15; add option state for serializer construction
-                optionState = PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_16)
-                        ? JSONOptions.byDataVersion() : JSONOptions.byDataVersion().at(2525);
+                if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_16)) {
+                    if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20_3)) {
+                        optionState = JSONOptions.byDataVersion();
+                    } else {
+                        optionState = JSONOptions.byDataVersion().at(2526);
+                    }
+                } else {
+                    optionState = JSONOptions.byDataVersion().at(2525);
+                }
                 Method COMPONENT_SERIALIZER_CREATE_METHOD = Reflection.getMethod(COMPONENT_SERIALIZER, "create", OptionState.class, Gson.class);
                 COMPONENT_SERIALIZER_CREATE = gson -> invokeSafe(COMPONENT_SERIALIZER_CREATE_METHOD, optionState, gson);
             } else {


### PR DESCRIPTION
Looks like starting from 1.20.3 UUID in components are serialized by 4 integers array instread of String representation of uuid.

Currently PE uses 1.20.3+ behaviour for < 1.20.3 and >= 1.16 servers what causes clients to disconnect when they try to decode that uuid.

1.16.5 client log: https://pastebin.com/wVNPNrew
Some debug when PE reencodes OPEN_WINDOW packet (1.16.5 server):
![image](https://github.com/retrooper/packetevents/assets/8667294/5a4d2669-9671-40db-aa22-2cd0c13b5ee3)

Before this change:
```
read: {"insertion":"e4139279-52a5-4ea3-82eb-71fddba549d2","hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:chest_minecart","id":"e4139279-52a5-4ea3-82eb-71fddba549d2","name":{"translate":"entity.minecraft.chest_minecart"}}},"translate":"entity.minecraft.chest_minecart"}
write:{"insertion":"e4139279-52a5-4ea3-82eb-71fddba549d2","hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:chest_minecart","id":[-468479367,1386565283,-2098499075,-609924654],"name":{"translate":"entity.minecraft.chest_minecart"}}},"translate":"entity.minecraft.chest_minecart"}
```
After this change:
```
read: {"insertion":"e4139279-52a5-4ea3-82eb-71fddba549d2","hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:chest_minecart","id":"e4139279-52a5-4ea3-82eb-71fddba549d2","name":{"translate":"entity.minecraft.chest_minecart"}}},"translate":"entity.minecraft.chest_minecart"}
write:{"insertion":"e4139279-52a5-4ea3-82eb-71fddba549d2","hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:chest_minecart","id":"e4139279-52a5-4ea3-82eb-71fddba549d2","name":{"translate":"entity.minecraft.chest_minecart"}}},"translate":"entity.minecraft.chest_minecart"}
```


This change was only tested on 1.16.5 server with 1.16.5 client. 