### PR TITLE
Add current commit hash to project version

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -180,8 +180,8 @@ public class PEVersion implements Comparable<PEVersion> {
 
     /**
      * Gets the snapshot commit hash. May be of any length.
-     * Availability is not guaranteed.
-     * Additionally, its presence is not contingent on this being a snapshot version.
+     * Availability is not guaranteed since it is contingent on how the program was built.
+     * Generally speaking, the commit hash is only available if the version is a snapshot version.
      *
      * @return the snapshot commit hash, if available.
      */

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -283,7 +283,8 @@ public class PEVersion implements Comparable<PEVersion> {
 
     /**
      * Converts the {@link PEVersion} to an array of version numbers.
-     * @deprecated since {@link PEVersion} instances now always use Semantic Versioning.
+     * @deprecated since {@link PEVersion} instances now always use Semantic Versioning, and thus, returning an "amorphous" array,
+     * with no definitive size, seems redundant.
      * @return an array of version numbers.
      */
     @Deprecated

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -179,9 +179,9 @@ public class PEVersion implements Comparable<PEVersion> {
     }
 
     /**
-     * Gets the snapshot commit hash. May be of any length.
+     * Gets the snapshot commit hash of the PacketEvents snapshot version. May be of any length.
      * Availability is not guaranteed since it is contingent on how the program was built.
-     * Generally speaking, the commit hash is only available if the version is a snapshot version.
+     * Generally speaking, the commit hash can only be available if the PacketEvents version is a snapshot version.
      *
      * @return the snapshot commit hash, if available.
      */

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PEVersion.java
@@ -26,7 +26,9 @@ import java.util.Objects;
 /**
  * Represents a PacketEvents version using Semantic Versioning.
  * Supports version comparison, cloning, and provides a string representation.
- * Snapshots will always resolve to a newer version than the non-snapshot version if major, minor, and patch are the same.
+ * Snapshot versioning is also supported.
+ * Generally a snapshot version is published before the release version,
+ * and thus, is considered "older" than the release version.
  */
 public class PEVersion implements Comparable<PEVersion> {
 
@@ -178,8 +180,8 @@ public class PEVersion implements Comparable<PEVersion> {
 
     /**
      * Gets the snapshot commit hash. May be of any length.
-     * May always be present or absent, doesn't matter
-     * wether this is a snapshot version or not.
+     * Availability is not guaranteed.
+     * Additionally, its presence is not contingent on this being a snapshot version.
      *
      * @return the snapshot commit hash, if available.
      */
@@ -191,7 +193,7 @@ public class PEVersion implements Comparable<PEVersion> {
      * Compares this {@link PEVersion} with another {@link PEVersion}.
      *
      * @param other the other {@link PEVersion}.
-     * @return a negative integer, zero, or a positive integer as this version is less than,
+     * @return a negative integer, zero, or a positive integer as this version can be less than,
      * equal to, or greater than the specified version.
      */
     @Override
@@ -281,7 +283,7 @@ public class PEVersion implements Comparable<PEVersion> {
 
     /**
      * Converts the {@link PEVersion} to an array of version numbers.
-     *
+     * @deprecated since {@link PEVersion} instances now always use Semantic Versioning.
      * @return an array of version numbers.
      */
     @Deprecated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,28 @@
+import java.io.ByteArrayOutputStream
+
+// TODO UPDATE
+val fullVersion = "2.4.1"
+val snapshot = true
+
 group = "com.github.retrooper"
 description = rootProject.name
-version = "2.4.1-SNAPSHOT" //TODO UPDATE - ADD "-SNAPSHOT" if we are dealing with snapshot versions
+
+fun getVersionMeta(): String {
+    if (!snapshot) {
+        return ""
+    }
+    var commitHash = ""
+    if (file(".git").isDirectory) {
+        val stdout = ByteArrayOutputStream()
+        exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+            standardOutput = stdout
+        }
+        commitHash = "+${stdout.toString().trim()}"
+    }
+    return "$commitHash-SNAPSHOT"
+}
+version = "$fullVersion${getVersionMeta()}"
 
 tasks {
     wrapper {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,12 @@ val snapshot = true
 group = "com.github.retrooper"
 description = rootProject.name
 
-fun getVersionMeta(): String {
+fun getVersionMeta(includeHash: Boolean): String {
     if (!snapshot) {
         return ""
     }
     var commitHash = ""
-    if (file(".git").isDirectory) {
+    if (includeHash && file(".git").isDirectory) {
         val stdout = ByteArrayOutputStream()
         exec {
             commandLine("git", "rev-parse", "--short", "HEAD")
@@ -22,7 +22,8 @@ fun getVersionMeta(): String {
     }
     return "$commitHash-SNAPSHOT"
 }
-version = "$fullVersion${getVersionMeta()}"
+version = "$fullVersion${getVersionMeta(true)}"
+ext["versionNoHash"] = "$fullVersion${getVersionMeta(false)}"
 
 tasks {
     wrapper {
@@ -62,4 +63,10 @@ tasks {
     }
 
     defaultTasks("build")
+}
+
+allprojects {
+    tasks.withType<Jar> {
+        archiveVersion = rootProject.ext["versionNoHash"] as String
+    }
 }

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
@@ -61,7 +61,7 @@ abstract class PEVersionTask : DefaultTask() {
         val snapShot: Boolean
     ) {
         companion object {
-            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(-SNAPSHOT)?""")
+            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(?:\+[0-9a-f]{8,})?(-SNAPSHOT)?""")
 
             fun fromString(version: String): Version {
                 val match = REGEX.matchEntire(version) ?: throw IllegalArgumentException("Invalid version: $version")

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
@@ -44,7 +44,7 @@ abstract class PEVersionTask : DefaultTask() {
             public final class PEVersions {
             
                 public static final String RAW = "$version";
-                public static final PEVersion CURRENT = new PEVersion(${ver.major}, ${ver.minor}, ${ver.patch}, ${ver.snapShot});
+                public static final PEVersion CURRENT = new PEVersion(${ver.major}, ${ver.minor}, ${ver.patch}, "${ver.snapshotCommit}");
                 public static final PEVersion UNKNOWN = new PEVersion(0, 0, 0);
                 
                 private PEVersions() {
@@ -58,10 +58,10 @@ abstract class PEVersionTask : DefaultTask() {
         val major: Int,
         val minor: Int,
         val patch: Int,
-        val snapShot: Boolean
+        val snapshotCommit: String?
     ) {
         companion object {
-            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(?:\+[0-9a-f]+)?(-SNAPSHOT)?""")
+            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(?:\+([0-9a-f]+)-SNAPSHOT)?""")
 
             fun fromString(version: String): Version {
                 val match = REGEX.matchEntire(version) ?: throw IllegalArgumentException("Invalid version: $version")
@@ -69,7 +69,7 @@ abstract class PEVersionTask : DefaultTask() {
                     match.groupValues[1].toInt(),
                     match.groupValues[2].toInt(),
                     match.groupValues[3].toInt(),
-                    match.groupValues[4].isNotEmpty()
+                    match.groupValues[4].ifEmpty { null }
                 )
             }
         }

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
@@ -44,7 +44,7 @@ abstract class PEVersionTask : DefaultTask() {
             public final class PEVersions {
             
                 public static final String RAW = "$version";
-                public static final PEVersion CURRENT = new PEVersion(${ver.major}, ${ver.minor}, ${ver.patch}, "${ver.snapshotCommit}");
+                public static final PEVersion CURRENT = new PEVersion(${ver.major}, ${ver.minor}, ${ver.patch}, ${ver.quotedSnapshotCommit()});
                 public static final PEVersion UNKNOWN = new PEVersion(0, 0, 0);
                 
                 private PEVersions() {
@@ -72,6 +72,13 @@ abstract class PEVersionTask : DefaultTask() {
                     match.groupValues[4].ifEmpty { null }
                 )
             }
+        }
+
+        fun quotedSnapshotCommit(): String {
+            if (snapshotCommit == null) {
+                return "null"
+            }
+            return "\"$snapshotCommit\"";
         }
     }
 

--- a/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/version/PEVersionTask.kt
@@ -61,7 +61,7 @@ abstract class PEVersionTask : DefaultTask() {
         val snapShot: Boolean
     ) {
         companion object {
-            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(?:\+[0-9a-f]{8,})?(-SNAPSHOT)?""")
+            private val REGEX = Regex("""(\d+)\.(\d+)\.(\d+)(?:\+[0-9a-f]+)?(-SNAPSHOT)?""")
 
             fun fromString(version: String): Version {
                 val match = REGEX.matchEntire(version) ?: throw IllegalArgumentException("Invalid version: $version")

--- a/buildSrc/src/main/kotlin/packetevents.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.library-conventions.gradle.kts
@@ -54,7 +54,7 @@ publishing {
         create<MavenPublication>("shadow") {
             groupId = project.group as String
             artifactId = "packetevents-" + project.name
-            version = project.version as String
+            version = rootProject.ext["versionNoHash"] as String
 
             if (isShadow) {
                 artifact(project.tasks.withType<ShadowJar>().getByName("shadowJar").archiveFile)

--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 tasks {
     shadowJar {
-        archiveFileName = "packetevents-${project.name}-${project.version}.jar"
+        archiveFileName = "packetevents-${project.name}-${rootProject.ext["versionNoHash"]}.jar"
         archiveClassifier = null
 
         relocate("net.kyori.adventure.text.serializer", "io.github.retrooper.packetevents.adventure.serializer")

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -63,7 +63,10 @@ tasks {
         }
     }
 
-    remapJar {
-        archiveBaseName.set("${rootProject.name}-fabric")
+    sequenceOf(remapJar, remapSourcesJar).forEach {
+        it {
+            archiveBaseName = "${rootProject.name}-fabric"
+            archiveVersion = rootProject.ext["versionNoHash"] as String
+        }
     }
 }


### PR DESCRIPTION
Only added when version is a snapshot version, disables itself if no git directory is found

---

Shortly discussed [on discord](https://canary.discord.com/channels/721686193061888071/782010220305973270/1257279805486006273), this allows to see which packetevents build a user has installed