### PR TITLE
Associate bukkit player with user object earlier

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
@@ -19,6 +19,7 @@
 package io.github.retrooper.packetevents.bukkit;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.FakeChannelUtil;
 import io.github.retrooper.packetevents.injector.SpigotChannelInjector;
@@ -29,7 +30,10 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
+@ApiStatus.Internal
 public class InternalBukkitListener implements Listener {
 
     private final Plugin plugin;
@@ -38,9 +42,26 @@ public class InternalBukkitListener implements Listener {
         this.plugin = plugin;
     }
 
+    // this is the first event executed after the player has
+    // finished logging in and has a channel reference set, for 1.20.2+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onLogin(PlayerSpawnLocationEvent event) {
+        if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20_2)) {
+            this.onLogin(event.getPlayer());
+        }
+    }
+
+    // packetevents may handle a few packets without a proper player
+    // reference here, but I'm pretty sure there is nothing we can do about that
+    // (and according to tests this doesn't really happen much in versions older than 1.20.2)
     @EventHandler(priority = EventPriority.HIGH)
-    public void onJoin(PlayerJoinEvent e) {
-        Player player = e.getPlayer();
+    public void onJoin(PlayerJoinEvent event) {
+        if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_20_2)) {
+            this.onLogin(event.getPlayer());
+        }
+    }
+
+    private void onLogin(Player player) {
         SpigotChannelInjector injector = (SpigotChannelInjector) PacketEvents.getAPI().getInjector();
 
         User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
@@ -48,7 +69,7 @@ public class InternalBukkitListener implements Listener {
             //We did not inject this user
             Object channel = PacketEvents.getAPI().getPlayerManager().getChannel(player);
             //Check if it is a fake connection...
-            if (!FakeChannelUtil.isFakeChannel(channel) && (!PacketEvents.getAPI().isTerminated() || PacketEvents.getAPI().getSettings().isKickIfTerminated())) {
+            if (channel == null || !FakeChannelUtil.isFakeChannel(channel) && (!PacketEvents.getAPI().isTerminated() || PacketEvents.getAPI().getSettings().isKickIfTerminated())) {
                 //Kick them, if they are not a fake player.
                 FoliaScheduler.getRegionScheduler().runDelayed(plugin, player.getLocation(), (o) -> {
                     player.kickPlayer("PacketEvents 2.0 failed to inject");

--- a/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
@@ -46,6 +46,7 @@ public class InternalBukkitListener implements Listener {
     // finished logging in and has a channel reference set, for 1.20.2+
     @EventHandler(priority = EventPriority.LOWEST)
     public void onLogin(PlayerSpawnLocationEvent event) {
+        System.out.println("First factual: " + event.getPlayer().getName());
         if (PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20_2)) {
             this.onLogin(event.getPlayer());
         }
@@ -56,12 +57,14 @@ public class InternalBukkitListener implements Listener {
     // (and according to tests this doesn't really happen much in versions older than 1.20.2)
     @EventHandler(priority = EventPriority.HIGH)
     public void onJoin(PlayerJoinEvent event) {
+        System.out.println("Second factual: " + event.getPlayer().getName());
         if (PacketEvents.getAPI().getServerManager().getVersion().isOlderThan(ServerVersion.V_1_20_2)) {
             this.onLogin(event.getPlayer());
         }
     }
 
     private void onLogin(Player player) {
+        System.out.println("PLAYER LOGGED ON: " + player.getName());
         SpigotChannelInjector injector = (SpigotChannelInjector) PacketEvents.getAPI().getInjector();
 
         User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
@@ -71,9 +74,9 @@ public class InternalBukkitListener implements Listener {
             //Check if it is a fake connection...
             if (channel == null || !FakeChannelUtil.isFakeChannel(channel) && (!PacketEvents.getAPI().isTerminated() || PacketEvents.getAPI().getSettings().isKickIfTerminated())) {
                 //Kick them, if they are not a fake player.
-                FoliaScheduler.getRegionScheduler().runDelayed(plugin, player.getLocation(), (o) -> {
+                FoliaScheduler.getEntityScheduler().runDelayed(player, plugin, (o) -> {
                     player.kickPlayer("PacketEvents 2.0 failed to inject");
-                }, 0);
+                }, null, 0);
             }
             return;
         }


### PR DESCRIPTION
I am not sure if this causes any issues, so I opened a PR before

@retrooper would be nice if you could take a look

Fixes https://github.com/retrooper/packetevents/issues/1036