### PR TITLE
Relocated entirety of net.kyori packages

### DIFF
--- a/bungeecord/build.gradle
+++ b/bungeecord/build.gradle
@@ -6,9 +6,7 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'net.kyori.adventure.text.serializer.gson', 'io.github.retrooper.packetevents.adventure.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'io.github.retrooper.packetevents.adventure.serializer.legacy'
-    relocate 'net.kyori.adventure.util.Codec', 'io.github.retrooper.packetevents.adventure.util.Codec'
+    relocate 'net.kyori', 'io.github.retrooper.packetevents.kyori'
     dependencies {
         exclude(dependency('com.google.code.gson:gson:2.8.0'))
     }

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -8,8 +8,7 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
 shadowJar {
-    relocate 'net.kyori.adventure.text.serializer.gson', 'io.github.retrooper.packetevents.adventure.serializer.gson'
-    relocate 'net.kyori.adventure.text.serializer.legacy', 'io.github.retrooper.packetevents.adventure.serializer.legacy'
+    relocate 'net.kyori', 'io.github.retrooper.packetevents.kyori'
     dependencies {
         exclude(dependency('com.google.code.gson:gson:.*'))
     }

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -9,9 +9,7 @@ repositories {
 }
 
 shadowJar {
-    relocate 'net.kyori.adventure.text.serializer.gson.legacyimpl',
-            'io.github.retrooper.packetevents.adventure.serializer.gson.legacyimpl'
-    relocate 'net.kyori.adventure.util.Codec', 'io.github.retrooper.packetevents.adventure.util.Codec'
+    relocate 'net.kyori', 'io.github.retrooper.packetevents.kyori'
 }
 
 dependencies {


### PR DESCRIPTION
Currently only a few of the `net.kyori` packages are relocated and it can/is causing incompatibilities with other plugins making use of other versions of adventure/MiniMessage.

Resolves #712 