### PR TITLE
Add jitpack support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,9 @@
 import java.io.ByteArrayOutputStream
 
+plugins {
+    `maven-publish`
+}
+
 // TODO UPDATE
 val fullVersion = "2.6.0"
 val snapshot = true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk21


### PR DESCRIPTION
This PR add jitpack support to have access to dev-build when coding. Example of build [here](https://jitpack.io/com/github/Elikill58/packetevents/2.0-7f76b74b3b-1/build.log), we can use this to have access to all parts:
```gradle
dependencies {
    implementation("com.github.Elikill58.packetevents:packetevents-velocity:2.0-SNAPSHOT")
}
```

Can you squash and merge the PR (instead of simple merge) ?