### PR TITLE
Keep Alive Client Version Check from V_1_12 to V_1_12_2

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientKeepAlive.java
@@ -42,7 +42,7 @@ public class WrapperPlayClientKeepAlive extends PacketWrapper<WrapperPlayClientK
 
     @Override
     public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12_2)) {
             this.id = readLong();
         } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             this.id = readVarInt();
@@ -53,7 +53,7 @@ public class WrapperPlayClientKeepAlive extends PacketWrapper<WrapperPlayClientK
 
     @Override
     public void write() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12_2)) {
             writeLong(id);
         } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             writeVarInt((int) id);

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerKeepAlive.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerKeepAlive.java
@@ -42,7 +42,7 @@ public class WrapperPlayServerKeepAlive extends PacketWrapper<WrapperPlayServerK
 
     @Override
     public void read() {
-        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12)) {
+        if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_12_2)) {
             this.id = readLong();
         } else if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             this.id = readVarInt();


### PR DESCRIPTION
**Description:**  

This update changes the client version check from `ClientVersion.V_1_12` to `ClientVersion.V_1_12_2` in the `WrapperPlayClientKeepAlive` class. This ensures compatibility with Minecraft versions starting from `V_1_12` and higher. Additionally, it ensures proper handling of the `KEEP_ALIVE` packet in both older and newer versions of the client and server. The logic remains the same, but the client version check has been updated to reflect the more precise versioning for Minecraft clients.

**Reference:**
- [V_1_12_1](https://minecraft.wiki/w/Protocol?oldid=2772349#Keep_Alive_(clientbound))
- [V_1_12_2](https://minecraft.wiki/w/Protocol?oldid=2772385#Keep_Alive_(clientbound))
- [From 1.12.2 to latest](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#Clientbound_Keep_Alive_(configuration))