### PR TITLE
Fix reading/writing of item attribute modifier component in 1.21

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemAttributeModifiers.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemAttributeModifiers.java
@@ -18,10 +18,14 @@
 
 package com.github.retrooper.packetevents.protocol.component.builtin.item;
 
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.attribute.Attribute;
 import com.github.retrooper.packetevents.protocol.attribute.AttributeOperation;
 import com.github.retrooper.packetevents.protocol.attribute.Attributes;
+import com.github.retrooper.packetevents.resources.ResourceLocation;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes.PropertyModifier;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.List;
@@ -168,11 +172,16 @@ public class ItemAttributeModifiers {
 
     public static class Modifier {
 
-        private UUID id;
-        private String name;
+        private UUID id; // removed in 1.21
+        private String name; // ResourceLocation since 1.21
         private double value;
         private AttributeOperation operation;
 
+        public Modifier(ResourceLocation name, double value, AttributeOperation operation) {
+            this(PropertyModifier.generateSemiUniqueId(name), name.toString(), value, operation);
+        }
+
+        @ApiStatus.Obsolete
         public Modifier(UUID id, String name, double value, AttributeOperation operation) {
             this.id = id;
             this.name = name;
@@ -181,32 +190,56 @@ public class ItemAttributeModifiers {
         }
 
         public static Modifier read(PacketWrapper<?> wrapper) {
-            UUID id = wrapper.readUUID();
-            String name = wrapper.readString();
+            UUID id;
+            String name;
+            if (wrapper.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
+                ResourceLocation nameKey = wrapper.readIdentifier();
+                name = nameKey.toString();
+                id = PropertyModifier.generateSemiUniqueId(nameKey);
+            } else {
+                id = wrapper.readUUID();
+                name = wrapper.readString();
+            }
             double value = wrapper.readDouble();
             AttributeOperation operation = wrapper.readEnum(AttributeOperation.values());
             return new Modifier(id, name, value, operation);
         }
 
         public static void write(PacketWrapper<?> wrapper, Modifier modifier) {
-            wrapper.writeUUID(modifier.id);
-            wrapper.writeString(modifier.name);
+            if (wrapper.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_21)) {
+                wrapper.writeIdentifier(new ResourceLocation(modifier.name));
+            } else {
+                wrapper.writeUUID(modifier.id);
+                wrapper.writeString(modifier.name);
+            }
             wrapper.writeDouble(modifier.value);
             wrapper.writeEnum(modifier.operation);
         }
 
+        public ResourceLocation getNameKey() {
+            return new ResourceLocation(this.name);
+        }
+
+        public void setNameKey(ResourceLocation nameKey) {
+            this.name = nameKey.toString();
+        }
+
+        @ApiStatus.Obsolete
         public UUID getId() {
             return this.id;
         }
 
+        @ApiStatus.Obsolete
         public void setId(UUID id) {
             this.id = id;
         }
 
+        @ApiStatus.Obsolete
         public String getName() {
             return this.name;
         }
 
+        @ApiStatus.Obsolete
         public void setName(String name) {
             this.name = name;
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerUpdateAttributes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerUpdateAttributes.java
@@ -229,7 +229,8 @@ public class WrapperPlayServerUpdateAttributes extends PacketWrapper<WrapperPlay
             this.operation = operation;
         }
 
-        private static UUID generateSemiUniqueId(ResourceLocation name) {
+        @ApiStatus.Internal
+        public static UUID generateSemiUniqueId(ResourceLocation name) {
             String extendedName = "packetevents_" + name.toString();
             return UUID.nameUUIDFromBytes(extendedName.getBytes(StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
[Discussed on discord](https://canary.discord.com/channels/721686193061888071/755472595096174873/1260554092707713124)
Fixes #889 
[Discussed on discord a second time](https://canary.discord.com/channels/721686193061888071/844238390567370813/1261408601147445422)

---

Tested on 1.20.6 with `/give @s minecraft:acacia_boat[attribute_modifiers={show_in_tooltip:true,modifiers:[{type:"minecraft:generic.gravity",amount:-0.05,name:"test",uuid:[0,0,0,0],operation:add_value,slot:any}]}]`
Tested on 1.21 with `/give @s minecraft:acacia_boat[attribute_modifiers={show_in_tooltip:true,modifiers:[{type:"minecraft:generic.gravity",amount:-0.05,id:"test",operation:add_value,slot:any}]}]`