### PR TITLE
Account for zero chunk data on unload chunk packet

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChunkData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChunkData.java
@@ -192,6 +192,9 @@ public class WrapperPlayServerChunkData extends PacketWrapper<WrapperPlayServerC
                 for (int i = 0; i < biomeDataBytes.length; i++) {
                     biomeDataBytes[i] = dataIn.readByte();
                 }
+            } else if (data.length == 0) {
+                // if cache-chunk-maps is enabled in paper, paper doesn't send any biome data on chunk unload
+                biomeDataBytes = data; // empty array
             } else {
                 biomeDataBytes = Arrays.copyOfRange(data, data.length - 256, data.length);
             }


### PR DESCRIPTION
Sent by Paper 1.8 if `cache-chunk-maps` is enabled in the paper config

Fixes #784 