### PR TITLE
Add missing getters to BiomeEffects

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/biome/BiomeEffects.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/biome/BiomeEffects.java
@@ -164,6 +164,18 @@ public class BiomeEffects {
         return this.ambientSound;
     }
 
+    public Optional<MoodSettings> getMoodSound() {
+        return this.moodSound;
+    }
+
+    public Optional<MusicSettings> getMusic() {
+        return this.music;
+    }
+
+    public Optional<AdditionsSettings> getAdditionsSound() {
+        return this.additionsSound;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;


### PR DESCRIPTION
This PR adds getters for `moodSound`, `music` and `additionsSound` in `BiomeEffects`. I see no obvious reason for their exclusion; I assume they were omitted by mistake. Nevertheless, their absence complicates creating new `BiomeEffects` objects based on existing ones, as all three are required in the constructor.