### PR TITLE
Divide Color's int rgb by 255 when using for particle colors

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustColorTransitionData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustColorTransitionData.java
@@ -54,7 +54,7 @@ public class ParticleDustColorTransitionData extends ParticleData {
     }
 
     public ParticleDustColorTransitionData(float scale, Color start, Color end) {
-        this(scale, start.red(), start.green(), start.blue(), end.red(), end.green(), end.blue());
+        this(scale, start.red() / 255f, start.green() / 255f, start.blue() / 255f, end.red() / 255f, end.green() / 255f, end.blue() / 255f);
     }
 
     public float getScale() {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustData.java
@@ -43,7 +43,7 @@ public class ParticleDustData extends ParticleData {
     }
 
     public ParticleDustData(float scale, Color color) {
-        this(scale, color.red(), color.green(), color.blue());
+        this(scale, color.red() / 255f, color.green() / 255f, color.blue() / 255f);
     }
 
     public float getRed() {


### PR DESCRIPTION
Currently it'll use the int as is from Color, eg: `0 to 255`.
It should be a decimal from `0.0 to 1.0` as per https://wiki.vg/Particles