### PR TITLE
Have fromBukkitEntityType invoke getByLegacyId instead

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotConversionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotConversionUtil.java
@@ -94,7 +94,7 @@ public class SpigotConversionUtil {
             if (entityType.getTypeId() == -1) {
                 return null;
             }
-            return EntityTypes.getById(serverVersion.toClientVersion(), entityType.getTypeId());
+            return EntityTypes.getByLegacyId(serverVersion.toClientVersion(), entityType.getTypeId());
         }
     }
 


### PR DESCRIPTION
Currently it's invoking getById() which is 1.14+, should be getByLegacyId()