### PR TITLE
Work around 1.20.5 not sending known dimension types

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/InternalPacketListener.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/InternalPacketListener.java
@@ -144,17 +144,7 @@ public class InternalPacketListener extends PacketListenerAbstract {
             }
 
             // Update world height
-            NBTCompound dimension = user.getWorldNBT(joinGame.getDimension());
-            if (dimension != null) {
-                NBTCompound worldNBT = dimension.getCompoundTagOrNull("element");
-                if (worldNBT != null) {
-                    user.setMinWorldHeight(worldNBT.getNumberTagOrNull("min_y").getAsInt());
-                    user.setTotalWorldHeight(worldNBT.getNumberTagOrNull("height").getAsInt());
-                } else {
-                    PacketEvents.getAPI().getLogger().warning(
-                            "No data was sent for dimension " + dimension + " to " + user.getName());
-                }
-            }
+            user.switchDimensionType(joinGame.getServerVersion(), joinGame.getDimension());
         }
 
         // Respawn is used to switch dimensions
@@ -165,17 +155,7 @@ public class InternalPacketListener extends PacketListenerAbstract {
                 return; // Fixed world height, no tags are sent to the client
             }
 
-            NBTCompound dimension = user.getWorldNBT(respawn.getDimension());
-            if (dimension != null) {
-                NBTCompound worldNBT = dimension.getCompoundTagOrNull("element"); // This is 1.17+, it always sends the world name
-                if (worldNBT != null) {
-                    user.setMinWorldHeight(worldNBT.getNumberTagOrNull("min_y").getAsInt());
-                    user.setTotalWorldHeight(worldNBT.getNumberTagOrNull("height").getAsInt());
-                } else {
-                    PacketEvents.getAPI().getLogger().warning(
-                            "No data was sent for dimension " + dimension + " to " + user.getName());
-                }
-            }
+            user.switchDimensionType(respawn.getServerVersion(), respawn.getDimension());
         } else if (event.getPacketType() == PacketType.Play.Server.CONFIGURATION_START) {
             user.setEncoderState(ConnectionState.CONFIGURATION);
         } else if (event.getPacketType() == PacketType.Configuration.Server.CONFIGURATION_END) {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -265,6 +265,41 @@ public class User {
         this.totalWorldHeight = totalWorldHeight;
     }
 
+    public void switchDimensionType(ServerVersion version, Dimension dimension) {
+        NBTCompound dimensionData = this.getWorldNBT(dimension);
+        if (dimensionData != null) {
+            NBTCompound worldNBT = dimensionData.getCompoundTagOrNull("element");
+            if (worldNBT != null) {
+                this.setMinWorldHeight(worldNBT.getNumberTagOrNull("min_y").getAsInt());
+                this.setTotalWorldHeight(worldNBT.getNumberTagOrNull("height").getAsInt());
+                return;
+            } else {
+                this.setDefaultWorldHeights(version, dimension);
+            }
+        }
+        if (version.isOlderThan(ServerVersion.V_1_20_5)
+                || this.clientVersion.isOlderThan(ClientVersion.V_1_20_5)) {
+            // hide this warning on 1.20.5, as the server does no longer send
+            // vanilla datapack dimension type contents
+            //
+            // this 1.20.5 feature can be fully worked around with by clearing the
+            // known packs sent by the client to the server durings config phase
+            PacketEvents.getAPI().getLogger().warning(
+                    "No data was sent for dimension " + dimensionData + " to " + this.getName());
+        }
+    }
+
+    public void setDefaultWorldHeights(ServerVersion version, Dimension dimension) {
+        boolean extended = version.isNewerThanOrEquals(ServerVersion.V_1_18)
+                && "minecraft:overworld".equals(this.getWorldName(dimension));
+        this.setDefaultWorldHeights(extended);
+    }
+
+    public void setDefaultWorldHeights(boolean extended) {
+        this.minWorldHeight = extended ? -64 : 0;
+        this.totalWorldHeight = extended ? 256 + 128 : 256;
+    }
+
     public void setWorldNBT(NBTList<NBTCompound> worldNBT) {
         this.worldNBT = worldNBT.getTags();
     }
@@ -308,5 +343,22 @@ public class User {
             return this.getWorldNBT(dimensionName);
         }
         return this.getWorldNBT(dimension.getId());
+    }
+
+    public @Nullable String getWorldName(int worldId) {
+        if (this.worldNBT == null) {
+            return null;
+        }
+        for (NBTCompound element : this.worldNBT) {
+            if (element.getNumberTagOrNull("id").getAsInt() == worldId) {
+                return element.getStringTagValueOrNull("name");
+            }
+        }
+        return null;
+    }
+
+    public @Nullable String getWorldName(Dimension dimension) {
+        String dimensionName = dimension.getDimensionName();
+        return dimensionName.isEmpty() ? this.getWorldName(dimension.getId()) : dimensionName;
     }
 }


### PR DESCRIPTION
The server no longer sends known registries to the vanilla client. This causes packetevents to no longer receive dimension type information, so fallback to vanilla defaults as a workaround.

Tested to work in overworld, nether and end on 1.20.6 client and 1.20.4 client (with ViaVersion/ViaBackwards) on 1.20.6 and 1.20.4 server