### PR TITLE
fix NPE for nbtInterpret

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -152,7 +153,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
         String selector = reader.readUTF("selector", Function.identity());
         String keybind = reader.readUTF("keybind", Function.identity());
         String nbt = reader.readUTF("nbt", Function.identity());
-        Boolean nbtInterpret = reader.readBoolean("interpret", Function.identity());
+        boolean nbtInterpret = Optional.ofNullable(reader.readBoolean("interpret", Function.identity())).orElse(false);
         BlockNBTComponent.Pos nbtBlock = reader.readUTF("block", BlockNBTComponent.Pos::fromString);
         String nbtEntity = reader.readUTF("entity", Function.identity());
         Key nbtStorage = reader.readUTF("storage", Key::key);


### PR DESCRIPTION
Fixes a null pointer exception when the "interpret" flag is not set.

I came across this using Items with NBT Compound lores: https://paste.md-5.net/acurekujeq.cs