### PR TITLE
Fix support for new bungee compression

### DIFF
--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/CustomPipelineUtil.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/injector/CustomPipelineUtil.java
@@ -130,12 +130,12 @@ public class CustomPipelineUtil {
         return output;
     }
 
-    public static void callPacketEncodeByteBuf(Object encoder, Object ctx, Object msg, Object output) throws InvocationTargetException {
+    public static void callPacketEncodeByteBuf(Object encoder, Object ctx, Object msg, List<Object> output) throws InvocationTargetException {
         if (BUNGEE_PACKET_ENCODE_BYTEBUF == null) {
             try {
                 BUNGEE_PACKET_ENCODE_BYTEBUF = encoder.getClass()
                         .getDeclaredMethod("encode", ChannelHandlerContext.class, ByteBuf.class,
-                                ByteBuf.class);
+                                List.class);
                 BUNGEE_PACKET_ENCODE_BYTEBUF.setAccessible(true);
             } catch (NoSuchMethodException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Bungee [changed some network internals last week](https://github.com/SpigotMC/BungeeCord/commit/b309e4ac50ca44f2cfc06e8d27de33a1f0c77549#diff-c1c0d1f8d0b4bc645d9a23cd0daee5755bd8f3f58af400763d8ccfb0bbe5ac06) for more performance
This fixes the packetevents injector to work with their new compressor

I am not sure if we still want to support older BungeeCord versions

---

Fixes https://github.com/retrooper/packetevents/issues/983
Fixes https://github.com/retrooper/packetevents/issues/989