### PR TITLE
Fix incorrect writing of Server Data packet 1.20.5+

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerServerData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerServerData.java
@@ -95,7 +95,7 @@ public class WrapperPlayServerServerData extends PacketWrapper<WrapperPlayServer
             writeBoolean(previewsChat);
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19_1)
-                && serverVersion.isOlderThanOrEquals(ServerVersion.V_1_20_5)) {
+                && serverVersion.isOlderThan(ServerVersion.V_1_20_5)) {
             writeBoolean(enforceSecureChat);
         }
     }


### PR DESCRIPTION
This fixes the client-side kick that happens moments after you join with 1.20.5/6:

```java
Internal Exception: io.netty.handler.codec.DecoderException: java.io.IOException: Packet play/clientbound/minecraft:server_data (class_7495) was larger than I expected, found 1 bytes extra whilst reading packet clientbound/minecraft:server_data
```
This error was discovered on velocity.