### PR TITLE
Fix 1.8< clients not having Reduced Debug Info.

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerJoinGame.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerJoinGame.java
@@ -301,7 +301,9 @@ public class WrapperPlayServerJoinGame extends PacketWrapper<WrapperPlayServerJo
             if (v1_14) {
                 viewDistance = readVarInt();
             }
-            reducedDebugInfo = readBoolean();
+            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+                reducedDebugInfo = readBoolean();
+            }
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15)) {
                 enableRespawnScreen = readBoolean();
             }
@@ -400,7 +402,9 @@ public class WrapperPlayServerJoinGame extends PacketWrapper<WrapperPlayServerJo
             if (v1_14) {
                 writeVarInt(viewDistance);
             }
-            writeBoolean(reducedDebugInfo);
+            if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
+                writeBoolean(reducedDebugInfo);
+            }
             if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_15)) {
                 writeBoolean(enableRespawnScreen);
             }


### PR DESCRIPTION
Fixes error with players joining on 1.7 not having reduced debug info field.

Wiki.vg Links:
1.7 - https://wiki.vg/index.php?title=Protocol&oldid=6003#Join_Game
1.8 - https://wiki.vg/index.php?title=Protocol&oldid=7368#Join_Game
