### PR TITLE
Feat: Global Versioning

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -103,6 +103,10 @@ tasks {
         from(project.layout.buildDirectory.dir("mappings/generated").get())
     }
 
+    generateVersionsFile {
+        packageName = "com.github.retrooper.packetevents.util"
+    }
+
     test {
         useJUnitPlatform()
     }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     packetevents.`shadow-conventions`
     packetevents.`library-conventions`
     `mapping-compression`
+    `pe-version`
 }
 
 // papermc repo + disableAutoTargetJvm needed for mockbukkit

--- a/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
@@ -36,8 +36,8 @@ public abstract class PacketEventsAPI<T> {
     private static final PacketEventsSettings SETTINGS = new PacketEventsSettings();
     private static final UpdateChecker UPDATE_CHECKER = new UpdateChecker();
     private static final LogManager LOG_MANAGER = new LogManager();
+    private static final Logger LOGGER = Logger.getLogger(PacketEventsAPI.class.getName());
     private static final PEVersion VERSION = PEVersion.createFromPackageVersion();
-    private final Logger LOGGER = Logger.getLogger(PacketEventsAPI.class.getName());
 
     public EventManager getEventManager() {
         return EVENT_MANAGER;

--- a/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
@@ -27,6 +27,7 @@ import com.github.retrooper.packetevents.netty.NettyManager;
 import com.github.retrooper.packetevents.settings.PacketEventsSettings;
 import com.github.retrooper.packetevents.util.LogManager;
 import com.github.retrooper.packetevents.util.PEVersion;
+import com.github.retrooper.packetevents.util.PEVersions;
 import com.github.retrooper.packetevents.util.updatechecker.UpdateChecker;
 
 import java.util.logging.Logger;
@@ -37,7 +38,6 @@ public abstract class PacketEventsAPI<T> {
     private static final UpdateChecker UPDATE_CHECKER = new UpdateChecker();
     private static final LogManager LOG_MANAGER = new LogManager();
     private static final Logger LOGGER = Logger.getLogger(PacketEventsAPI.class.getName());
-    private static final PEVersion VERSION = PEVersion.createFromPackageVersion();
 
     public EventManager getEventManager() {
         return EVENT_MANAGER;
@@ -52,7 +52,7 @@ public abstract class PacketEventsAPI<T> {
     }
 
     public PEVersion getVersion() {
-        return VERSION;
+        return PEVersions.CURRENT;
     }
 
     public Logger getLogger() {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -247,4 +247,14 @@ public class PEVersion implements Comparable<PEVersion> {
     public String toString() {
         return major + "." + minor + "." + patch + (snapshot ? "-SNAPSHOT" : "");
     }
+
+    /**
+     * Converts the {@link PEVersion} to an array of version numbers.
+     *
+     * @return an array of version numbers.
+     */
+    @Deprecated
+    public int[] toArray() {
+        return new int[]{major, minor, patch};
+    }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -177,7 +177,7 @@ public class PEVersion implements Comparable<PEVersion> {
         int patchCompare = Integer.compare(this.patch, other.patch);
         if (patchCompare != 0) return patchCompare;
 
-        return Boolean.compare(other.snapshot, this.snapshot);
+        return Boolean.compare(this.snapshot, other.snapshot);
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -18,12 +18,9 @@
 
 package com.github.retrooper.packetevents.util;
 
-import com.github.retrooper.packetevents.PacketEvents;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
-import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * Represents a PacketEvents version using Semantic Versioning.
@@ -31,8 +28,6 @@ import java.util.logging.Logger;
  * Snapshots will always resolve to a newer version than the non-snapshot version if major, minor, and patch are the same.
  */
 public class PEVersion implements Comparable<PEVersion> {
-
-    public static final PEVersion UNKNOWN = new PEVersion(0, 0, 0);
 
     private final int major;
     private final int minor;
@@ -106,21 +101,6 @@ public class PEVersion implements Comparable<PEVersion> {
      */
     public static PEVersion fromString(@NotNull final String version) {
         return new PEVersion(version);
-    }
-
-    /**
-     * Creates a {@link PEVersion} instance from the package implementation version.
-     *
-     * @return a {@link PEVersion} instance.
-     */
-    public static PEVersion createFromPackageVersion() {
-        Optional<PEVersion> version = Optional.ofNullable(PacketEvents.class.getPackage().getImplementationVersion()).map(PEVersion::fromString);
-        if (!version.isPresent()) {
-            Logger logger = Logger.getLogger(PEVersion.class.getName());
-            logger.warning("[packetevents-version] Failed to retrieve the PacketEvents version from the package implementation version. Are you using a using a custom build?");
-        }
-
-        return version.orElse(UNKNOWN);
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -234,7 +234,7 @@ public class PEVersion implements Comparable<PEVersion> {
      * @return an array of version numbers.
      */
     @Deprecated
-    public int[] toArray() {
+    public int[] asArray() {
         return new int[]{major, minor, patch};
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/reflection/Reflection.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/reflection/Reflection.java
@@ -30,271 +30,265 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class Reflection {
-    //FIELDS
-    public static Field[] getFields(final Class<?> cls) {
-        if (cls == null) {
-            return new Field[0];
-        }
-        final Field[] declaredFields = cls.getDeclaredFields();
-        for (final Field f : declaredFields) {
-            f.setAccessible(true);
-        }
-        return declaredFields;
-    }
+	//FIELDS
+	public static Field[] getFields(final Class<?> cls) {
+		if (cls == null) {
+			return new Field[0];
+		}
+		final Field[] declaredFields = cls.getDeclaredFields();
+		for (final Field f : declaredFields) {
+			f.setAccessible(true);
+		}
+		return declaredFields;
+	}
 
-    public static Field getField(final Class<?> cls, final String name) {
-        if (cls == null) {
-            return null;
-        }
-        try {
-            final Field field = cls.getDeclaredField(name);
-            field.setAccessible(true);
-            return field;
-        } catch (NoSuchFieldException e) {
-            try {
-                final Field field = cls.getField(name);
-                field.setAccessible(true);
-                return field;
-            } catch (NoSuchFieldException e1) {
-                if (cls.getSuperclass() != null) {
-                    return getField(cls.getSuperclass(), name);
-                }
-            }
-        }
-        return null;
-    }
+	public static Field getField(final Class<?> cls, final String name) {
+		if (cls == null) {
+			return null;
+		}
+		try {
+			final Field field = cls.getDeclaredField(name);
+			field.setAccessible(true);
+			return field;
+		} catch (NoSuchFieldException e) {
+			if (cls.getSuperclass() != null) {
+				return getField(cls.getSuperclass(), name);
+			}
+		}
+		return null;
+	}
 
-    public static Field getField(final Class<?> cls, final Class<?> dataType, final int index) {
-        if (dataType == null || cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Field f : getFields(cls)) {
-            if (dataType.isAssignableFrom(f.getType())) {
-                if (currentIndex++ == index) {
-                    return f;
-                }
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getField(cls.getSuperclass(), dataType, index);
-        }
-        return null;
-    }
+	public static Field getField(final Class<?> cls, final Class<?> dataType, final int index) {
+		if (dataType == null || cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Field f : getFields(cls)) {
+			if (dataType.isAssignableFrom(f.getType())) {
+				if (currentIndex++ == index) {
+					return f;
+				}
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getField(cls.getSuperclass(), dataType, index);
+		}
+		return null;
+	}
 
-    public static Field getField(final Class<?> cls, final Class<?> dataType, final int index, boolean ignoreStatic) {
-        if (dataType == null || cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Field f : getFields(cls)) {
-            if (dataType.isAssignableFrom(f.getType()) && (!ignoreStatic || !Modifier.isStatic(f.getModifiers()))) {
-                if (currentIndex++ == index) {
-                    return f;
-                }
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getField(cls.getSuperclass(), dataType, index);
-        }
-        return null;
-    }
+	public static Field getField(final Class<?> cls, final Class<?> dataType, final int index, boolean ignoreStatic) {
+		if (dataType == null || cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Field f : getFields(cls)) {
+			if (dataType.isAssignableFrom(f.getType()) && (!ignoreStatic || !Modifier.isStatic(f.getModifiers()))) {
+				if (currentIndex++ == index) {
+					return f;
+				}
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getField(cls.getSuperclass(), dataType, index);
+		}
+		return null;
+	}
 
-    public static Field getField(final Class<?> cls, final int index) {
-        if (cls == null) {
-            return null;
-        }
-        try {
-            return getFields(cls)[index];
-        } catch (Exception ex) {
-            if (cls.getSuperclass() != null) {
-                return getFields(cls.getSuperclass())[index];
-            }
-        }
-        return null;
-    }
+	public static Field getField(final Class<?> cls, final int index) {
+		if (cls == null) {
+			return null;
+		}
+		try {
+			return getFields(cls)[index];
+		} catch (Exception ex) {
+			if (cls.getSuperclass() != null) {
+				return getFields(cls.getSuperclass())[index];
+			}
+		}
+		return null;
+	}
 
-    //METHODS
-    public static Method getMethod(final Class<?> cls, final String name, final Class<?>... params) {
-        if (cls == null) {
-            return null;
-        }
-        try {
-            final Method m = cls.getDeclaredMethod(name, params);
-            m.setAccessible(true);
-            return m;
-        } catch (NoSuchMethodException e) {
-            try {
-                final Method m = cls.getMethod(name, params);
-                m.setAccessible(true);
-                return m;
-            } catch (NoSuchMethodException e1) {
-                if (cls.getSuperclass() != null) {
-                    return getMethod(cls.getSuperclass(), name, params);
-                }
-            }
-        }
-        return null;
-    }
+	//METHODS
+	public static Method getMethod(final Class<?> cls, final String name, final Class<?>... params) {
+		if (cls == null) {
+			return null;
+		}
+		try {
+			final Method m = cls.getDeclaredMethod(name, params);
+			m.setAccessible(true);
+			return m;
+		} catch (NoSuchMethodException e) {
+			try {
+				final Method m = cls.getMethod(name, params);
+				m.setAccessible(true);
+				return m;
+			} catch (NoSuchMethodException e1) {
+				if (cls.getSuperclass() != null) {
+					return getMethod(cls.getSuperclass(), name, params);
+				}
+			}
+		}
+		return null;
+	}
 
-    public static Method getMethod(final Class<?> cls, final int index, final Class<?>... params) {
-        if (cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Method m : cls.getDeclaredMethods()) {
-            if ((params == null || Arrays.equals(m.getParameterTypes(), params)) && index == currentIndex++) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethod(cls.getSuperclass(), index, params);
-        }
-        return null;
-    }
+	public static Method getMethod(final Class<?> cls, final int index, final Class<?>... params) {
+		if (cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Method m : cls.getDeclaredMethods()) {
+			if ((params == null || Arrays.equals(m.getParameterTypes(), params)) && index == currentIndex++) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethod(cls.getSuperclass(), index, params);
+		}
+		return null;
+	}
 
-    public static Method getMethod(final Class<?> cls, final Class<?> returning, final int index, final Class<?>... params) {
-        if (cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Method m : cls.getDeclaredMethods()) {
-            if (Arrays.equals(m.getParameterTypes(), params)
-                    && (returning == null || m.getReturnType().equals(returning))
-                    && index == currentIndex++) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethod(cls.getSuperclass(), null, index, params);
-        }
-        return null;
-    }
+	public static Method getMethod(final Class<?> cls, final Class<?> returning, final int index, final Class<?>... params) {
+		if (cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Method m : cls.getDeclaredMethods()) {
+			if (Arrays.equals(m.getParameterTypes(), params)
+					&& (returning == null || m.getReturnType().equals(returning))
+					&& index == currentIndex++) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethod(cls.getSuperclass(), null, index, params);
+		}
+		return null;
+	}
 
-    public static Method getMethodExact(final Class<?> cls, final String name, Class<?> returning, Class<?>... params) {
-        if (cls == null) {
-            return null;
-        }
-        for (final Method m : cls.getDeclaredMethods()) {
-            if (m.getName().equals(name)
-                    && Arrays.equals(m.getParameterTypes(), params) &&
-                    (returning == null || m.getReturnType().equals(returning))) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethodExact(cls.getSuperclass(), name, null, params);
-        }
-        return null;
-    }
+	public static Method getMethodExact(final Class<?> cls, final String name, Class<?> returning, Class<?>... params) {
+		if (cls == null) {
+			return null;
+		}
+		for (final Method m : cls.getDeclaredMethods()) {
+			if (m.getName().equals(name)
+					&& Arrays.equals(m.getParameterTypes(), params) &&
+					(returning == null || m.getReturnType().equals(returning))) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethodExact(cls.getSuperclass(), name, null, params);
+		}
+		return null;
+	}
 
-    public static Method getMethod(final Class<?> cls, final String name, final int index) {
-        if (cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Method m : cls.getDeclaredMethods()) {
-            if (m.getName().equals(name) && index == currentIndex++) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethod(cls.getSuperclass(), name, index);
-        }
-        return null;
-    }
+	public static Method getMethod(final Class<?> cls, final String name, final int index) {
+		if (cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Method m : cls.getDeclaredMethods()) {
+			if (m.getName().equals(name) && index == currentIndex++) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethod(cls.getSuperclass(), name, index);
+		}
+		return null;
+	}
 
-    public static Method getMethod(final Class<?> cls, final Class<?> returning, final int index) {
-        if (cls == null) {
-            return null;
-        }
-        int currentIndex = 0;
-        for (final Method m : cls.getDeclaredMethods()) {
-            if ((returning == null || m.getReturnType().equals(returning)) && index == currentIndex++) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethod(cls.getSuperclass(), returning, index);
-        }
-        return null;
-    }
+	public static Method getMethod(final Class<?> cls, final Class<?> returning, final int index) {
+		if (cls == null) {
+			return null;
+		}
+		int currentIndex = 0;
+		for (final Method m : cls.getDeclaredMethods()) {
+			if ((returning == null || m.getReturnType().equals(returning)) && index == currentIndex++) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethod(cls.getSuperclass(), returning, index);
+		}
+		return null;
+	}
 
-    public static Method getMethodCheckContainsString(final Class<?> cls, final String nameContainsThisStr, final Class<?> returning) {
-        if (cls == null) {
-            return null;
-        }
-        for (Method m : cls.getDeclaredMethods()) {
-            if (m.getName().contains(nameContainsThisStr) && (returning == null || m.getReturnType().equals(returning))) {
-                m.setAccessible(true);
-                return m;
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            return getMethodCheckContainsString(cls.getSuperclass(), nameContainsThisStr, returning);
-        }
-        return null;
-    }
+	public static Method getMethodCheckContainsString(final Class<?> cls, final String nameContainsThisStr, final Class<?> returning) {
+		if (cls == null) {
+			return null;
+		}
+		for (Method m : cls.getDeclaredMethods()) {
+			if (m.getName().contains(nameContainsThisStr) && (returning == null || m.getReturnType().equals(returning))) {
+				m.setAccessible(true);
+				return m;
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			return getMethodCheckContainsString(cls.getSuperclass(), nameContainsThisStr, returning);
+		}
+		return null;
+	}
 
-    public static List<Method> getMethods(final Class<?> cls, final String name, final Class<?> returning) {
-        if (cls == null) {
-            return null;
-        }
-        final List<Method> methods = new ArrayList<>();
-        for (final Method m : cls.getDeclaredMethods()) {
-            if (m.getName().equals(name)
-                    && (returning == null || m.getReturnType().equals(returning))) {
-                m.setAccessible(true);
-                methods.add(m);
-            }
-        }
-        if (cls.getSuperclass() != null) {
-            methods.addAll(getMethods(cls.getSuperclass(), name, returning));
-        }
-        return methods;
-    }
+	public static List<Method> getMethods(final Class<?> cls, final String name, final Class<?> returning) {
+		if (cls == null) {
+			return null;
+		}
+		final List<Method> methods = new ArrayList<>();
+		for (final Method m : cls.getDeclaredMethods()) {
+			if (m.getName().equals(name)
+					&& (returning == null || m.getReturnType().equals(returning))) {
+				m.setAccessible(true);
+				methods.add(m);
+			}
+		}
+		if (cls.getSuperclass() != null) {
+			methods.addAll(getMethods(cls.getSuperclass(), name, returning));
+		}
+		return methods;
+	}
 
-    // CLASS
-    @Nullable
-    public static Class<?> getClassByNameWithoutException(final String name) {
-        try {
-            return Class.forName(name);
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
-    }
+	// CLASS
+	@Nullable
+	public static Class<?> getClassByNameWithoutException(final String name) {
+		try {
+			return Class.forName(name);
+		} catch (ClassNotFoundException e) {
+			return null;
+		}
+	}
 
-    // CONSTRUCTOR
-    public static Constructor<?> getConstructor(final Class<?> cls, final int index) {
-        if (cls == null) {
-            return null;
-        }
-        final Constructor<?> constructor = cls.getDeclaredConstructors()[index];
-        constructor.setAccessible(true);
-        return constructor;
-    }
+	// CONSTRUCTOR
+	public static Constructor<?> getConstructor(final Class<?> cls, final int index) {
+		if (cls == null) {
+			return null;
+		}
+		final Constructor<?> constructor = cls.getDeclaredConstructors()[index];
+		constructor.setAccessible(true);
+		return constructor;
+	}
 
-    public static Constructor<?> getConstructor(final Class<?> cls, final Class<?>... params) {
-        if (cls == null) {
-            return null;
-        }
-        try {
-            final Constructor<?> c = cls.getDeclaredConstructor(params);
-            c.setAccessible(true);
-            return c;
-        } catch (NoSuchMethodException e) {
-            try {
-                final Constructor<?> c = cls.getConstructor(params);
-                c.setAccessible(true);
-                return c;
-            } catch (NoSuchMethodException e1) {
-                return null;
-            }
-        }
-    }
+	public static Constructor<?> getConstructor(final Class<?> cls, final Class<?>... params) {
+		if (cls == null) {
+			return null;
+		}
+		try {
+			final Constructor<?> c = cls.getDeclaredConstructor(params);
+			c.setAccessible(true);
+			return c;
+		} catch (NoSuchMethodException e) {
+			try {
+				final Constructor<?> c = cls.getConstructor(params);
+				c.setAccessible(true);
+				return c;
+			} catch (NoSuchMethodException e1) {
+				return null;
+			}
+		}
+	}
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/updatechecker/UpdateChecker.java
@@ -59,7 +59,7 @@ public class UpdateChecker {
         PEVersion localVersion = PacketEvents.getAPI().getVersion();
         PEVersion newVersion;
         try {
-            newVersion = new PEVersion(checkLatestReleasedVersion());
+            newVersion = PEVersion.fromString(checkLatestReleasedVersion());
         } catch (Exception ex) {
             PacketEvents.getAPI().getLogManager().warn("Failed to check for updates. "
                     + (ex.getCause() != null ? ex.getCause().getClass().getName() + ": " + ex.getCause().getMessage() : ex.getMessage()));

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionPlugin.kt
@@ -2,6 +2,7 @@ package com.github.retrooper.version
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
@@ -10,9 +11,8 @@ class PEVersionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         val task = target.tasks.register<PEVersionTask>(PEVersionTask.TASK_NAME) {
-            group = target.rootProject.group.toString()
+            group = target.rootProject.name.toString()
 
-            packageName = "com.github.retrooper.packetevents.util"
             version = target.version.toString()
             outputDir = target.layout.buildDirectory.dir("generated/sources/src/java/main")
         }
@@ -20,7 +20,7 @@ class PEVersionPlugin : Plugin<Project> {
         target.afterEvaluate {
             val sourceSets = target.extensions.getByName<SourceSetContainer>("sourceSets")
 
-            sequenceOf("main", "test").forEach {
+            sequenceOf(SourceSet.MAIN_SOURCE_SET_NAME, SourceSet.TEST_SOURCE_SET_NAME).forEach {
                 sourceSets.getByName(it).java.srcDir(task.flatMap { it.outputDir })
             }
 

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionPlugin.kt
@@ -1,0 +1,31 @@
+package com.github.retrooper.version
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.register
+
+class PEVersionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val task = target.tasks.register<PEVersionTask>(PEVersionTask.TASK_NAME) {
+            group = target.rootProject.group.toString()
+
+            packageName = "com.github.retrooper.packetevents.util"
+            version = target.version.toString()
+            outputDir = target.layout.buildDirectory.dir("generated/sources/src/java/main")
+        }
+
+        target.afterEvaluate {
+            val sourceSets = target.extensions.getByName<SourceSetContainer>("sourceSets")
+
+            sequenceOf("main", "test").forEach {
+                sourceSets.getByName(it).java.srcDir(task.flatMap { it.outputDir })
+            }
+
+            task.get().generate()
+        }
+    }
+
+}

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
@@ -1,0 +1,75 @@
+package com.github.retrooper.version
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class PEVersionTask : DefaultTask() {
+
+    companion object {
+        const val TASK_NAME = "generateVersionsFile"
+    }
+
+    @get:Input
+    abstract var packageName: String
+
+    @get:Input
+    abstract var version: String
+
+    @get:OutputDirectory
+    abstract var outputDir: Provider<Directory>
+
+    @TaskAction
+    fun generate() {
+        val dir = outputDir.get().dir(packageName.replace('.', '/'))
+        dir.asFile.mkdirs()
+
+        val file = dir.file("PEVersions.java").asFile
+        if (!file.exists()) {
+            file.createNewFile()
+        }
+
+        val ver = Version.fromString(version)
+        logger.info("Generating PEVersions.java with version $ver")
+
+        file.writeText("""
+            package $packageName;
+            
+            public final class PEVersions {
+            
+                public static final String RAW = "$version";
+                public static final PEVersion CURRENT = new PEVersion(${ver.major}, ${ver.minor}, ${ver.patch}, ${ver.snapShot});
+                public static final PEVersion UNKNOWN = new PEVersion(0, 0, 0);
+                
+                private PEVersions() {
+                    throw new IllegalStateException();
+                }
+            }
+        """.trimIndent())
+    }
+
+    private data class Version(
+        val major: Int,
+        val minor: Int,
+        val patch: Int,
+        val snapShot: Boolean
+    ) {
+        companion object {
+            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(-SNAPSHOT)?""")
+
+            fun fromString(version: String): Version {
+                val match = REGEX.matchEntire(version) ?: throw IllegalArgumentException("Invalid version: $version")
+                return Version(
+                    match.groupValues[1].toInt(),
+                    match.groupValues[2].toInt(),
+                    match.groupValues[3].toInt(),
+                    match.groupValues[4].isNotEmpty()
+                )
+            }
+        }
+    }
+
+}

--- a/buildSrc/src/main/kotlin/packetevents.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.library-conventions.gradle.kts
@@ -142,7 +142,7 @@ publishing {
 
 // So that SNAPSHOT is always the latest SNAPSHOT
 configurations.all {
-    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
+    resolutionStrategy.cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
 }
 
 val taskNames = gradle.startParameter.taskNames

--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -7,12 +7,6 @@ plugins {
 }
 
 tasks {
-    jar {
-        manifest {
-            attributes["Implementation-Version"] = rootProject.version
-        }
-    }
-
     shadowJar {
         archiveFileName = "packetevents-${project.name}-${project.version}.jar"
         archiveClassifier = null
@@ -24,6 +18,10 @@ tasks {
         }
 
         mergeServiceFiles()
+
+        manifest {
+            attributes["Implementation-Version"] = rootProject.version
+        }
     }
 
     assemble {

--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -18,10 +18,6 @@ tasks {
         }
 
         mergeServiceFiles()
-
-        manifest {
-            attributes["Implementation-Version"] = rootProject.version
-        }
     }
 
     assemble {

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/pe-version.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/pe-version.properties
@@ -1,0 +1,1 @@
+implementation-class=com.github.retrooper.version.PEVersionPlugin

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
@@ -49,10 +49,10 @@ public class BungeePipelineInjector implements ChannelInjector {
 		ChannelHandler handlerInstance = null;
 		for (String channelName : channel.pipeline().names()) {
 			ChannelHandler handler = channel.pipeline().get(channelName);
+			if (handler == null) continue;
 			Field childHandlerField = Reflection.getField(handler.getClass(), "childHandler");
 			if (childHandlerField != null && childHandlerField.getType().isAssignableFrom(ChannelInitializer.class)) {
 				initializerField = childHandlerField;
-				initializerField.setAccessible(true);
 				handlerInstance = handler;
 			}
 		}

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
@@ -51,7 +51,7 @@ public class BungeePipelineInjector implements ChannelInjector {
 			ChannelHandler handler = channel.pipeline().get(channelName);
 			if (handler == null) continue;
 			Field childHandlerField = Reflection.getField(handler.getClass(), "childHandler");
-			if (childHandlerField != null && childHandlerField.getType().isAssignableFrom(ChannelInitializer.class)) {
+			if (childHandlerField != null) {
 				initializerField = childHandlerField;
 				handlerInstance = handler;
 			}
@@ -72,7 +72,7 @@ public class BungeePipelineInjector implements ChannelInjector {
 		};
 
 		try {
-			initializerField.set(handlerInstance, newInitializer);
+			finalInitializerField.set(handlerInstance, newInitializer);
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException(e);
 		}

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/BungeePipelineInjector.java
@@ -51,7 +51,8 @@ public class BungeePipelineInjector implements ChannelInjector {
             ChannelHandler handler = channel.pipeline().get(channelName);
             if (handler == null) continue;
             try {
-                Field f = handler.getClass().getField("childHandler");
+                Field f = handler.getClass().getDeclaredField("childHandler");
+                f.setAccessible(true);
                 if (f.getType().isAssignableFrom(ChannelInitializer.class)) {
                     handlerInstance = handler;
                     initializerField = f;
@@ -76,8 +77,10 @@ public class BungeePipelineInjector implements ChannelInjector {
         };
 
         try {
-            finalInitializerField.set(handlerInstance, newInitializer);
-        } catch (IllegalAccessException e) {
+            Field childHandlerField = handlerInstance.getClass().getDeclaredField("childHandler");
+            childHandlerField.setAccessible(true);
+            childHandlerField.set(handlerInstance, newInitializer);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
@@ -44,7 +44,7 @@ public class ServerChannelHandler extends ChannelInboundHandlerAdapter {
                 //Remove "." at the end.
                 stringVersion = stringVersion.substring(0, stringVersion.length() - 1);
             }
-            return new PEVersion(stringVersion);
+            return PEVersion.fromString(stringVersion);
         }
         return null;
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/manager/server/ServerManagerImpl.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/manager/server/ServerManagerImpl.java
@@ -37,13 +37,13 @@ public class ServerManagerImpl implements ServerManager {
         }
         //Our PEVersion class can parse this version and detect if it is a newer version than what is currently supported
         //and account for that properly
-        PEVersion version = new PEVersion(bukkitVersion.substring(0, bukkitVersion.indexOf("-")));
-        PEVersion latestVersion = new PEVersion(ServerVersion.getLatest().getReleaseName());
+        PEVersion version = PEVersion.fromString(bukkitVersion.substring(0, bukkitVersion.indexOf("-")));
+        PEVersion latestVersion = PEVersion.fromString(ServerVersion.getLatest().getReleaseName());
         if (version.isNewerThan(latestVersion)) {
             //We do not support this version yet, so let us warn the user
             plugin.getLogger().warning("[packetevents] We currently do not support the minecraft version "
-                    + version.toString() + ", so things might break. PacketEvents will behave as if the minecraft version were "
-                    + latestVersion.toString() + "!");
+                    + version + ", so things might break. PacketEvents will behave as if the minecraft version were "
+                    + latestVersion + "!");
             return ServerVersion.getLatest();
         }
         for (final ServerVersion val : ServerVersion.reversedValues()) {

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -878,9 +878,6 @@ public final class SpigotReflectionUtil {
 
     public static Object createPacketDataSerializer(Object byteBuf) {
         try {
-            if (REGISTRY_FRIENDLY_BYTE_BUF_CONSTRUCTOR != null) {
-                return REGISTRY_FRIENDLY_BYTE_BUF_CONSTRUCTOR.newInstance(byteBuf, getFrozenRegistryAccess());
-            }
             return NMS_PACKET_DATA_SERIALIZER_CONSTRUCTOR.newInstance(byteBuf);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -883,6 +883,9 @@ public final class SpigotReflectionUtil {
 
     public static Object createPacketDataSerializer(Object byteBuf) {
         try {
+            if (REGISTRY_FRIENDLY_BYTE_BUF_CONSTRUCTOR != null) {
+                return REGISTRY_FRIENDLY_BYTE_BUF_CONSTRUCTOR.newInstance(byteBuf, getFrozenRegistryAccess());
+            }
             return NMS_PACKET_DATA_SERIALIZER_CONSTRUCTOR.newInstance(byteBuf);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -138,6 +138,8 @@ public final class SpigotReflectionUtil {
 
     private static boolean PAPER_ENTITY_LOOKUP_EXISTS = false;
 
+    private static boolean IS_OBFUSCATED;
+
     //Cache entities right after we request/find them for faster search.
     public static Map<Integer, Entity> ENTITY_ID_CACHE = new MapMaker().weakValues().makeMap();
 
@@ -297,8 +299,6 @@ public final class SpigotReflectionUtil {
         PAPER_ENTITY_LOOKUP_EXISTS = Reflection.getField(WORLD_SERVER_CLASS, PAPER_ENTITY_LOOKUP_CLASS, 0) != null;
     }
 
-    private static boolean IS_OBFUSCATED;
-
     private static void initClasses() {
         // spigot / paper versions older than 1.20.5 use spigot mappings
         IS_OBFUSCATED = Reflection.getClassByNameWithoutException("net.minecraft.server.network.PlayerConnection") != null;
@@ -328,7 +328,11 @@ public final class SpigotReflectionUtil {
         if (V_1_17_OR_HIGHER) {
             LEVEL_ENTITY_GETTER_CLASS = getServerClass("world.level.entity.LevelEntityGetter", "");
             PERSISTENT_ENTITY_SECTION_MANAGER_CLASS = getServerClass("world.level.entity.PersistentEntitySectionManager", "");
-            PAPER_ENTITY_LOOKUP_CLASS = Reflection.getClassByNameWithoutException("io.papermc.paper.chunk.system.entity.EntityLookup");
+            PAPER_ENTITY_LOOKUP_CLASS = Reflection.getClassByNameWithoutException("ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup");
+            if (PAPER_ENTITY_LOOKUP_CLASS == null) {
+                //Older than 1.21 names this differently
+                PAPER_ENTITY_LOOKUP_CLASS = Reflection.getClassByNameWithoutException("io.papermc.paper.chunk.system.entity.EntityLookup");
+            }
         }
         DIMENSION_MANAGER_CLASS = getServerClass(IS_OBFUSCATED ? "world.level.dimension.DimensionManager" : "world.level.dimension.DimensionType", "DimensionManager");
         MOJANG_CODEC_CLASS = Reflection.getClassByNameWithoutException("com.mojang.serialization.Codec");

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -137,6 +137,7 @@ public final class SpigotReflectionUtil {
     private static Object DIMENSION_TYPE_REGISTRY_KEY;
 
     private static boolean PAPER_ENTITY_LOOKUP_EXISTS = false;
+    private static boolean PAPER_ENTITY_LOOKUP_LEGACY = false;
 
     private static boolean IS_OBFUSCATED;
 
@@ -297,6 +298,10 @@ public final class SpigotReflectionUtil {
         }
 
         PAPER_ENTITY_LOOKUP_EXISTS = Reflection.getField(WORLD_SERVER_CLASS, PAPER_ENTITY_LOOKUP_CLASS, 0) != null;
+        if (PAPER_ENTITY_LOOKUP_EXISTS) {
+            //It's not inside the Level class (NMS World) class, which is how it was on < 1.21 Paper
+            PAPER_ENTITY_LOOKUP_LEGACY = Reflection.getField(NMS_WORLD_CLASS, PAPER_ENTITY_LOOKUP_CLASS, 0) == null;
+        }
     }
 
     private static void initClasses() {
@@ -1034,6 +1039,10 @@ public final class SpigotReflectionUtil {
                 ReflectionObject reflectWorldServer = new ReflectionObject(worldServer);
                 Object levelEntityGetter;
                 if (PAPER_ENTITY_LOOKUP_EXISTS) {
+                    if (!PAPER_ENTITY_LOOKUP_LEGACY) {
+                        //Check in the correct class!
+                        reflectWorldServer = new ReflectionObject(worldServer, NMS_WORLD_CLASS);
+                    }
                     levelEntityGetter = reflectWorldServer.readObject(0, PAPER_ENTITY_LOOKUP_CLASS);
                 } else {
                     Object entitySectionManager = reflectWorldServer.readObject(0, PERSISTENT_ENTITY_SECTION_MANAGER_CLASS);
@@ -1095,6 +1104,10 @@ public final class SpigotReflectionUtil {
             ReflectionObject wrappedWorldServer = new ReflectionObject(worldServer);
             Object levelEntityGetter;
             if (PAPER_ENTITY_LOOKUP_EXISTS) {
+                if (!PAPER_ENTITY_LOOKUP_LEGACY) {
+                    //Check in the correct class!
+                    wrappedWorldServer = new ReflectionObject(worldServer, NMS_WORLD_CLASS);
+                }
                 levelEntityGetter = wrappedWorldServer.readObject(0, PAPER_ENTITY_LOOKUP_CLASS);
             } else {
                 Object persistentEntitySectionManager = wrappedWorldServer.readObject(0, PERSISTENT_ENTITY_SECTION_MANAGER_CLASS);


### PR DESCRIPTION
# PacketEvents Global Versioning

This PR introduces a global versioning system for the entire library, aiming to simplify version management by removing the need to change versions across multiple files and locations.

## PEVersion
The `PEVersion` class has been completely rewritten to improve its implementation and support for the `SNAPSHOT` tag. The new class implements `Comparable<PEVersion>` and incorporates proper versioning logic. The previous integer array has been replaced with four fields: `int major`, `int minor`, `int patch`, and `boolean snapshot`.

### Key Changes:
- **Deprecated Constructor:** The old constructor is marked as deprecated.
- **New Constructors:** Two new constructors have been added. One requires semantic versioning, and the other is an overloaded method defaulting `snapshot` to false. These constructors throw an `IllegalArgumentException` if the provided version isn't in semantic versioning format.
- **SNAPSHOT Handling:** The `-SNAPSHOT` suffix is optional and defaults to false if not present.
- **Javadoc Updates:** The existing Javadoc has been revised to reflect the new implementation, with links to relevant classes and deprecated methods pointing to their replacements.
- **Comparable Implementation:** The class now implements `Comparable<PEVersion>`, enhancing readability and understanding of the version comparison logic.

### Versioning Example
- `2.3.1-SNAPSHOT` < `3.2.0`
- `2.3.1` > `2.3.1-SNAPSHOT`

`SNAPSHOT` is treated as a pre-release, thus `2.3.1` is considered newer than `2.3.1-SNAPSHOT`.

## Resource Processor
To streamline updating platform-specific version files (`plugin.yml`, `bungee.yml`, etc.), a task has been added to the `packetevents.library-convention`. This task replaces the version variable in these files during compilation, removing the need for manual updates.

### Velocity Implementation:
- The previous `@Plugin` annotation, which generated a `velocity-plugin.json` at runtime, has been removed.
- The `velocity-plugin.json` has now been manually placed in the resources directory with the version variable to be overwritten during the build process.

## Build Source PEVersion Task / Plugin
Initially, we considered adding the project version to the JAR manifest, but this approach proved unsuitable when shading the library into other plugins, as the manifest would be lost.

### Solution:
- A version file is created within the final build to indicate the library's version, ensuring compatibility even when the library is shaded.
- A new task, `PEVersionTask`, has been implemented by @AbhigyaKrishna. This task, named `generateVersionsFile`, creates a `PEVersions` file during compilation, instantiating the `PEVersion` class with the provided version.

This global versioning system simplifies version management and ensures consistent versioning across the entire library.