### PR TITLE
Fix compatibility with adventure versions older than 4.13.0

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -163,14 +163,17 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
         if (text != null) {
             builder = Component.text().content(text);
         } else if (translate != null) {
+            TranslatableComponent.Builder i18nBuilder;
+            builder = i18nBuilder = Component.translatable().key(translate);
             if (translateWith != null) {
                 if (BackwardCompatUtil.IS_4_15_0_OR_NEWER) {
-                    builder = Component.translatable().key(translate).fallback(translateFallback).arguments(translateWith);
+                    i18nBuilder.arguments(translateWith);
                 } else {
-                    builder = Component.translatable().key(translate).fallback(translateFallback).args(translateWith);
+                    i18nBuilder.args(translateWith);
                 }
-            } else {
-                builder = Component.translatable().key(translate).fallback(translateFallback);
+            }
+            if (BackwardCompatUtil.IS_4_13_0_OR_NEWER) {
+                i18nBuilder.fallback(translateFallback);
             }
         } else if (score != null) {
             builder = Component.score()
@@ -230,9 +233,11 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             writer.writeUTF("translate", ((TranslatableComponent) component).key());
 
             // translation fallback
-            String fallback = ((TranslatableComponent) component).fallback();
-            if (fallback != null) {
-                writer.writeUTF("fallback", fallback);
+            if (BackwardCompatUtil.IS_4_13_0_OR_NEWER) {
+                String fallback = ((TranslatableComponent) component).fallback();
+                if (fallback != null) {
+                    writer.writeUTF("fallback", fallback);
+                }
             }
 
             // translation arguments

--- a/patch/adventure-text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/BackwardCompatUtil.java
+++ b/patch/adventure-text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/BackwardCompatUtil.java
@@ -31,10 +31,20 @@ import java.util.UUID;
 
 public final class BackwardCompatUtil {
 
+    public static final boolean IS_4_13_0_OR_NEWER;
     public static final boolean IS_4_15_0_OR_NEWER;
     public static final boolean IS_4_17_0_OR_NEWER;
 
     static {
+        boolean is4_13_0OrNewer = false;
+        try {
+            // translatable fallback support was added in 4.13.0
+            Component.translatable().fallback("");
+            is4_13_0OrNewer = true;
+        } catch (Throwable ignored) {
+        }
+        IS_4_13_0_OR_NEWER = is4_13_0OrNewer;
+
         boolean is4_15_0OrNewer = false;
         try {
             Component.translatable().arguments(Component.empty()); // TranslatableComponent#arguments method was added in 4.15.0


### PR DESCRIPTION
Translation fallback methods didn't exist before

Fixes https://github.com/retrooper/packetevents/issues/915