### PR TITLE
Add wrapper for BossBar packet

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -24,6 +24,7 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.color.DyeColor;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 
 public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBossBar> {
@@ -32,8 +33,8 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
     private Action action;
     private Component title;
     private float health;
-    private Color color;
-    private Division division;
+    private BossBar.Color color;
+    private BossBar.Overlay division;
     private short flags;
 
     public WrapperPlayServerBossBar(PacketSendEvent event) {
@@ -54,8 +55,8 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         case ADD:
             title = readComponent();
             health = readFloat();
-            color = readEnum(Color.class);
-            division = readEnum(Division.class);
+            color = readEnum(BossBar.Color.class);
+            division = readEnum(BossBar.Overlay.class);
             flags = readUnsignedByte();
             break;
         case REMOVE: // do nothing
@@ -67,8 +68,8 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             title = readComponent();
             break;
         case UPDATE_STYLE:
-            color = readEnum(Color.class);
-            division = readEnum(Division.class);
+            color = readEnum(BossBar.Color.class);
+            division = readEnum(BossBar.Overlay.class);
             break;
         case UPDATE_FLAGS:
             flags = readUnsignedByte();
@@ -149,19 +150,19 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         this.health = health;
     }
     
-    public Color getColor() {
+    public BossBar.Color getColor() {
         return color;
     }
     
-    public void setColor(Color color) {
+    public void setColor(BossBar.Color color) {
         this.color = color;
     }
     
-    public Division getDivision() {
+    public BossBar.Overlay getDivision() {
         return division;
     }
     
-    public void setDivision(Division division) {
+    public void setDivision(BossBar.Overlay division) {
         this.division = division;
     }
     
@@ -175,23 +176,5 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
     
     public enum Action {
         ADD, REMOVE, UPDATE_HEALTH, UPDATE_TITLE, UPDATE_STYLE, UPDATE_FLAGS;
-    }
-    
-    public enum Division {
-        NONE, NOTCH_6, NOTCH_10, NOTCH_12, NOTCH_20;
-    }
-    
-    public enum Color {
-        PINK(DyeColor.PINK), BLUE(DyeColor.BLUE), RED(DyeColor.RED), GREEN(DyeColor.GREEN), YELLOW(DyeColor.YELLOW), PURPLE(DyeColor.PURPLE), WHITE(DyeColor.WHITE);
-        
-        private DyeColor color;
-        
-        private Color(DyeColor color) {
-            this.color = color;
-        }
-        
-        public DyeColor getDyeColor() {
-            return color;
-        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -21,6 +21,7 @@ package com.github.retrooper.packetevents.wrapper.play.server;
 import java.util.UUID;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.color.DyeColor;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import net.kyori.adventure.text.Component;
@@ -193,5 +194,4 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             return color;
         }
     }
-}
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -18,6 +18,8 @@
 
 package com.github.retrooper.packetevents.wrapper.play.server;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
@@ -35,7 +37,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
     private float health;
     private BossBar.Color color;
     private BossBar.Overlay division;
-    private short flags;
+    private List<BossBar.Flag> flags;
 
     public WrapperPlayServerBossBar(PacketSendEvent event) {
         super(event);
@@ -57,7 +59,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             health = readFloat();
             color = readEnum(BossBar.Color.class);
             division = readEnum(BossBar.Overlay.class);
-            flags = readUnsignedByte();
+            flags = getFlagsFromBytes(readUnsignedByte());
             break;
         case REMOVE: // do nothing
             break;
@@ -72,7 +74,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             division = readEnum(BossBar.Overlay.class);
             break;
         case UPDATE_FLAGS:
-            flags = readUnsignedByte();
+            flags = getFlagsFromBytes(readUnsignedByte());
             break;
         }
     }
@@ -87,7 +89,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             writeFloat(health);
             writeEnum(color);
             writeEnum(division);
-            writeByte(flags);
+            writeByte(convertFlagsToBytes());
             break;
         case REMOVE: // do nothing
             break;
@@ -102,7 +104,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             writeEnum(division);
             break;
         case UPDATE_FLAGS:
-            writeByte(flags);
+            writeByte(convertFlagsToBytes());
             break;
         }
     }
@@ -116,6 +118,40 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         color = wrapper.color;
         division = wrapper.division;
         flags = wrapper.flags;
+    }
+
+    private List<BossBar.Flag> getFlagsFromBytes(short b) {
+        List<BossBar.Flag> list = new ArrayList<>();
+        if((b & 0x01) != 0)
+            list.add(BossBar.Flag.DARKEN_SCREEN);
+        if((b & 0x02) != 0)
+            list.add(BossBar.Flag.PLAY_BOSS_MUSIC);
+        if((b & 0x04) != 0)
+            list.add(BossBar.Flag.CREATE_WORLD_FOG);
+        return list;
+    }
+
+    private byte convertFlagsToBytes() {
+        int bitmask = 0;
+        for (BossBar.Flag flag : flags) {
+            int id;
+            switch(flag) {
+            case DARKEN_SCREEN:
+                id = 1;
+                break;
+            case PLAY_BOSS_MUSIC:
+                id = 2;
+                break;
+            case CREATE_WORLD_FOG:
+                id = 4;
+                break;
+            default:
+                id = 0;
+                break;
+            }
+            bitmask |= id;
+        }
+        return (byte) bitmask;
     }
     
     public UUID getUuid() {
@@ -166,11 +202,11 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         this.division = division;
     }
     
-    public short getFlags() {
+    public List<Flag> getFlags() {
         return flags;
     }
     
-    public void setFlags(short flags) {
+    public void setFlags(List<Flag> flags) {
         this.flags = flags;
     }
     

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -36,7 +36,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
     private Component title;
     private float health;
     private BossBar.Color color;
-    private BossBar.Overlay division;
+    private BossBar.Overlay overlay;
     private List<BossBar.Flag> flags;
 
     public WrapperPlayServerBossBar(PacketSendEvent event) {
@@ -58,7 +58,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             title = readComponent();
             health = readFloat();
             color = readEnum(BossBar.Color.class);
-            division = readEnum(BossBar.Overlay.class);
+            overlay = readEnum(BossBar.Overlay.class);
             flags = getFlagsFromBytes(readUnsignedByte());
             break;
         case REMOVE: // do nothing
@@ -71,7 +71,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             break;
         case UPDATE_STYLE:
             color = readEnum(BossBar.Color.class);
-            division = readEnum(BossBar.Overlay.class);
+            overlay = readEnum(BossBar.Overlay.class);
             break;
         case UPDATE_FLAGS:
             flags = getFlagsFromBytes(readUnsignedByte());
@@ -88,7 +88,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             writeComponent(title);
             writeFloat(health);
             writeEnum(color);
-            writeEnum(division);
+            writeEnum(overlay);
             writeByte(convertFlagsToBytes());
             break;
         case REMOVE: // do nothing
@@ -101,7 +101,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
             break;
         case UPDATE_STYLE:
             writeEnum(color);
-            writeEnum(division);
+            writeEnum(overlay);
             break;
         case UPDATE_FLAGS:
             writeByte(convertFlagsToBytes());
@@ -116,7 +116,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         title = wrapper.title;
         health = wrapper.health;
         color = wrapper.color;
-        division = wrapper.division;
+        overlay = wrapper.overlay;
         flags = wrapper.flags;
     }
 
@@ -194,19 +194,19 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         this.color = color;
     }
     
-    public BossBar.Overlay getDivision() {
-        return division;
+    public BossBar.Overlay getOverlay() {
+        return overlay;
     }
     
-    public void setDivision(BossBar.Overlay division) {
-        this.division = division;
+    public void setOverlay(BossBar.Overlay overlay) {
+        this.overlay = overlay;
     }
     
-    public List<Flag> getFlags() {
+    public List<BossBar.Flag> getFlags() {
         return flags;
     }
     
-    public void setFlags(List<Flag> flags) {
+    public void setFlags(List<BossBar.Flag> flags) {
         this.flags = flags;
     }
     

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -18,12 +18,10 @@
 
 package com.github.retrooper.packetevents.wrapper.play.server;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.EnumSet;
 import java.util.UUID;
 
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.protocol.color.DyeColor;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import net.kyori.adventure.bossbar.BossBar;
@@ -37,7 +35,7 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
     private float health;
     private BossBar.Color color;
     private BossBar.Overlay overlay;
-    private List<BossBar.Flag> flags;
+    private EnumSet<BossBar.Flag> flags;
 
     public WrapperPlayServerBossBar(PacketSendEvent event) {
         super(event);
@@ -120,8 +118,8 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         flags = wrapper.flags;
     }
 
-    private List<BossBar.Flag> getFlagsFromBytes(short b) {
-        List<BossBar.Flag> list = new ArrayList<>();
+    private EnumSet<BossBar.Flag> getFlagsFromBytes(short b) {
+        EnumSet<BossBar.Flag> list = EnumSet.noneOf(BossBar.Flag.class);
         if((b & 0x01) != 0)
             list.add(BossBar.Flag.DARKEN_SCREEN);
         if((b & 0x02) != 0)
@@ -202,11 +200,11 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         this.overlay = overlay;
     }
     
-    public List<BossBar.Flag> getFlags() {
+    public EnumSet<BossBar.Flag> getFlags() {
         return flags;
     }
     
-    public void setFlags(List<BossBar.Flag> flags) {
+    public void setFlags(EnumSet<BossBar.Flag> flags) {
         this.flags = flags;
     }
     

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -152,11 +152,11 @@ public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBos
         return (byte) bitmask;
     }
     
-    public UUID getUuid() {
+    public UUID getUUID() {
         return uuid;
     }
     
-    public void setUuid(UUID uuid) {
+    public void setUUID(UUID uuid) {
         this.uuid = uuid;
     }
     

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBossBar.java
@@ -1,0 +1,197 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.wrapper.play.server;
+
+import java.util.UUID;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import net.kyori.adventure.text.Component;
+
+public class WrapperPlayServerBossBar extends PacketWrapper<WrapperPlayServerBossBar> {
+
+    private UUID uuid;
+    private Action action;
+    private Component title;
+    private float health;
+    private Color color;
+    private Division division;
+    private short flags;
+
+    public WrapperPlayServerBossBar(PacketSendEvent event) {
+        super(event);
+    }
+
+    public WrapperPlayServerBossBar(UUID uuid, Action action) {
+        super(PacketType.Play.Server.BOSS_BAR);
+        this.uuid = uuid;
+        this.action = action;
+    }
+    
+    @Override
+    public void read() {
+        uuid = readUUID();
+        action = readEnum(Action.class);
+        switch (action) {
+        case ADD:
+            title = readComponent();
+            health = readFloat();
+            color = readEnum(Color.class);
+            division = readEnum(Division.class);
+            flags = readUnsignedByte();
+            break;
+        case REMOVE: // do nothing
+            break;
+        case UPDATE_HEALTH:
+            health = readFloat();
+            break;
+        case UPDATE_TITLE:
+            title = readComponent();
+            break;
+        case UPDATE_STYLE:
+            color = readEnum(Color.class);
+            division = readEnum(Division.class);
+            break;
+        case UPDATE_FLAGS:
+            flags = readUnsignedByte();
+            break;
+        }
+    }
+    
+    @Override
+    public void write() {
+        writeUUID(uuid);
+        writeEnum(action);
+        switch (action) {
+        case ADD:
+            writeComponent(title);
+            writeFloat(health);
+            writeEnum(color);
+            writeEnum(division);
+            writeByte(flags);
+            break;
+        case REMOVE: // do nothing
+            break;
+        case UPDATE_HEALTH:
+            writeFloat(health);
+            break;
+        case UPDATE_TITLE:
+            writeComponent(title);
+            break;
+        case UPDATE_STYLE:
+            writeEnum(color);
+            writeEnum(division);
+            break;
+        case UPDATE_FLAGS:
+            writeByte(flags);
+            break;
+        }
+    }
+    
+    @Override
+    public void copy(WrapperPlayServerBossBar wrapper) {
+        uuid = wrapper.uuid;
+        action = wrapper.action;
+        title = wrapper.title;
+        health = wrapper.health;
+        color = wrapper.color;
+        division = wrapper.division;
+        flags = wrapper.flags;
+    }
+    
+    public UUID getUuid() {
+        return uuid;
+    }
+    
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+    
+    public Action getAction() {
+        return action;
+    }
+    
+    public void setAction(Action action) {
+        this.action = action;
+    }
+    
+    public Component getTitle() {
+        return title;
+    }
+    
+    public void setTitle(Component title) {
+        this.title = title;
+    }
+    
+    public float getHealth() {
+        return health;
+    }
+    
+    public void setHealth(float health) {
+        this.health = health;
+    }
+    
+    public Color getColor() {
+        return color;
+    }
+    
+    public void setColor(Color color) {
+        this.color = color;
+    }
+    
+    public Division getDivision() {
+        return division;
+    }
+    
+    public void setDivision(Division division) {
+        this.division = division;
+    }
+    
+    public short getFlags() {
+        return flags;
+    }
+    
+    public void setFlags(short flags) {
+        this.flags = flags;
+    }
+    
+    public enum Action {
+        ADD, REMOVE, UPDATE_HEALTH, UPDATE_TITLE, UPDATE_STYLE, UPDATE_FLAGS;
+    }
+    
+    public enum Division {
+        NONE, NOTCH_6, NOTCH_10, NOTCH_12, NOTCH_20;
+    }
+    
+    public enum Color {
+        PINK(DyeColor.PINK), BLUE(DyeColor.BLUE), RED(DyeColor.RED), GREEN(DyeColor.GREEN), YELLOW(DyeColor.YELLOW), PURPLE(DyeColor.PURPLE), WHITE(DyeColor.WHITE);
+        
+        private DyeColor color;
+        
+        private Color(DyeColor color) {
+            this.color = color;
+        }
+        
+        public DyeColor getDyeColor() {
+            return color;
+        }
+    }
+}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
 org.gradle.jvmargs=-Xmx2000m
-org.gradle.java.home=C\:\\Software\\Java\\jdk-21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx2000m
+org.gradle.java.home=C\:\\Software\\Java\\jdk-21


### PR DESCRIPTION
This PR add a wrapper for `BOSS_BAR` packet.

I pre-answer few questions:
- I made my own `Color` enum to prevent switch/case to read color. It also help to other developer to only use right colors
- The constructor isn't with all parameters as they are different between each actions
- For the flags, I didn't convert them to something else that byte as it seems to changed multiple times. Also, I'm reading as UnsignedByte but there isn't writeUnsignedByte, I tried writeShort but that was too much.
- In general, I used description available [here](https://wiki.vg/Protocol#Boss_Bar) and tested on my own server

I suggest you to Squash and merge. That's would be perfect.