### PR TITLE
fixed entity id assign bug

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -713,8 +713,8 @@ public final class SpigotReflectionUtil {
                 AtomicInteger atomicInteger = (AtomicInteger) field.get(null);
                 return atomicInteger.incrementAndGet();
             } else {
-                int id = field.getInt(null) + 1;
-                field.set(null, id);
+                int id = field.getInt(null);
+                field.set(null, id + 1);
                 return id;
             }
         } catch (IllegalAccessException ex) {


### PR DESCRIPTION
As what I saw in NMS 1_8_R3, the entityCount first assigned then gets incremented, but in newer versions they migrated to AtomicInteger values in which they used the incrementAndGet() method which increments then gets the value. I discovered this when weird stuff starts happening, for example: NPC spawned but froze the player, in which I suspected about the entity id being the same on both NPC & player.
NMS code (entity constructor):
``` java
    public Entity(World world) {
        this.id = entityCount++;
[...]
````