### PR TITLE
Switch EventManager listenerSet to CopyOnWriteArraySet

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -23,7 +23,7 @@ import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Level;
 
 public class EventManager {
@@ -82,7 +82,7 @@ public class EventManager {
     public PacketListenerCommon registerListener(PacketListenerCommon listener) {
         Set<PacketListenerCommon> listenerSet = listenersMap.get(listener.getPriority());
         if (listenerSet == null) {
-            listenerSet = ConcurrentHashMap.newKeySet();
+            listenerSet = new CopyOnWriteArraySet<>();
         }
         listenerSet.add(listener);
         listenersMap.put(listener.getPriority(), listenerSet);


### PR DESCRIPTION
The current ConcurrentHashMap.newKeySet in EventManager can cause fairly significant overhead in thread usage.

The [CopyOnWriteArraySet](https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/util/concurrent/CopyOnWriteArraySet.html) is generally only preferred when you have a very small number of writes and a very high number of reads. The usage here is one of these cases, as it should be rather uncommon for plugins to remove packet listeners. On the other hand, this set is iterated over every single time a packet is sent, which is incredibly common.

I've tested this using Grim on a server that averages 60-80 concurrent players, and observed significantly lower netty thread usage.
I don't currently have the spark flame graph handy as I've had this change running for several months. I can replicate a spark report with this data if required.