### PR TITLE
Refactor NAMED_SOUND_EFFECT to CUSTOM_SOUND_EFFECT as SOUND_EFFECT is doing the work of NAMED_SOUND_EFFECT

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
@@ -753,7 +753,7 @@ public final class PacketType {
             SCULK_VIBRATION_SIGNAL,
             ACKNOWLEDGE_PLAYER_DIGGING,
             CHAT_PREVIEW_PACKET,
-            NAMED_SOUND_EFFECT,
+            CUSTOM_SOUND_EFFECT,
             PLAYER_CHAT_HEADER,
             PLAYER_INFO,
             DISPLAY_CHAT_PREVIEW,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_12.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_12.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_12 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_12_1.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_12_1.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_12_1 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_13.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_13.java
@@ -48,7 +48,7 @@ public enum ClientboundPacketType_1_13 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_14.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_14.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_14 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_14_4.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_14_4.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_14_4 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_15.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_15.java
@@ -45,7 +45,7 @@ public enum ClientboundPacketType_1_15 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_15_2.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_15_2.java
@@ -50,7 +50,7 @@ public enum ClientboundPacketType_1_15_2 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_16.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_16.java
@@ -48,7 +48,7 @@ public enum ClientboundPacketType_1_16 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_16_2.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_16_2.java
@@ -43,7 +43,7 @@ public enum ClientboundPacketType_1_16_2 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_17.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_17.java
@@ -55,7 +55,7 @@ public enum ClientboundPacketType_1_17 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_18.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_18.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_18 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19.java
@@ -58,7 +58,7 @@ public enum ClientboundPacketType_1_19 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19_1.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19_1.java
@@ -62,7 +62,7 @@ public enum ClientboundPacketType_1_19_1 {
     CUSTOM_CHAT_COMPLETIONS,
 
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
 
     //Added in 1.19.1
     DELETE_CHAT,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19_3.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_19_3.java
@@ -64,7 +64,7 @@ public enum ClientboundPacketType_1_19_3 {
     PLUGIN_MESSAGE,
 
     //Removed in 1.19.3
-    //NAMED_SOUND_EFFECT,
+    //CUSTOM_SOUND_EFFECT,
 
     //Added in 1.19.1
     DELETE_CHAT,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_9.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_9.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_9 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_9_3.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/clientbound/ClientboundPacketType_1_9_3.java
@@ -44,7 +44,7 @@ public enum ClientboundPacketType_1_9_3 {
     SET_SLOT,
     SET_COOLDOWN,
     PLUGIN_MESSAGE,
-    NAMED_SOUND_EFFECT,
+    CUSTOM_SOUND_EFFECT,
     DISCONNECT,
     ENTITY_STATUS,
     EXPLOSION,


### PR DESCRIPTION
It'd be nice if we could rename `SOUND_EFFECT` and the wrapper to NAMED_SOUND_EFFECT, but that'd break existing usages.