### PR TITLE
Fix Encryption Response packet wrapper write method for server versions between 1.19 and 1.19.2

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/client/WrapperLoginClientEncryptionResponse.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/client/WrapperLoginClientEncryptionResponse.java
@@ -71,10 +71,13 @@ public class WrapperLoginClientEncryptionResponse extends PacketWrapper<WrapperL
         writeByteArray(encryptedSharedSecret);
 
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)
-                && serverVersion.isOlderThanOrEquals(ServerVersion.V_1_19_2)
-                && saltSignature != null) {
-            writeBoolean(false);
-            writeSaltSignature(saltSignature);
+                && serverVersion.isOlderThanOrEquals(ServerVersion.V_1_19_2)) {
+            writeBoolean(saltSignature == null);
+            if(saltSignature != null) {
+                writeSaltSignature(saltSignature);
+            } else {
+                writeByteArray(encryptedVerifyToken);
+            }
         } else {
             writeByteArray(encryptedVerifyToken);
         }


### PR DESCRIPTION
When an Encryption Response packet is wrapped in server versions between 1.19 and 1.19.2, in some cases a disconnect occurs because the actual write method defined in the wrapper attempts to write the verification token in case the Salt Signature is null, regardless of the boolean value introduced in version 1.19 (and removed in version 1.19.3). I tested a build of this PR on a Velocity proxy and it worked, allowing me to set the Verify Token without causing a disconnection.

Fixes #770.