### PR TITLE
Revert some fixes for particle data decoding/encoding

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustColorTransitionData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustColorTransitionData.java
@@ -159,7 +159,6 @@ public class ParticleDustColorTransitionData extends ParticleData {
         String fromColorKey = "from_color";
         String toColorKey = "to_color";
         if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            compound = compound.getCompoundTagOrThrow("value");
             fromColorKey = "fromColor";
             toColorKey = "toColor";
         }
@@ -173,9 +172,6 @@ public class ParticleDustColorTransitionData extends ParticleData {
         String fromColorKey = "from_color";
         String toColorKey = "to_color";
         if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            NBTCompound innerCompound = new NBTCompound();
-            compound.setTag("value", innerCompound);
-            compound = innerCompound;
             fromColorKey = "fromColor";
             toColorKey = "toColor";
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleDustData.java
@@ -156,9 +156,6 @@ public class ParticleDustData extends ParticleData {
     }
 
     public static ParticleDustData decode(NBTCompound compound, ClientVersion version) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            compound = compound.getCompoundTagOrThrow("value");
-        }
         NBT colorNBT = compound.getTagOrNull("color");
         float[] color = decodeColor(colorNBT);
         float scale = compound.getNumberTagOrThrow("scale").getAsFloat();
@@ -166,11 +163,6 @@ public class ParticleDustData extends ParticleData {
     }
 
     public static void encode(ParticleDustData data, ClientVersion version, NBTCompound compound) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            NBTCompound innerCompound = new NBTCompound();
-            compound.setTag("value", innerCompound);
-            compound = innerCompound;
-        }
         compound.setTag("color", encodeColor(null, data.red, data.green, data.blue));
         compound.setTag("scale", new NBTFloat(data.scale));
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleSculkChargeData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleSculkChargeData.java
@@ -30,19 +30,11 @@ public class ParticleSculkChargeData extends ParticleData {
     }
 
     public static ParticleSculkChargeData decode(NBTCompound compound, ClientVersion version) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            compound = compound.getCompoundTagOrThrow("value");
-        }
         float roll = compound.getNumberTagOrThrow("roll").getAsFloat();
         return new ParticleSculkChargeData(roll);
     }
 
     public static void encode(ParticleSculkChargeData data, ClientVersion version, NBTCompound compound) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            NBTCompound innerCompound = new NBTCompound();
-            compound.setTag("value", innerCompound);
-            compound = innerCompound;
-        }
         compound.setTag("roll", new NBTFloat(data.roll));
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleShriekData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleShriekData.java
@@ -30,19 +30,11 @@ public class ParticleShriekData extends ParticleData {
     }
 
     public static ParticleShriekData decode(NBTCompound compound, ClientVersion version) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            compound = compound.getCompoundTagOrThrow("value");
-        }
         int delay = compound.getNumberTagOrThrow("delay").getAsInt();
         return new ParticleShriekData(delay);
     }
 
     public static void encode(ParticleShriekData data, ClientVersion version, NBTCompound compound) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            NBTCompound innerCompound = new NBTCompound();
-            compound.setTag("value", innerCompound);
-            compound = innerCompound;
-        }
         compound.setTag("delay", new NBTInt(data.delay));
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleVibrationData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleVibrationData.java
@@ -156,9 +156,6 @@ public class ParticleVibrationData extends ParticleData {
     }
 
     public static ParticleVibrationData decode(NBTCompound compound, ClientVersion version) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            compound = compound.getCompoundTagOrThrow("value");
-        }
         Vector3i origin = version.isNewerThanOrEquals(ClientVersion.V_1_19) ? null :
                 new Vector3i(compound.getTagOfTypeOrThrow("origin", NBTIntArray.class).getValue());
         PositionSource destination = PositionSource.decode(compound.getCompoundTagOrThrow("destination"), version);
@@ -167,11 +164,6 @@ public class ParticleVibrationData extends ParticleData {
     }
 
     public static void encode(ParticleVibrationData data, ClientVersion version, NBTCompound compound) {
-        if (version.isOlderThan(ClientVersion.V_1_20_5)) {
-            NBTCompound innerCompound = new NBTCompound();
-            compound.setTag("value", innerCompound);
-            compound = innerCompound;
-        }
         if (version.isOlderThan(ClientVersion.V_1_19)) {
             Vector3i startPos = data.getStartingPosition();
             if (startPos != null) {


### PR DESCRIPTION
I didn't properly implement this before and thought there were no map-codecs, which have special handling when dispatching codecs by type... Mojang's codecs are confusing

---

Fixes https://github.com/retrooper/packetevents/issues/993 (see comments, not related to initial problem)