### PR TITLE
Fix errors with viaversion and map decorations

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
@@ -512,7 +512,7 @@ public class ItemStack {
             int maxAmount = getType().getMaxAmount();
             return "ItemStack[type=" + identifier + ", amount=" + amount + "/" + maxAmount
                     + ", nbt tag names: " + (nbt != null ? nbt.getTagNames() : "[null]")
-                    + ", legacyData=" + legacyData + ", components=" + components + "]";
+                    + ", legacyData=" + legacyData + ", components=" + (components != null ? components.getPatches() : null) + "]";
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/resources/ResourceLocation.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/resources/ResourceLocation.java
@@ -21,6 +21,9 @@ package com.github.retrooper.packetevents.resources;
 import java.util.Objects;
 
 public class ResourceLocation {
+
+    public static final String VANILLA_NAMESPACE = "minecraft";
+
     protected final String namespace;
     protected final String key;
 
@@ -30,7 +33,7 @@ public class ResourceLocation {
     }
 
     public ResourceLocation(String location) {
-        String[] array = new String[]{"minecraft", location};
+        String[] array = new String[]{VANILLA_NAMESPACE, location};
         int index = location.indexOf(":");
         if (index != -1) {
             array[1] = location.substring(index + 1);
@@ -40,6 +43,19 @@ public class ResourceLocation {
         }
         this.namespace = array[0];
         this.key = array[1];
+    }
+
+    public static String normString(String location) {
+        int index = location.indexOf(':');
+        if (index > 0) {
+            return location; // namespace already set
+        } else if (index == -1) {
+            // prepend namespace and delimiter
+            return VANILLA_NAMESPACE + ":" + location;
+        } else { // index == 0
+            // treat prepending delimiter as no namespace
+            return VANILLA_NAMESPACE + location;
+        }
     }
 
     public String getNamespace() {
@@ -70,6 +86,6 @@ public class ResourceLocation {
     }
 
     public static ResourceLocation minecraft(String key) {
-        return new ResourceLocation("minecraft", key);
+        return new ResourceLocation(VANILLA_NAMESPACE, key);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
@@ -61,8 +61,14 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
     }
 
     @Override
+    public @Nullable T getByName(ResourceLocation name) {
+        return this.typeMap.get(name.toString()); // skip norming call
+    }
+
+    @Override
     public @Nullable T getByName(String name) {
-        return this.typeMap.get(name);
+        // prepend "minecraft:" prefix if no other namespace has been specified
+        return this.typeMap.get(ResourceLocation.normString(name));
     }
 
     @Override


### PR DESCRIPTION
Reproducible on a 1.20.6+ server with a 1.20.4- client when packetevents tries to parse a map decoration type
Caused by packetevents not seeing "`red_x`" as the same as "minecraft:red_x"

This now implements a more generic solution, normalizing all string inputs for registries

Fixes #988 