### PR TITLE
Include relocated bstats classes in published shadow jar

### DIFF
--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -6,8 +6,14 @@ plugins {
     com.gradleup.shadow
 }
 
+val compileShadowOnly: Configuration by configurations.creating {
+    configurations.compileOnly.get().extendsFrom(this)
+}
+
 tasks {
     shadowJar {
+        configurations.add(compileShadowOnly)
+
         archiveFileName = "packetevents-${project.name}-${rootProject.ext["versionNoHash"]}.jar"
         archiveClassifier = null
 

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     compileOnly(libs.bungeecord)
     shadow(libs.bundles.adventure)
-    shadow(libs.bstats.bungeecord)
+    compileShadowOnly(libs.bstats.bungeecord)
     shadow(project(":api", "shadow"))
     shadow(project(":netty-common"))
 }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 dependencies {
     compileOnly(libs.netty)
     shadow(libs.bundles.adventure)
-    shadow(libs.bstats.bukkit)
+    compileShadowOnly(libs.bstats.bukkit)
     shadow(project(":api", "shadow"))
     shadow(project(":netty-common"))
 

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     }
     shadow(project(":api", "shadow"))
     shadow(project(":netty-common"))
-    shadow(libs.bstats.sponge)
+    compileShadowOnly(libs.bstats.sponge)
 
     compileOnly(libs.via.version)
 }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     annotationProcessor(libs.velocity)
     shadow(project(":api", "shadow"))
     shadow(project(":netty-common"))
-    shadow(libs.bstats.velocity)
+    compileShadowOnly(libs.bstats.velocity)
     // Velocity already bundles with adventure
 }
 


### PR DESCRIPTION
This moves bstats dependencies to a separate gradle dependency configuration, which is always shadowed and used in compile classpath