### PR TITLE
Add 1.21.1 version support

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/server/ServerVersion.java
@@ -49,7 +49,8 @@ public enum ServerVersion {
     V_1_19(759), V_1_19_1(760), V_1_19_2(760), V_1_19_3(761), V_1_19_4(762),
     //1.20 and 1.20.1 have the same protocol version. 1.20.3 and 1.20.4 have the same protocol version. 1.20.5 and 1.20.6 have the same protocol version
     V_1_20(763), V_1_20_1(763), V_1_20_2(764), V_1_20_3(765), V_1_20_4(765), V_1_20_5(766), V_1_20_6(766),
-    V_1_21(767),
+    //1.21 and 1.21.1 have the same protocol version
+    V_1_21(767), V_1_21_1(767),
     //TODO UPDATE Add server version constant
     ERROR(-1, true);
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/ClientVersion.java
@@ -95,7 +95,10 @@ public enum ClientVersion {
      * 1.20.5 and 1.20.6 have the same protocol version.
      */
     V_1_20_5(766),
-  
+
+    /**
+     * 1.21 and 1.21.1 have the same protocol version.
+     */
     V_1_21(767),
     //TODO UPDATE Add new protocol version field
 


### PR DESCRIPTION
Nothing changed on the network, 1.21.1 only fixed some server-related crashes related to command argument parsing and block entities