### PR TITLE
Use global synchronized registries as fallback

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of packetevents - https://github.com/retrooper/packetevents
- * Copyright (C) 2022 retrooper and contributors
+ * Copyright (C) 2024 retrooper and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@ import com.github.retrooper.packetevents.protocol.chat.ChatTypes;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessageLegacy;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage_v1_16;
-import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
 import com.github.retrooper.packetevents.protocol.nbt.NBTList;
 import com.github.retrooper.packetevents.protocol.world.Dimension;
@@ -36,6 +35,7 @@ import com.github.retrooper.packetevents.protocol.world.dimension.DimensionTypes
 import com.github.retrooper.packetevents.resources.ResourceLocation;
 import com.github.retrooper.packetevents.util.adventure.AdventureSerializer;
 import com.github.retrooper.packetevents.util.mappings.IRegistry;
+import com.github.retrooper.packetevents.util.mappings.IRegistryHolder;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChatMessage;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerCloseWindow;
@@ -53,7 +53,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class User {
+public class User implements IRegistryHolder {
+
     private final Object channel;
     private ConnectionState decoderState;
     private ConnectionState encoderState;
@@ -75,19 +76,13 @@ public class User {
     }
 
     @ApiStatus.Internal
-    @SuppressWarnings("unchecked") // should be fine
-    public <T extends MappedEntity> IRegistry<T> getUserRegistryOrFallback(IRegistry<T> fallbackRegistry) {
-        IRegistry<?> replacedRegistry = this.registries.get(fallbackRegistry.getRegistryKey());
-        return replacedRegistry != null ? (IRegistry<T>) replacedRegistry : fallbackRegistry;
-    }
-
-    @ApiStatus.Internal
-    public IRegistry<?> getUserRegistry(ResourceLocation registryKey) {
+    @Override
+    public @Nullable IRegistry<?> getRegistry(ResourceLocation registryKey, ClientVersion version) {
         return this.registries.get(registryKey);
     }
 
     @ApiStatus.Internal
-    public void putUserRegistry(IRegistry<?> registry) {
+    public void putRegistry(IRegistry<?> registry) {
         this.registries.put(registry.getRegistryKey(), registry);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/Dimension.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/Dimension.java
@@ -102,7 +102,7 @@ public class Dimension {
     public com.github.retrooper.packetevents.protocol.world.dimension.DimensionType asDimensionType(
             @Nullable User user, @Nullable ClientVersion version) {
         IRegistry<com.github.retrooper.packetevents.protocol.world.dimension.DimensionType> registry = user != null
-                ? user.getUserRegistryOrFallback(DimensionTypes.getRegistry()) : DimensionTypes.getRegistry();
+                ? user.getRegistryOr(DimensionTypes.getRegistry()) : DimensionTypes.getRegistry();
         String dimName = this.getDimensionName();
         if (!dimName.isEmpty()) {
             return registry.getByName(new ResourceLocation(dimName));

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/GlobalRegistryHolder.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/GlobalRegistryHolder.java
@@ -18,43 +18,32 @@
 
 package com.github.retrooper.packetevents.util.mappings;
 
-import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
+import com.github.retrooper.packetevents.util.mappings.SynchronizedRegistriesHandler.RegistryEntry;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.function.BiFunction;
+@ApiStatus.Internal
+public final class GlobalRegistryHolder implements IRegistryHolder {
 
-public interface IRegistry<T extends MappedEntity> extends BiFunction<ClientVersion, Integer, T> {
+    public static final IRegistryHolder INSTANCE = new GlobalRegistryHolder();
 
-    default @Nullable T getByName(ResourceLocation name) {
-        return this.getByName(name.toString());
+    private GlobalRegistryHolder() {
     }
 
-    @Nullable
-    T getByName(String name);
-
-    @Nullable
-    T getById(ClientVersion version, int id);
-
-    default int getId(String entityName, ClientVersion version) {
-        return this.getId(this.getByName(entityName), version);
+    public static Object getGlobalRegistryCacheKey(@Nullable User user, ClientVersion version) {
+        return version; // global registries, only depends on packet version
     }
-
-    int getId(MappedEntity entity, ClientVersion version);
-
-    /**
-     * Returns an immutable view of the registry entries.
-     *
-     * @return Registry entries
-     */
-    Collection<T> getEntries();
-
-    ResourceLocation getRegistryKey();
 
     @Override
-    default T apply(ClientVersion version, Integer id) {
-        return this.getById(version, id);
+    public @Nullable IRegistry<?> getRegistry(ResourceLocation registryKey, ClientVersion version) {
+        RegistryEntry<?> registryEntry = SynchronizedRegistriesHandler.getRegistryEntry(registryKey);
+        if (registryEntry == null) {
+            return null;
+        }
+        Object cacheKey = getGlobalRegistryCacheKey(null, version);
+        return registryEntry.getSyncedRegistry(cacheKey);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/IRegistryHolder.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/IRegistryHolder.java
@@ -18,43 +18,29 @@
 
 package com.github.retrooper.packetevents.util.mappings;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.function.BiFunction;
+@ApiStatus.Internal
+public interface IRegistryHolder {
 
-public interface IRegistry<T extends MappedEntity> extends BiFunction<ClientVersion, Integer, T> {
-
-    default @Nullable T getByName(ResourceLocation name) {
-        return this.getByName(name.toString());
+    default <T extends MappedEntity> IRegistry<T> getRegistryOr(IRegistry<T> fallbackRegistry) {
+        return this.getRegistryOr(fallbackRegistry, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
     }
 
-    @Nullable
-    T getByName(String name);
-
-    @Nullable
-    T getById(ClientVersion version, int id);
-
-    default int getId(String entityName, ClientVersion version) {
-        return this.getId(this.getByName(entityName), version);
+    @SuppressWarnings("unchecked") // should be fine
+    default <T extends MappedEntity> IRegistry<T> getRegistryOr(IRegistry<T> fallbackRegistry, ClientVersion version) {
+        IRegistry<?> replacedRegistry = this.getRegistry(fallbackRegistry.getRegistryKey(), version);
+        return replacedRegistry != null ? (IRegistry<T>) replacedRegistry : fallbackRegistry;
     }
 
-    int getId(MappedEntity entity, ClientVersion version);
-
-    /**
-     * Returns an immutable view of the registry entries.
-     *
-     * @return Registry entries
-     */
-    Collection<T> getEntries();
-
-    ResourceLocation getRegistryKey();
-
-    @Override
-    default T apply(ClientVersion version, Integer id) {
-        return this.getById(version, id);
+    default @Nullable IRegistry<?> getRegistry(ResourceLocation registryKey) {
+        return this.getRegistry(registryKey, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion());
     }
+
+    @Nullable IRegistry<?> getRegistry(ResourceLocation registryKey, ClientVersion version);
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SimpleRegistry.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SimpleRegistry.java
@@ -18,18 +18,15 @@
 
 package com.github.retrooper.packetevents.util.mappings;
 
-import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
-import com.github.retrooper.packetevents.wrapper.configuration.server.WrapperConfigServerRegistryData.RegistryElement;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public final class SimpleRegistry<T extends MappedEntity> implements IRegistry<T> {
@@ -92,5 +89,10 @@ public final class SimpleRegistry<T extends MappedEntity> implements IRegistry<T
     @Override
     public ResourceLocation getRegistryKey() {
         return this.registryKey;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleRegistry[" + this.registryKey + ']';
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SynchronizedRegistriesHandler.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SynchronizedRegistriesHandler.java
@@ -82,6 +82,10 @@ public final class SynchronizedRegistriesHandler {
     private SynchronizedRegistriesHandler() {
     }
 
+    public static @Nullable RegistryEntry<?> getRegistryEntry(ResourceLocation registryKey) {
+        return REGISTRY_KEYS.get(registryKey);
+    }
+
     public static void handleRegistry(
             User user, ClientVersion version,
             ResourceLocation registryName,
@@ -108,7 +112,7 @@ public final class SynchronizedRegistriesHandler {
             syncedRegistry = registryData.computeSyncedRegistry(cacheKey, () ->
                     registryData.createFromElements(elements, version));
         }
-        user.putUserRegistry(syncedRegistry);
+        user.putRegistry(syncedRegistry);
     }
 
     public static void handleLegacyRegistries(
@@ -130,13 +134,15 @@ public final class SynchronizedRegistriesHandler {
         }
     }
 
+    @ApiStatus.Internal
     @FunctionalInterface
-    private interface NbtEntryDecoder<T> {
+    public interface NbtEntryDecoder<T> {
 
         T decode(NBT nbt, ClientVersion version, @Nullable TypesBuilderData data);
     }
 
-    private static final class RegistryEntry<T extends MappedEntity & CopyableEntity<T>> {
+    @ApiStatus.Internal
+    public static final class RegistryEntry<T extends MappedEntity & CopyableEntity<T>> {
 
         private final IRegistry<T> baseRegistry;
         private final NbtEntryDecoder<T> decoder;
@@ -153,6 +159,10 @@ public final class SynchronizedRegistriesHandler {
         ) {
             this.baseRegistry = baseRegistry;
             this.decoder = decoder;
+        }
+
+        public @Nullable SimpleRegistry<T> getSyncedRegistry(Object key) {
+            return this.syncedRegistries.get(key);
         }
 
         @SuppressWarnings("unchecked")

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
@@ -89,4 +89,9 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
     public ResourceLocation getRegistryKey() {
         return this.registryKey;
     }
+
+    @Override
+    public String toString() {
+        return "VersionedRegistry[" + this.registryKey + ']';
+    }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerJoinGame.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerJoinGame.java
@@ -504,8 +504,7 @@ public class WrapperPlayServerJoinGame extends PacketWrapper<WrapperPlayServerJo
     }
 
     public DimensionType getDimensionType() {
-        IRegistry<DimensionType> registry = this.user == null ? DimensionTypes.getRegistry() :
-                this.user.getUserRegistryOrFallback(DimensionTypes.getRegistry());
+        IRegistry<DimensionType> registry = this.getRegistryHolder().getRegistryOr(DimensionTypes.getRegistry());
         return this.dimensionTypeRef.resolve(registry, this.serverVersion.toClientVersion());
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerRespawn.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerRespawn.java
@@ -69,7 +69,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
             @Nullable ResourceLocation deathDimensionName, @Nullable WorldBlockPosition lastDeathPosition,
             @Nullable Integer portalCooldown
     ) {
-        this( dimension.asDimensionTypeRef(), worldName, difficulty, hashedSeed, gameMode, previousGameMode,
+        this(dimension.asDimensionTypeRef(), worldName, difficulty, hashedSeed, gameMode, previousGameMode,
                 worldDebug, worldFlat, keepingAllPlayerData, deathDimensionName, lastDeathPosition, portalCooldown);
     }
 
@@ -79,7 +79,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
             @Nullable GameMode previousGameMode, boolean worldDebug, boolean worldFlat, byte keptData,
             @Nullable WorldBlockPosition lastDeathPosition, @Nullable Integer portalCooldown
     ) {
-        this( dimension.asDimensionTypeRef(), worldName, difficulty, hashedSeed, gameMode, previousGameMode,
+        this(dimension.asDimensionTypeRef(), worldName, difficulty, hashedSeed, gameMode, previousGameMode,
                 worldDebug, worldFlat, keptData, lastDeathPosition, portalCooldown);
     }
 
@@ -266,8 +266,7 @@ public class WrapperPlayServerRespawn extends PacketWrapper<WrapperPlayServerRes
     }
 
     public DimensionType getDimensionType() {
-        IRegistry<DimensionType> registry = this.user == null ? DimensionTypes.getRegistry() :
-                this.user.getUserRegistryOrFallback(DimensionTypes.getRegistry());
+        IRegistry<DimensionType> registry = this.getRegistryHolder().getRegistryOr(DimensionTypes.getRegistry());
         return this.dimensionTypeRef.resolve(registry, this.serverVersion.toClientVersion());
     }
 

--- a/fabric/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPacketEventsBuilder.java
+++ b/fabric/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPacketEventsBuilder.java
@@ -17,6 +17,7 @@ import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.settings.PacketEventsSettings;
 import com.github.retrooper.packetevents.util.LogManager;
+import com.github.retrooper.packetevents.util.mappings.GlobalRegistryHolder;
 import com.github.retrooper.packetevents.util.reflection.ReflectionObject;
 import io.github.retrooper.packetevents.handler.PacketDecoder;
 import io.github.retrooper.packetevents.handler.PacketEncoder;
@@ -92,7 +93,7 @@ public class FabricPacketEventsBuilder {
 
                 @Override
                 public Object getRegistryCacheKey(User user, ClientVersion version) {
-                    return version; // global registries, only depends on packet version
+                    return GlobalRegistryHolder.getGlobalRegistryCacheKey(user, version);
                 }
             };
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/manager/server/ServerManagerImpl.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/manager/server/ServerManagerImpl.java
@@ -24,6 +24,7 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.PEVersion;
+import com.github.retrooper.packetevents.util.mappings.GlobalRegistryHolder;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
@@ -69,6 +70,6 @@ public class ServerManagerImpl implements ServerManager {
 
     @Override
     public Object getRegistryCacheKey(User user, ClientVersion version) {
-        return version; // global registries, only depends on packet version
+        return GlobalRegistryHolder.getGlobalRegistryCacheKey(user, version);
     }
 }


### PR DESCRIPTION
Works around issues where plugins convert items to bukkit items, which doesn't preserve registry holder context, e.g. [PacketEventsHook in ExcellentEnchants](https://github.com/nulli0n/ExcellentEnchants-spigot/blob/8623159ca61b60e1d3cae22c77a99e82b15b9d5f/Core/src/main/java/su/nightexpress/excellentenchants/hook/impl/PacketEventsHook.java)

Fixes #963