### PR TITLE
Fix map ItemStack decoding for rotation key

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemMapDecorations.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemMapDecorations.java
@@ -122,7 +122,7 @@ public class ItemMapDecorations {
             compound.setTag("type", new NBTString(decoration.type.getName().toString()));
             compound.setTag("x", new NBTDouble(decoration.x));
             compound.setTag("z", new NBTDouble(decoration.z));
-            compound.setTag("float", new NBTFloat(decoration.rotation));
+            compound.setTag("rotation", new NBTFloat(decoration.rotation));
         }
 
         public MapDecorationType getType() {


### PR DESCRIPTION
Fixes https://github.com/retrooper/packetevents/issues/810