### PR TITLE
Fix spigot particle conversion

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     api project(':netty-common')
     api(adventureDependencies)
 
-    compileOnly 'org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.viaversion:viaversion:4.5.0'
     compileOnly 'com.github.ProtocolSupport:ProtocolSupport:3d24efeda6'
 }


### PR DESCRIPTION
Fixes #775

---

Particles were internally rewritten by spigot to be based on the vanilla registry in [1.20.2 (last year)](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/67a52a64854b21060cfd6eb7ca8bb7c2cdf02d1b#src%2Fmain%2Fjava%2Forg%2Fbukkit%2Fcraftbukkit%2FCraftParticle.java?t=42)