### PR TITLE
fix: Fixes NoSuchMethodError for GsonComponentSerializer on version 1.16.5

### DIFF
--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -11,9 +11,7 @@ tasks {
         archiveFileName = "packetevents-${project.name}-${project.version}.jar"
         archiveClassifier = null
 
-        relocate("net.kyori.adventure.text.serializer.gson", "io.github.retrooper.packetevents.adventure.serializer.gson")
-        relocate("net.kyori.adventure.text.serializer.json", "io.github.retrooper.packetevents.adventure.serializer.json")
-        relocate("net.kyori.adventure.text.serializer.legacy", "io.github.retrooper.packetevents.adventure.serializer.legacy")
+        relocate("net.kyori.adventure.text.serializer", "io.github.retrooper.packetevents.adventure.serializer")
         relocate("net.kyori.option", "io.github.retrooper.packetevents.adventure.option")
         dependencies {
             exclude(dependency("com.google.code.gson:gson:.*"))


### PR DESCRIPTION
Fixed NoSuchMethodError in GsonComponentSerializer due to older version of abstract classes in version 1.16.5

Ticket: #832