### PR TITLE
Clear the buffer if the packet send event is canceled in Velocity and BungeeCord

### DIFF
--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -63,6 +63,8 @@ public class PacketEventsEncoder extends MessageToByteEncoder<ByteBuf> {
             if (doCompression) {
                 recompress(ctx, buffer);
             }
+        } else {
+            ByteBufHelper.clear(packetSendEvent.getByteBuf());
         }
         if (packetSendEvent.hasPostTasks()) {
             for (Runnable task : packetSendEvent.getPostTasks()) {

--- a/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -51,6 +51,8 @@ public class PacketEventsEncoder extends MessageToByteEncoder<ByteBuf> {
                 packetSendEvent.getLastUsedWrapper().write();
             }
             buffer.readerIndex(firstReaderIndex);
+        } else {
+            ByteBufHelper.clear(packetSendEvent.getByteBuf());
         }
         if (packetSendEvent.hasPostTasks()) {
             for (Runnable task : packetSendEvent.getPostTasks()) {


### PR DESCRIPTION
This fixes #788 (at least for me), although I'm not sure if this is the best way.