### PR TITLE
Force usage of plugin classloader to lookup classes of other plugins

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/GeyserUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/GeyserUtil.java
@@ -18,6 +18,7 @@
 
 package io.github.retrooper.packetevents.util;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.util.reflection.Reflection;
 
 import java.lang.reflect.InvocationTargetException;
@@ -35,7 +36,8 @@ public class GeyserUtil {
     public static boolean isGeyserPlayer(UUID uuid) {
         if (!CHECKED_FOR_GEYSER) {
             try {
-                GEYSER_CLASS = Class.forName("org.geysermc.api.Geyser");
+                ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
+                GEYSER_CLASS = classLoader.loadClass("org.geysermc.api.Geyser");
                 GEYSER_PRESENT = true;
             } catch (ClassNotFoundException e) {
                 GEYSER_PRESENT = false;
@@ -46,7 +48,8 @@ public class GeyserUtil {
         if (GEYSER_PRESENT) {
             if (GEYSER_API_CLASS == null) {
                 try {
-                    GEYSER_API_CLASS = Class.forName("org.geysermc.api.GeyserApiBase");
+                    ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
+                    GEYSER_API_CLASS = classLoader.loadClass("org.geysermc.api.GeyserApiBase");
                 }
                 catch (ClassNotFoundException e) {
                     e.printStackTrace();

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -19,6 +19,7 @@
 package io.github.retrooper.packetevents.util;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.PacketEventsAPI;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.netty.buffer.UnpooledByteBufAllocationHelper;

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -19,7 +19,6 @@
 package io.github.retrooper.packetevents.util;
 
 import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.PacketEventsAPI;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.netty.buffer.UnpooledByteBufAllocationHelper;

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/protocolsupport/ProtocolSupportUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/protocolsupport/ProtocolSupportUtil.java
@@ -18,6 +18,7 @@
 
 package io.github.retrooper.packetevents.util.protocolsupport;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import protocolsupport.api.ProtocolSupportAPI;
@@ -30,7 +31,8 @@ public class ProtocolSupportUtil {
     public static boolean isAvailable() {
         if (available == ProtocolSupportState.UNKNOWN) {
             try {
-                Class.forName("protocolsupport.api.ProtocolSupportAPI");
+                ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
+                classLoader.loadClass("protocolsupport.api.ProtocolSupportAPI");
                 available = ProtocolSupportState.ENABLED;
                 return true;
             } catch (Exception e) {

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionAccessorImplLegacy.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionAccessorImplLegacy.java
@@ -42,11 +42,12 @@ public class ViaVersionAccessorImplLegacy implements ViaVersionAccessor {
     private void load() {
         if (viaClass == null) {
             try {
-                viaClass = Class.forName("us.myles.ViaVersion.api.Via");
+                ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
+                viaClass = classLoader.loadClass("us.myles.ViaVersion.api.Via");
                 viaManagerField = viaClass.getDeclaredField("manager");
-                bukkitDecodeHandlerClass = Class.forName("us.myles.ViaVersion.bukkit.handlers.BukkitDecodeHandler");
-                bukkitEncodeHandlerClass = Class.forName("us.myles.ViaVersion.bukkit.handlers.BukkitEncodeHandler");
-                Class<?> viaAPIClass = Class.forName("us.myles.ViaVersion.api.ViaAPI");
+                bukkitDecodeHandlerClass = classLoader.loadClass("us.myles.ViaVersion.bukkit.handlers.BukkitDecodeHandler");
+                bukkitEncodeHandlerClass = classLoader.loadClass("us.myles.ViaVersion.bukkit.handlers.BukkitEncodeHandler");
+                Class<?> viaAPIClass = classLoader.loadClass("us.myles.ViaVersion.api.ViaAPI");
                 apiAccessor = viaClass.getMethod("getAPI");
                 getPlayerVersionMethod = viaAPIClass.getMethod("getPlayerVersion", Object.class);
             } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
@@ -56,7 +57,8 @@ public class ViaVersionAccessorImplLegacy implements ViaVersionAccessor {
 
         if (userConnectionClass == null) {
             try {
-                userConnectionClass = Class.forName("us.myles.ViaVersion.api.data.UserConnection");
+                ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
+                userConnectionClass = classLoader.loadClass("us.myles.ViaVersion.api.data.UserConnection");
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/viaversion/ViaVersionUtil.java
@@ -18,6 +18,7 @@
 
 package io.github.retrooper.packetevents.util.viaversion;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.player.User;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -31,12 +32,13 @@ public class ViaVersionUtil {
 
     private static void load() {
         if (viaVersionAccessor == null) {
+            ClassLoader classLoader = PacketEvents.getAPI().getPlugin().getClass().getClassLoader();
             try {
-                Class.forName("com.viaversion.viaversion.api.Via");
+                classLoader.loadClass("com.viaversion.viaversion.api.Via");
                 viaVersionAccessor = new ViaVersionAccessorImpl();
             } catch (Exception e) {
                 try {
-                    Class.forName("us.myles.ViaVersion.api.Via");
+                    classLoader.loadClass("us.myles.ViaVersion.api.Via");
                     viaVersionAccessor = new ViaVersionAccessorImplLegacy();
                 } catch (ClassNotFoundException ex) {
                     viaVersionAccessor = null;


### PR DESCRIPTION
Works around issues caused by some plugins loading packetevents through the library loader, which doesn't know about the classloader of plugins

Fixes https://github.com/retrooper/packetevents/issues/982