### PR TITLE
Use correct scheduler for kicking player

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/bukkit/InternalBukkitListener.java
@@ -50,9 +50,9 @@ public class InternalBukkitListener implements Listener {
             //Check if it is a fake connection...
             if (!FakeChannelUtil.isFakeChannel(channel) && (!PacketEvents.getAPI().isTerminated() || PacketEvents.getAPI().getSettings().isKickIfTerminated())) {
                 //Kick them, if they are not a fake player.
-                FoliaScheduler.getRegionScheduler().runDelayed(plugin, player.getLocation(), (o) -> {
+                FoliaScheduler.getEntityScheduler().runDelayed(player, plugin, (o) -> {
                     player.kickPlayer("PacketEvents 2.0 failed to inject");
-                }, 0);
+                }, null, 0);
             }
             return;
         }


### PR DESCRIPTION
In some rare cases, player may be teleported during join and kick will fail,
and all entity operations should be run on EntityScheduler like what they say in [Folia Javadoc](https://jd.papermc.io/folia/1.20/org/bukkit/Bukkit.html#getRegionScheduler())