### PR TITLE
Fix various packet wrapper issues

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Node.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Node.java
@@ -16,9 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 package com.github.retrooper.packetevents.protocol.chat;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.chat.Parsers.Parser;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,20 +27,33 @@ import java.util.List;
 import java.util.Optional;
 
 public class Node {
+
     private byte flags;
     private List<Integer> children;
     private int redirectNodeIndex;
     private Optional<String> name;
-    private Optional<Integer> parserID;
+    private Optional<Parser> parser;
     private Optional<List<Object>> properties;
     private Optional<ResourceLocation> suggestionsType;
 
-    public Node(byte flags, List<Integer> children, int redirectNodeIndex, @Nullable String name, @Nullable Integer parserID, @Nullable List<Object> properties, @Nullable ResourceLocation suggestionsType) {
+    public Node(
+            byte flags, List<Integer> children, int redirectNodeIndex, @Nullable String name,
+            @Nullable Integer parserID, @Nullable List<Object> properties, @Nullable ResourceLocation suggestionsType
+    ) {
+        this(flags, children, redirectNodeIndex, name, parserID == null ? null : Parsers.getById(
+                        PacketEvents.getAPI().getServerManager().getVersion().toClientVersion(), parserID),
+                properties, suggestionsType);
+    }
+
+    public Node(
+            byte flags, List<Integer> children, int redirectNodeIndex, @Nullable String name, @Nullable Parser parser,
+            @Nullable List<Object> properties, @Nullable ResourceLocation suggestionsType
+    ) {
         this.flags = flags;
         this.children = children;
         this.redirectNodeIndex = redirectNodeIndex;
         this.name = Optional.ofNullable(name);
-        this.parserID = Optional.ofNullable(parserID);
+        this.parser = Optional.ofNullable(parser);
         this.properties = Optional.ofNullable(properties);
         this.suggestionsType = Optional.ofNullable(suggestionsType);
     }
@@ -76,12 +90,22 @@ public class Node {
         this.name = name;
     }
 
+    public Optional<Parser> getParser() {
+        return this.parser;
+    }
+
+    public void setParser(Optional<Parser> parser) {
+        this.parser = parser;
+    }
+
     public Optional<Integer> getParserID() {
-        return parserID;
+        return this.parser.map(parser -> parser.getId(PacketEvents.getAPI()
+                .getServerManager().getVersion().toClientVersion()));
     }
 
     public void setParserID(Optional<Integer> parserID) {
-        this.parserID = parserID;
+        this.parser = parserID.map(id -> Parsers.getById(PacketEvents.getAPI()
+                .getServerManager().getVersion().toClientVersion(), id));
     }
 
     public Optional<List<Object>> getProperties() {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Parsers.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Parsers.java
@@ -151,7 +151,9 @@ public class Parsers {
     public static final Parser COMPONENT = define("component", null, null);
     public static final Parser STYLE = define("style", null, null);
     public static final Parser MESSAGE = define("message", null, null);
-    public static final Parser NBT = define("nbt", null, null);
+    public static final Parser NBT_COMPOUND_TAG = define("nbt_compound_tag", null, null);
+    @Deprecated
+    public static final Parser NBT = NBT_COMPOUND_TAG;
     public static final Parser NBT_TAG = define("nbt_tag", null, null);
     public static final Parser NBT_PATH = define("nbt_path", null, null);
     public static final Parser OBJECTIVE = define("objective", null, null);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Parsers.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/chat/Parsers.java
@@ -172,10 +172,13 @@ public class Parsers {
     public static final Parser ITEM_SLOT = define("item_slot", null, null);
     public static final Parser ITEM_SLOTS = define("item_slots", null, null);
     public static final Parser RESOURCE_LOCATION = define("resource_location", null, null);
+    public static final Parser MOB_EFFECT = define("mob_effect", null, null);
     public static final Parser FUNCTION = define("function", null, null);
     public static final Parser ENTITY_ANCHOR = define("entity_anchor", null, null);
     public static final Parser INT_RANGE = define("int_range", null, null);
     public static final Parser FLOAT_RANGE = define("float_range", null, null);
+    public static final Parser ITEM_ENCHANTMENT = define("item_enchantment", null, null);
+    public static final Parser ENTITY_SUMMON = define("entity_summon", null, null);
     public static final Parser DIMENSION = define("dimension", null, null);
     public static final Parser GAMEMODE = define("gamemode", null, null);
     public static final Parser TIME = define("time",

--- a/api/src/main/java/com/github/retrooper/packetevents/resources/ResourceLocation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/resources/ResourceLocation.java
@@ -18,6 +18,8 @@
 
 package com.github.retrooper.packetevents.resources;
 
+import java.util.Objects;
+
 public class ResourceLocation {
     protected final String namespace;
     protected final String key;
@@ -46,6 +48,11 @@ public class ResourceLocation {
 
     public String getKey() {
         return key;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.namespace, this.key);
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -33,6 +33,7 @@ import com.github.retrooper.packetevents.protocol.chat.LastSeenMessages;
 import com.github.retrooper.packetevents.protocol.chat.MessageSignature;
 import com.github.retrooper.packetevents.protocol.chat.Node;
 import com.github.retrooper.packetevents.protocol.chat.Parsers;
+import com.github.retrooper.packetevents.protocol.chat.Parsers.Parser;
 import com.github.retrooper.packetevents.protocol.chat.RemoteChatSession;
 import com.github.retrooper.packetevents.protocol.chat.SignedCommandArgument;
 import com.github.retrooper.packetevents.protocol.chat.filter.FilterMask;
@@ -1247,16 +1248,18 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
 
         int redirectNodeIndex = ((flags & 0x08) != 0) ? readVarInt() : 0;
         if (nodeType == 2) {
-            String name = readString();
-            int parserID = readVarInt();
-            List<Object> properties = Parsers.getById(this.serverVersion.toClientVersion(), parserID)
-                    .readProperties(this).orElse(null);
-            ResourceLocation suggestionType = ((flags & 0x10) != 0) ? readIdentifier() : null;
-            return new Node(flags, children, redirectNodeIndex, name, parserID, properties, suggestionType);
+            String name = this.readString();
+            Parser parser = this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)
+                    ? this.readMappedEntity(Parsers::getById)
+                    : Parsers.getByName(this.readIdentifier().toString());
+            List<Object> properties = parser.readProperties(this).orElse(null);
+            ResourceLocation suggestionType = ((flags & 0x10) != 0) ? this.readIdentifier() : null;
+            return new Node(flags, children, redirectNodeIndex, name, parser, properties, suggestionType);
         } else if (nodeType == 1) {
-            return new Node(flags, children, redirectNodeIndex, readString(), null, null, null);
+            String name = this.readString();
+            return new Node(flags, children, redirectNodeIndex, name, (Parser) null, null, null);
         } else {
-            return new Node(flags, children, redirectNodeIndex, null, null, null, null);
+            return new Node(flags, children, redirectNodeIndex, null, (Parser) null, null, null);
         }
     }
 
@@ -1267,10 +1270,16 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
             writeVarInt(node.getRedirectNodeIndex());
         }
         node.getName().ifPresent(this::writeString);
-        node.getParserID().ifPresent(this::writeVarInt);
-        if (node.getProperties().isPresent()) {
-            Parsers.getById(this.serverVersion.toClientVersion(), node.getParserID().get())
-                    .writeProperties(this, node.getProperties().get());
+        if (node.getParser().isPresent()) {
+            Parser parser = node.getParser().get();
+            if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
+                this.writeMappedEntity(parser);
+            } else {
+                this.writeIdentifier(parser.getName());
+            }
+            if (node.getProperties().isPresent()) {
+                parser.writeProperties(this, node.getProperties().get());
+            }
         }
         node.getSuggestionsType().ifPresent(this::writeIdentifier);
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonCookieResponse.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonCookieResponse.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.wrapper.common.client;
 
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
@@ -31,7 +32,12 @@ public abstract class WrapperCommonCookieResponse<T extends WrapperCommonCookieR
     private ResourceLocation key;
     private byte @Nullable [] payload;
 
+    @Deprecated
     public WrapperCommonCookieResponse(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperCommonCookieResponse(PacketReceiveEvent event) {
         super(event);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientCookieResponse.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/client/WrapperConfigClientCookieResponse.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.wrapper.configuration.client;
 
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
@@ -26,7 +27,12 @@ import org.jetbrains.annotations.Nullable;
 
 public class WrapperConfigClientCookieResponse extends WrapperCommonCookieResponse<WrapperConfigClientCookieResponse> {
 
+    @Deprecated
     public WrapperConfigClientCookieResponse(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperConfigClientCookieResponse(PacketReceiveEvent event) {
         super(event);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/client/WrapperLoginClientCookieResponse.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/client/WrapperLoginClientCookieResponse.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.wrapper.login.client;
 
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
@@ -26,7 +27,12 @@ import org.jetbrains.annotations.Nullable;
 
 public class WrapperLoginClientCookieResponse extends WrapperCommonCookieResponse<WrapperLoginClientCookieResponse> {
 
+    @Deprecated
     public WrapperLoginClientCookieResponse(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperLoginClientCookieResponse(PacketReceiveEvent event) {
         super(event);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientCookieResponse.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientCookieResponse.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.wrapper.play.client;
 
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
@@ -26,7 +27,12 @@ import org.jetbrains.annotations.Nullable;
 
 public class WrapperPlayClientCookieResponse extends WrapperCommonCookieResponse<WrapperPlayClientCookieResponse> {
 
+    @Deprecated
     public WrapperPlayClientCookieResponse(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperPlayClientCookieResponse(PacketReceiveEvent event) {
         super(event);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntitySoundEffect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntitySoundEffect.java
@@ -27,6 +27,8 @@ import com.github.retrooper.packetevents.protocol.sound.SoundCategory;
 import com.github.retrooper.packetevents.protocol.sound.Sounds;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPlayServerEntitySoundEffect> {
 
     private Sound sound;
@@ -34,6 +36,7 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
     private int entityId;
     private float volume;
     private float pitch;
+    private long seed;
 
     public WrapperPlayServerEntitySoundEffect(PacketSendEvent event) {
         super(event);
@@ -45,12 +48,17 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
     }
 
     public WrapperPlayServerEntitySoundEffect(Sound sound, SoundCategory soundCategory, int entityId, float volume, float pitch) {
+        this(sound, soundCategory, entityId, volume, pitch, ThreadLocalRandom.current().nextLong());
+    }
+
+    public WrapperPlayServerEntitySoundEffect(Sound sound, SoundCategory soundCategory, int entityId, float volume, float pitch, long seed) {
         super(PacketType.Play.Server.ENTITY_SOUND_EFFECT);
         this.sound = sound;
         this.soundCategory = soundCategory;
         this.entityId = entityId;
         this.volume = volume;
         this.pitch = pitch;
+        this.seed = seed;
     }
 
     @Override
@@ -65,6 +73,9 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
         }
         else {
             pitch = readUnsignedByte() / 63.5F;
+        }
+        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
+            this.seed = this.readLong();
         }
     }
 
@@ -84,6 +95,9 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
         else {
             writeByte((int) (pitch * 63.5F));
         }
+        if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
+            this.writeLong(this.seed);
+        }
     }
 
     @Override
@@ -93,6 +107,7 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
         this.entityId = wrapper.entityId;
         this.volume = wrapper.volume;
         this.pitch = wrapper.pitch;
+        this.seed = wrapper.seed;
     }
 
     public Sound getSound() {
@@ -143,5 +158,13 @@ public class WrapperPlayServerEntitySoundEffect extends PacketWrapper<WrapperPla
 
     public void setPitch(float pitch) {
         this.pitch = pitch;
+    }
+
+    public long getSeed() {
+        return this.seed;
+    }
+
+    public void setSeed(long seed) {
+        this.seed = seed;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
@@ -46,7 +46,7 @@ public class WrapperPlayServerWorldBorderWarningReach extends PacketWrapper<Wrap
     }
 
     @Override
-    public void copy(WrapperPlayWorldBorderWarningReach packet) {
+    public void copy(WrapperPlayServerWorldBorderWarningReach packet) {
         warningBlocks = packet.warningBlocks;
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
@@ -22,7 +22,7 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
-public class WrapperPlayWorldBorderWarningReach extends PacketWrapper<WrapperPlayWorldBorderWarningReach> {
+public class WrapperPlayServerWorldBorderWarningReach extends PacketWrapper<WrapperPlayServerWorldBorderWarningReach> {
 
     private int warningBlocks;
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerWorldBorderWarningReach.java
@@ -26,11 +26,11 @@ public class WrapperPlayServerWorldBorderWarningReach extends PacketWrapper<Wrap
 
     private int warningBlocks;
 
-    public WrapperPlayWorldBorderWarningReach(PacketSendEvent event) {
+    public WrapperPlayServerWorldBorderWarningReach(PacketSendEvent event) {
         super(event);
     }
 
-    public WrapperPlayWorldBorderWarningReach(int warningBlocks) {
+    public WrapperPlayServerWorldBorderWarningReach(int warningBlocks) {
         super(PacketType.Play.Server.WORLD_BORDER_WARNING_REACH);
         this.warningBlocks = warningBlocks;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayWorldBorderWarningReach.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayWorldBorderWarningReach.java
@@ -18,11 +18,17 @@
 
 package com.github.retrooper.packetevents.wrapper.play.server;
 
+import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class WrapperPlayWorldBorderWarningReach extends PacketWrapper<WrapperPlayWorldBorderWarningReach> {
+
     private int warningBlocks;
+
+    public WrapperPlayWorldBorderWarningReach(PacketSendEvent event) {
+        super(event);
+    }
 
     public WrapperPlayWorldBorderWarningReach(int warningBlocks) {
         super(PacketType.Play.Server.WORLD_BORDER_WARNING_REACH);


### PR DESCRIPTION
Fixes #797 

---

## List of fixes

- missing seed in `WrapperPlayServerEntitySoundEffect`
- missing/wrong command argument parsers
- missing/wrong constructors for multiple wrappers
  - `WrapperConfigClientCookieResponse`
  - `WrapperLoginClientCookieResponse`
  - `WrapperPlayClientCookieResponse`
  - `WrapperPlayServerWorldBorderWarningReach`
- wrongly encoded sound category for <1.9 in `WrapperPlayServerSoundEffect`
- everything related to `WrapperPlayServerTags`