### PR TITLE
Fixed: Paper Schedulers 0 delay handling

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/AsyncScheduler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/AsyncScheduler.java
@@ -107,11 +107,13 @@ public class AsyncScheduler {
      * @param plugin   Plugin which owns the specified task.
      * @param task     Specified task.
      * @param delay    The time delay to pass before the task should be executed.
-     * @param period   The time period between each task execution.
+     * @param period   The time period between each task execution. Any value less-than 1 is treated as 1.
      * @param timeUnit The time unit for the initial delay and period.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer<Object> task, long delay, long period, @NotNull TimeUnit timeUnit) {
+        if (period < 1) period = 1;
+
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> task.accept(null), convertTimeToTicks(delay, timeUnit), convertTimeToTicks(period, timeUnit)));
         }
@@ -131,12 +133,11 @@ public class AsyncScheduler {
      * @param plugin   Plugin which owns the specified task.
      * @param task     Specified task.
      * @param initialDelayTicks    The time delay in ticks to pass before the task should be executed.
-     * @param periodTicks   The time period in ticks between each task execution.
+     * @param periodTicks   The time period in ticks between each task execution. Any value less-than 1 is treated as 1.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer<Object> task, long initialDelayTicks, long periodTicks) {
-
-        if (initialDelayTicks < 1) initialDelayTicks = 1;
+        if (periodTicks < 1) periodTicks = 1;
 
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> task.accept(null), initialDelayTicks, periodTicks));

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/EntityScheduler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/EntityScheduler.java
@@ -54,11 +54,9 @@ public class EntityScheduler {
      * @param plugin  Plugin which owns the specified task.
      * @param run     The callback to run after the specified delay, may not be null.
      * @param retired Retire callback to run if the entity is retired before the run callback can be invoked, may be null.
-     * @param delay   The delay in ticks before the run callback is invoked. Any value less-than 1 is treated as 1.
+     * @param delay   The delay in ticks before the run callback is invoked.
      */
     public void execute(@NotNull Entity entity, @NotNull Plugin plugin, @NotNull Runnable run, @Nullable Runnable retired, long delay) {
-        if (delay < 1) delay = 1;
-
         if (!isFolia) {
             Bukkit.getScheduler().runTaskLater(plugin, run, delay);
             return;
@@ -152,11 +150,12 @@ public class EntityScheduler {
      * @param task              The task to execute
      * @param retired           Retire callback to run if the entity is retired before the run callback can be invoked, may be null.
      * @param initialDelayTicks The initial delay, in ticks before the method is invoked. Any value less-than 1 is treated as 1.
-     * @param periodTicks       The period, in ticks.
+     * @param periodTicks       The period, in ticks. Any value less-than 1 is treated as 1.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Entity entity, @NotNull Plugin plugin, @NotNull Consumer<Object> task, @Nullable Runnable retired, long initialDelayTicks, long periodTicks) {
         if (initialDelayTicks < 1) initialDelayTicks = 1;
+        if (periodTicks < 1) periodTicks = 1;
 
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(plugin, () -> task.accept(null), initialDelayTicks, periodTicks));

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/GlobalRegionScheduler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/GlobalRegionScheduler.java
@@ -130,11 +130,12 @@ public class GlobalRegionScheduler {
      * @param plugin            The plugin that owns the task
      * @param task              The task to execute
      * @param initialDelayTicks The initial delay, in ticks before the method is invoked. Any value less-than 1 is treated as 1.
-     * @param periodTicks       The period, in ticks.
+     * @param periodTicks       The period, in ticks. Any value less-than 1 is treated as 1.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer<Object> task, long initialDelayTicks, long periodTicks) {
         if (initialDelayTicks < 1) initialDelayTicks = 1;
+        if (periodTicks < 1) periodTicks = 1;
 
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(plugin, () -> task.accept(null), initialDelayTicks, periodTicks));

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/RegionScheduler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/folia/RegionScheduler.java
@@ -217,11 +217,12 @@ public class RegionScheduler {
      * @param chunkZ            The chunk Z coordinate of the region that owns the task
      * @param task              The task to execute
      * @param initialDelayTicks The initial delay, in ticks before the method is invoked. Any value less-than 1 is treated as 1.
-     * @param periodTicks       The period, in ticks.
+     * @param periodTicks       The period, in ticks. Any value less-than 1 is treated as 1.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer<Object> task, long initialDelayTicks, long periodTicks) {
         if (initialDelayTicks < 1) initialDelayTicks = 1;
+        if (periodTicks < 1) periodTicks = 1;
 
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(plugin, () -> task.accept(null), initialDelayTicks, periodTicks));
@@ -243,11 +244,12 @@ public class RegionScheduler {
      * @param location          The location at which the region executing should own
      * @param task              The task to execute
      * @param initialDelayTicks The initial delay, in ticks before the method is invoked. Any value less-than 1 is treated as 1.
-     * @param periodTicks       The period, in ticks.
+     * @param periodTicks       The period, in ticks. Any value less-than 1 is treated as 1.
      * @return {@link TaskWrapper} instance representing a wrapped task
      */
     public TaskWrapper runAtFixedRate(@NotNull Plugin plugin, @NotNull Location location, @NotNull Consumer<Object> task, long initialDelayTicks, long periodTicks) {
         if (initialDelayTicks < 1) initialDelayTicks = 1;
+        if (periodTicks < 1) periodTicks = 1;
 
         if (!isFolia) {
             return new TaskWrapper(Bukkit.getScheduler().runTaskTimer(plugin, () -> task.accept(null), initialDelayTicks, periodTicks));


### PR DESCRIPTION
Fixed a few schedulers that do not support a delay of 0 on either the initial or timed delay. (Gotta love their JavaDocs)