### PR TITLE
Synchronize packet encoding

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
@@ -104,10 +104,13 @@ public interface ProtocolManager {
         PacketWrapper<?>[] wrappers = PacketTransformationUtil.transform(wrapper);
         Object[] buffers = new Object[wrappers.length];
         for (int i = 0; i < wrappers.length; i++) {
-            wrappers[i].prepareForSend(channel, outgoing);
-            buffers[i] = wrappers[i].buffer;
-            // Fix race condition when sending packets to multiple people (due to when the buffer is freed)
-            wrappers[i].buffer = null;
+            PacketWrapper<?> wrappper = wrappers[i];
+            synchronized (wrappper.bufferLock) {
+                wrappper.prepareForSend(channel, outgoing);
+                buffers[i] = wrappper.buffer;
+                // Fix race condition when sending packets to multiple people (due to when the buffer is freed)
+                wrappper.buffer = null;
+            }
         }
         return buffers;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -128,6 +128,9 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
     @Nullable
     public Object buffer;
 
+    @ApiStatus.Internal
+    public final Object bufferLock = new Object();
+
     protected ClientVersion clientVersion;
     protected ServerVersion serverVersion;
     private PacketTypeData packetTypeData;


### PR DESCRIPTION
Resolves concurrency issues which may happen when sending the same packet wrapper to different players, concurrently

This is not a perfect solution, but the alternative would be refactoring the packetwrapper to be based on buffers passed during encoding as parameters, which would be too much effort and would require breaking changes

Fixes https://github.com/retrooper/packetevents/issues/991