### PR TITLE
Remove amount check from isEmpty

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
@@ -517,7 +517,7 @@ public class ItemStack {
     }
 
     public boolean isEmpty() {
-        return type == null || type == ItemTypes.AIR || amount <= 0;
+        return type == null || type == ItemTypes.AIR;
     }
 
     public static Builder builder() {


### PR DESCRIPTION
This allows negative item sizes to be sent through packetevents
At the moment ItemStacks with a negative or zero amount can not be serialized through packetevents.
This breaks compatibility for plugins expecting isEmpty to return true if the amount is zero or below