### PR TITLE
Remove nbt reading limit in registry-data packet for pre 1.20.5

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/codec/NBTCodec.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/codec/NBTCodec.java
@@ -151,6 +151,10 @@ public class NBTCodec {
 
     public static NBT readNBTFromBuffer(Object byteBuf, ServerVersion serverVersion) {
         NBTLimiter limiter = NBTLimiter.forBuffer(byteBuf);
+        return readNBTFromBuffer(byteBuf, serverVersion, limiter);
+    }
+
+    public static NBT readNBTFromBuffer(Object byteBuf, ServerVersion serverVersion, NBTLimiter limiter) {
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             try {
                 final boolean named = serverVersion.isOlderThan(ServerVersion.V_1_20_2);

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -76,6 +76,7 @@ import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.nbt.NBT;
 import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
+import com.github.retrooper.packetevents.protocol.nbt.NBTLimiter;
 import com.github.retrooper.packetevents.protocol.nbt.codec.NBTCodec;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
@@ -611,6 +612,14 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
 
     public NBT readNBTRaw() {
         return NBTCodec.readNBTFromBuffer(buffer, serverVersion);
+    }
+
+    public NBTCompound readUnlimitedNBT() {
+        return (NBTCompound) this.readUnlimitedNBTRaw();
+    }
+
+    public NBT readUnlimitedNBTRaw() {
+        return NBTCodec.readNBTFromBuffer(buffer, serverVersion, NBTLimiter.noop());
     }
 
     public void writeNBT(NBTCompound nbt) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerRegistryData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/configuration/server/WrapperConfigServerRegistryData.java
@@ -75,8 +75,8 @@ public class WrapperConfigServerRegistryData extends PacketWrapper<WrapperConfig
 
     @Override
     public void read() {
-        if (!this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_5)) {
-            this.registryData = this.readNBT();
+        if (this.serverVersion.isOlderThan(ServerVersion.V_1_20_5)) {
+            this.registryData = this.readUnlimitedNBT();
             return;
         }
         this.registryKey = this.readIdentifier();
@@ -89,7 +89,7 @@ public class WrapperConfigServerRegistryData extends PacketWrapper<WrapperConfig
 
     @Override
     public void write() {
-        if (!this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20_5)) {
+        if (this.serverVersion.isOlderThan(ServerVersion.V_1_20_5)) {
             this.writeNBT(this.registryData);
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/retrooper/packetevents/issues/993