### PR TITLE
Fix: Netty Version not being properly converted to an PEVersion

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -33,7 +33,7 @@ tasks {
     // 1.17           = Java 16
     // 1.18 - 1.20.4  = Java 17
     // 1-20.5+        = Java 21
-    val version = "1.20.6"
+    val version = "1.21"
     val javaVersion = JavaLanguageVersion.of(21)
 
     val jvmArgsExternal = listOf(

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
@@ -29,21 +29,28 @@ import io.netty.util.Version;
 import java.util.Map;
 
 public class ServerChannelHandler extends ChannelInboundHandlerAdapter {
+    public static final PEVersion MODERN_NETTY_VERSION = new PEVersion(4, 1, 24);
     public static boolean CHECKED_NETTY_VERSION;
     public static PEVersion NETTY_VERSION;
-    public static final PEVersion MODERN_NETTY_VERSION = new PEVersion(4, 1, 24);
 
     private static PEVersion resolveNettyVersion() {
         Map<String, Version> nettyArtifacts = Version.identify();
         Version version = nettyArtifacts.getOrDefault("netty-common", nettyArtifacts.get("netty-all"));
         if (version != null) {
             String stringVersion = version.artifactVersion();
-            //Let us remove the ".Final" from the version by just removing any words (non numbers or dots)
+
+            // Remove the ".Final" from the version by just removing any words (non numbers or dots)
             stringVersion = stringVersion.replaceAll("[^\\d.]", "");
-            if (stringVersion.endsWith(".")) {
-                //Remove "." at the end.
-                stringVersion = stringVersion.substring(0, stringVersion.length() - 1);
+
+            // Make sure stringVersion only contains 3 values like 4.2.0 but not 4.2.0.2
+            String[] splitVersion = stringVersion.split("\\.");
+            if (splitVersion.length > 3) {
+                stringVersion = splitVersion[0] + "." + splitVersion[1] + "." + splitVersion[2];
             }
+
+            // If the string ends with a dot, remove it
+            stringVersion = stringVersion.endsWith(".") ? stringVersion.substring(0, stringVersion.length() - 1) : stringVersion;
+
             return PEVersion.fromString(stringVersion);
         }
         return null;


### PR DESCRIPTION
Make sure to handle NettyVersions properly as they don't follow semantic versioning.
This fixes the following issue:
![image](https://github.com/retrooper/packetevents/assets/70259613/3bac9a59-f696-47fe-af31-258b47d761c1)


PS. Bumped the runServer task to use Minecraft server version 1.21 while I was at it. 