### PR TITLE
Add clone() to Vector classes and add new Mutable Vector Classes

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -19,14 +19,12 @@
 package com.github.retrooper.packetevents.util;
 
 import com.github.retrooper.packetevents.protocol.nbt.NBT;
-import com.github.retrooper.packetevents.protocol.nbt.NBTDouble;
 import com.github.retrooper.packetevents.protocol.nbt.NBTList;
 import com.github.retrooper.packetevents.protocol.nbt.NBTNumber;
-import com.github.retrooper.packetevents.protocol.nbt.NBTType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
@@ -107,35 +105,6 @@ public class Vector3d implements VectorInterface3d {
         }
     }
 
-    public static Vector3d read(PacketWrapper<?> wrapper) {
-        double x = wrapper.readDouble();
-        double y = wrapper.readDouble();
-        double z = wrapper.readDouble();
-        return new Vector3d(x, y, z);
-    }
-
-    public static void write(PacketWrapper<?> wrapper, Vector3d vector) {
-        wrapper.writeDouble(vector.x);
-        wrapper.writeDouble(vector.y);
-        wrapper.writeDouble(vector.z);
-    }
-
-    public static Vector3d decode(NBT tag, ClientVersion version) {
-        NBTList<?> list = (NBTList<?>) tag;
-        double x = ((NBTNumber) list.getTag(0)).getAsDouble();
-        double y = ((NBTNumber) list.getTag(1)).getAsDouble();
-        double z = ((NBTNumber) list.getTag(2)).getAsDouble();
-        return new Vector3d(x, y, z);
-    }
-
-    public static NBT encode(Vector3d vector3d, ClientVersion version) {
-        NBTList<NBTDouble> list = new NBTList<>(NBTType.DOUBLE, 3);
-        list.addTag(new NBTDouble(vector3d.x));
-        list.addTag(new NBTDouble(vector3d.y));
-        list.addTag(new NBTDouble(vector3d.z));
-        return list;
-    }
-
     @Override
     public double getX() {
         return x;
@@ -183,90 +152,109 @@ public class Vector3d implements VectorInterface3d {
         return Objects.hash(x, y, z);
     }
 
+    @Override
     public Vector3d add(double x, double y, double z) {
         return new Vector3d(this.x + x, this.y + y, this.z + z);
     }
 
-    public Vector3d add(Vector3d other) {
-        return add(other.x, other.y, other.z);
+    @Override
+    public Vector3d add(VectorInterface3i other) {
+        return add(other.getX(), other.getY(), other.getZ());
     }
 
+    @Override
     public Vector3d offset(BlockFace face) {
         return add(face.getModX(), face.getModY(), face.getModZ());
     }
 
+    @Override
     public Vector3d subtract(double x, double y, double z) {
         return new Vector3d(this.x - x, this.y - y, this.z - z);
     }
 
-    public Vector3d subtract(Vector3d other) {
-        return subtract(other.x, other.y, other.z);
+    @Override
+    public Vector3d subtract(VectorInterface3d other) {
+        return subtract(other.getX(), other.getY(), other.getZ());
     }
 
+    @Override
     public Vector3d multiply(double x, double y, double z) {
         return new Vector3d(this.x * x, this.y * y, this.z * z);
     }
 
-    public Vector3d multiply(Vector3d other) {
-        return multiply(other.x, other.y, other.z);
+    @Override
+    public Vector3d multiply(VectorInterface3d other) {
+        return multiply(other.getX(), other.getY(), other.getZ());
     }
 
+    @Override
     public Vector3d multiply(double value) {
         return multiply(value, value, value);
     }
 
-    public Vector3d crossProduct(Vector3d other) {
-        double newX = this.y * other.z - other.y * this.z;
-        double newY = this.z * other.x - other.z * this.x;
-        double newZ = this.x * other.y - other.x * this.y;
+    @Override
+    public Vector3d crossProduct(VectorInterface3d other) {
+        double newX = this.y * other.getZ() - other.getY() * this.z;
+        double newY = this.z * other.getX() - other.getZ() * this.x;
+        double newZ = this.x * other.getY() - other.getX() * this.y;
         return new Vector3d(newX, newY, newZ);
     }
 
-    public double dot(Vector3d other) {
-        return this.x * other.x + this.y * other.y + this.z * other.z;
+    @Override
+    public double dot(VectorInterface3d other) {
+        return this.x * other.getX() + this.y * other.getY() + this.z * other.getZ();
     }
 
+    @Override
     public Vector3d with(Double x, Double y, Double z) {
         return new Vector3d(x == null ? this.x : x, y == null ? this.y : y, z == null ? this.z : z);
     }
 
+    @Override
     public Vector3d withX(double x) {
         return new Vector3d(x, this.y, this.z);
     }
 
+    @Override
     public Vector3d withY(double y) {
         return new Vector3d(this.x, y, this.z);
     }
 
+    @Override
     public Vector3d withZ(double z) {
         return new Vector3d(this.x, this.y, z);
     }
 
-    public double distance(Vector3d other) {
+    @Override
+    public double distance(VectorInterface3d other) {
         return Math.sqrt(distanceSquared(other));
     }
 
+    @Override
     public double length() {
         return Math.sqrt(lengthSquared());
     }
 
+    @Override
     public double lengthSquared() {
         return (x * x) + (y * y) + (z * z);
     }
 
+    @Override
     public Vector3d normalize() {
         double length = length();
-
         return new Vector3d(x / length, y / length, z / length);
     }
 
-    public double distanceSquared(Vector3d other) {
-        double distX = (x - other.x) * (x - other.x);
-        double distY = (y - other.y) * (y - other.y);
-        double distZ = (z - other.z) * (z - other.z);
+    @Override
+    public double distanceSquared(VectorInterface3d other) {
+        double distX = (x - other.getX()) * (x - other.getX());
+        double distY = (y - other.getY()) * (y - other.getY());
+        double distZ = (z - other.getZ()) * (z - other.getZ());
         return distX + distY + distZ;
     }
 
+    @Override
     public Vector3i toVector3i() {
         return new Vector3i((int) x, (int) y, (int) z);
     }
@@ -276,18 +264,17 @@ public class Vector3d implements VectorInterface3d {
         return "X: " + x + ", Y: " + y + ", Z: " + z;
     }
 
-    public static Vector3d zero() {
-        return new Vector3d();
-    }
-
+    @Override
     public int getBlockX() {
         return MathUtil.floor(x);
     }
 
+    @Override
     public int getBlockY() {
         return MathUtil.floor(y);
     }
 
+    @Override
     public int getBlockZ() {
         return MathUtil.floor(z);
     }
@@ -299,5 +286,32 @@ public class Vector3d implements VectorInterface3d {
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }
+    }
+
+    public static Vector3d read(PacketWrapper<?> wrapper) {
+        double x = wrapper.readDouble();
+        double y = wrapper.readDouble();
+        double z = wrapper.readDouble();
+        return new Vector3d(x, y, z);
+    }
+
+    public static void write(PacketWrapper<?> wrapper, VectorInterface3d vector) {
+        VectorInterface3d.write(wrapper, vector);
+    }
+
+    public static Vector3d decode(NBT tag, ClientVersion version) {
+        NBTList<?> list = (NBTList<?>) tag;
+        double x = ((NBTNumber) list.getTag(0)).getAsDouble();
+        double y = ((NBTNumber) list.getTag(1)).getAsDouble();
+        double z = ((NBTNumber) list.getTag(2)).getAsDouble();
+        return new Vector3d(x, y, z);
+    }
+
+    public static NBT encode(VectorInterface3d vector3d, ClientVersion version) {
+        return VectorInterface3d.encode(vector3d, version);
+    }
+
+    public static Vector3d zero() {
+        return new Vector3d();
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -151,6 +151,10 @@ public class Vector3d implements VectorInterface3d {
         return z;
     }
 
+    public boolean equals(Vector3d other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -28,6 +28,7 @@ import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * 3D double Vector.
@@ -37,7 +38,7 @@ import java.util.Objects;
  * @author retrooper
  * @since 1.8
  */
-public class Vector3d {
+public class Vector3d implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -269,5 +270,14 @@ public class Vector3d {
 
     public static Vector3d zero() {
         return new Vector3d();
+    }
+
+    @NotNull
+    public Vector3d clone() {
+        try {
+            return (Vector3d) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -42,15 +42,15 @@ public class Vector3d implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final double x;
+    public double x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final double y;
+    public double y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final double z;
+    public double z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
@@ -270,6 +270,24 @@ public class Vector3d implements Cloneable {
 
     public static Vector3d zero() {
         return new Vector3d();
+    }
+
+    @NotNull
+    public Vector3d setX(double x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public Vector3d setY(double y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public Vector3d setZ(double z) {
+        this.z = z;
+        return this;
     }
 
     @NotNull

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -290,6 +290,18 @@ public class Vector3d implements Cloneable {
         return this;
     }
 
+    public int getBlockX() {
+        return (int) Math.floor(x);
+    }
+
+    public int getBlockY() {
+        return (int) Math.floor(y);
+    }
+
+    public int getBlockZ() {
+        return (int) Math.floor(z);
+    }
+
     @NotNull
     public Vector3d clone() {
         try {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java
@@ -153,7 +153,8 @@ public class Vector3d implements VectorInterface3d {
 
     /**
      * Is the object we are comparing to equal to us?
-     * It must be of type Vector3d or Vector3i and all values must be equal to the values in this class.
+     * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f
+     * and all values must be equal to the values in this class.
      *
      * @param obj Compared object.
      * @return Are they equal?
@@ -163,12 +164,12 @@ public class Vector3d implements VectorInterface3d {
         if (obj instanceof VectorInterface3d) {
             VectorInterface3d vec = (VectorInterface3d) obj;
             return x == vec.getX() && y == vec.getY() && z == vec.getZ();
-        } else if (obj instanceof Vector3f) {
-            Vector3f vec = (Vector3f) obj;
-            return x == vec.x && y == vec.y && z == vec.z;
-        } else if (obj instanceof Vector3i) {
-            Vector3i vec = (Vector3i) obj;
-            return x == (double) vec.x && y == (double) vec.y && z == (double) vec.z;
+        } else if (obj instanceof VectorInterface3f) {
+            VectorInterface3f vec = (VectorInterface3f) obj;
+            return x == vec.getX() && y == vec.getY() && z == vec.getZ();
+        } else if (obj instanceof VectorInterface3i) {
+            VectorInterface3i vec = (VectorInterface3i) obj;
+            return x == (double) vec.getX() && y == (double) vec.getY() && z == (double) vec.getZ();
         }
         return false;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -21,6 +21,7 @@ package com.github.retrooper.packetevents.util;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 
 import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * 3D float Vector.
@@ -30,7 +31,7 @@ import java.util.Objects;
  * @author retrooper
  * @since 1.8
  */
-public class Vector3f {
+public class Vector3f implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -204,6 +205,15 @@ public class Vector3f {
 
     public static Vector3f zero() {
         return new Vector3f();
+    }
+
+    @NotNull
+    public Vector3f clone() {
+        try {
+            return (Vector3f) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
     }
 }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -35,15 +35,15 @@ public class Vector3f implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final float x;
+    public float x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final float y;
+    public float y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final float z;
+    public float z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
@@ -205,6 +205,24 @@ public class Vector3f implements Cloneable {
 
     public static Vector3f zero() {
         return new Vector3f();
+    }
+
+    @NotNull
+    public Vector3f setX(float x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public Vector3f setY(float y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public Vector3f setZ(int z) {
+        this.z = z;
+        return this;
     }
 
     @NotNull

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  * @author retrooper
  * @since 1.8
  */
-public class Vector3f implements Cloneable {
+public class Vector3f implements VectorInterface3f {
     /**
      * X (coordinate/angle/whatever you wish)
      */

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -112,6 +112,10 @@ public class Vector3f implements Cloneable {
         return z;
     }
 
+    public boolean equals(Vector3f other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -23,6 +23,7 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 
 import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * 3D int Vector.
@@ -33,7 +34,7 @@ import java.util.Objects;
  * @author retrooper
  * @since 1.7
  */
-public class Vector3i {
+public class Vector3i implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -255,5 +256,14 @@ public class Vector3i {
 
     public static Vector3i zero() {
         return new Vector3i();
+    }
+
+    @NotNull
+    public Vector3i clone() {
+        try {
+            return (Vector3i) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -159,6 +159,10 @@ public class Vector3i implements Cloneable {
         return z;
     }
 
+    public boolean equals(Vector3i other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
  * @author retrooper
  * @since 1.7
  */
-public class Vector3i implements Cloneable {
+public class Vector3i implements VectorInterface3i {
     /**
      * X (coordinate/angle/whatever you wish)
      */

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -38,15 +38,15 @@ public class Vector3i implements Cloneable {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final int x;
+    public int x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final int y;
+    public int y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final int z;
+    public int z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
@@ -247,6 +247,24 @@ public class Vector3i implements Cloneable {
 
     public Vector3i withZ(int z) {
         return new Vector3i(this.x, this.y, z);
+    }
+
+    @NotNull
+    public Vector3i setX(int x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public Vector3i setY(int y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public Vector3i setZ(int z) {
+        this.z = z;
+        return this;
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3d.java
@@ -1,0 +1,7 @@
+package com.github.retrooper.packetevents.util;
+
+public interface VectorInterface3d extends Cloneable {
+    double getX();
+    double getY();
+    double getZ();
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3d.java
@@ -1,7 +1,77 @@
 package com.github.retrooper.packetevents.util;
 
-public interface VectorInterface3d extends Cloneable {
+import com.github.retrooper.packetevents.protocol.nbt.NBT;
+import com.github.retrooper.packetevents.protocol.nbt.NBTDouble;
+import com.github.retrooper.packetevents.protocol.nbt.NBTList;
+import com.github.retrooper.packetevents.protocol.nbt.NBTType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.world.BlockFace;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+
+public interface VectorInterface3d {
+    static void write(PacketWrapper<?> wrapper, VectorInterface3d vector) {
+        wrapper.writeDouble(vector.getX());
+        wrapper.writeDouble(vector.getY());
+        wrapper.writeDouble(vector.getZ());
+    }
+
+    static NBT encode(VectorInterface3d vector3d, ClientVersion version) {
+        NBTList<NBTDouble> list = new NBTList<>(NBTType.DOUBLE, 3);
+        list.addTag(new NBTDouble(vector3d.getX()));
+        list.addTag(new NBTDouble(vector3d.getY()));
+        list.addTag(new NBTDouble(vector3d.getZ()));
+        return list;
+    }
+
     double getX();
+
     double getY();
+
     double getZ();
+
+    VectorInterface3d add(double x, double y, double z);
+
+    VectorInterface3d add(VectorInterface3i other);
+
+    VectorInterface3d offset(BlockFace face);
+
+    VectorInterface3d subtract(double x, double y, double z);
+
+    VectorInterface3d subtract(VectorInterface3d other);
+
+    VectorInterface3d multiply(double x, double y, double z);
+
+    VectorInterface3d multiply(VectorInterface3d other);
+
+    VectorInterface3d multiply(double value);
+
+    VectorInterface3d crossProduct(VectorInterface3d other);
+
+    double dot(VectorInterface3d other);
+
+    VectorInterface3d with(Double x, Double y, Double z);
+
+    VectorInterface3d withX(double x);
+
+    VectorInterface3d withY(double y);
+
+    VectorInterface3d withZ(double z);
+
+    double distance(VectorInterface3d other);
+
+    double length();
+
+    double lengthSquared();
+
+    VectorInterface3d normalize();
+
+    double distanceSquared(VectorInterface3d other);
+
+    Vector3i toVector3i();
+
+    int getBlockX();
+
+    int getBlockY();
+
+    int getBlockZ();
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3f.java
@@ -1,0 +1,7 @@
+package com.github.retrooper.packetevents.util;
+
+public interface VectorInterface3f extends Cloneable {
+    float getX();
+    float getY();
+    float getZ();
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorInterface3i.java
@@ -1,0 +1,7 @@
+package com.github.retrooper.packetevents.util;
+
+public interface VectorInterface3i extends Cloneable {
+    int getX();
+    int getY();
+    int getZ();
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorM3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorM3d.java
@@ -26,7 +26,6 @@ import com.github.retrooper.packetevents.protocol.nbt.NBTType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,24 +37,24 @@ import org.jetbrains.annotations.NotNull;
  * @author retrooper
  * @since 1.8
  */
-public class Vector3d implements VectorInterface3d {
+public class VectorM3d implements VectorInterface3d {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final double x;
+    public double x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final double y;
+    public double y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final double z;
+    public double z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
      */
-    public Vector3d() {
+    public VectorM3d() {
         this.x = 0.0;
         this.y = 0.0;
         this.z = 0.0;
@@ -68,7 +67,7 @@ public class Vector3d implements VectorInterface3d {
      * @param y Y
      * @param z Z
      */
-    public Vector3d(double x, double y, double z) {
+    public VectorM3d(double x, double y, double z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -82,7 +81,7 @@ public class Vector3d implements VectorInterface3d {
      *
      * @param array Array.
      */
-    public Vector3d(double[] array) {
+    public VectorM3d(double[] array) {
         if (array.length > 0) {
             x = array[0];
         } else {
@@ -107,28 +106,28 @@ public class Vector3d implements VectorInterface3d {
         }
     }
 
-    public static Vector3d read(PacketWrapper<?> wrapper) {
+    public static VectorM3d read(PacketWrapper<?> wrapper) {
         double x = wrapper.readDouble();
         double y = wrapper.readDouble();
         double z = wrapper.readDouble();
-        return new Vector3d(x, y, z);
+        return new VectorM3d(x, y, z);
     }
 
-    public static void write(PacketWrapper<?> wrapper, Vector3d vector) {
+    public static void write(PacketWrapper<?> wrapper, VectorM3d vector) {
         wrapper.writeDouble(vector.x);
         wrapper.writeDouble(vector.y);
         wrapper.writeDouble(vector.z);
     }
 
-    public static Vector3d decode(NBT tag, ClientVersion version) {
+    public static VectorM3d decode(NBT tag, ClientVersion version) {
         NBTList<?> list = (NBTList<?>) tag;
         double x = ((NBTNumber) list.getTag(0)).getAsDouble();
         double y = ((NBTNumber) list.getTag(1)).getAsDouble();
         double z = ((NBTNumber) list.getTag(2)).getAsDouble();
-        return new Vector3d(x, y, z);
+        return new VectorM3d(x, y, z);
     }
 
-    public static NBT encode(Vector3d vector3d, ClientVersion version) {
+    public static NBT encode(VectorM3d vector3d, ClientVersion version) {
         NBTList<NBTDouble> list = new NBTList<>(NBTType.DOUBLE, 3);
         list.addTag(new NBTDouble(vector3d.x));
         list.addTag(new NBTDouble(vector3d.y));
@@ -178,66 +177,62 @@ public class Vector3d implements VectorInterface3d {
         return Objects.hash(x, y, z);
     }
 
-    public Vector3d add(double x, double y, double z) {
-        return new Vector3d(this.x + x, this.y + y, this.z + z);
+    public VectorM3d add(double x, double y, double z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
     }
 
-    public Vector3d add(Vector3d other) {
+    public VectorM3d add(VectorM3d other) {
         return add(other.x, other.y, other.z);
     }
 
-    public Vector3d offset(BlockFace face) {
+    public VectorM3d offset(BlockFace face) {
         return add(face.getModX(), face.getModY(), face.getModZ());
     }
 
-    public Vector3d subtract(double x, double y, double z) {
-        return new Vector3d(this.x - x, this.y - y, this.z - z);
+    public VectorM3d subtract(double x, double y, double z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
     }
 
-    public Vector3d subtract(Vector3d other) {
+    public VectorM3d subtract(VectorM3d other) {
         return subtract(other.x, other.y, other.z);
     }
 
-    public Vector3d multiply(double x, double y, double z) {
-        return new Vector3d(this.x * x, this.y * y, this.z * z);
+    public VectorM3d multiply(double x, double y, double z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
     }
 
-    public Vector3d multiply(Vector3d other) {
+    public VectorM3d multiply(VectorM3d other) {
         return multiply(other.x, other.y, other.z);
     }
 
-    public Vector3d multiply(double value) {
+    public VectorM3d multiply(double value) {
         return multiply(value, value, value);
     }
 
-    public Vector3d crossProduct(Vector3d other) {
+    public VectorM3d crossProduct(VectorM3d other) {
         double newX = this.y * other.z - other.y * this.z;
         double newY = this.z * other.x - other.z * this.x;
         double newZ = this.x * other.y - other.x * this.y;
-        return new Vector3d(newX, newY, newZ);
+        this.x = newX;
+        this.y = newY;
+        this.z = newZ;
+        return this;
     }
 
-    public double dot(Vector3d other) {
+    public double dot(VectorM3d other) {
         return this.x * other.x + this.y * other.y + this.z * other.z;
     }
 
-    public Vector3d with(Double x, Double y, Double z) {
-        return new Vector3d(x == null ? this.x : x, y == null ? this.y : y, z == null ? this.z : z);
-    }
-
-    public Vector3d withX(double x) {
-        return new Vector3d(x, this.y, this.z);
-    }
-
-    public Vector3d withY(double y) {
-        return new Vector3d(this.x, y, this.z);
-    }
-
-    public Vector3d withZ(double z) {
-        return new Vector3d(this.x, this.y, z);
-    }
-
-    public double distance(Vector3d other) {
+    public double distance(VectorM3d other) {
         return Math.sqrt(distanceSquared(other));
     }
 
@@ -249,13 +244,15 @@ public class Vector3d implements VectorInterface3d {
         return (x * x) + (y * y) + (z * z);
     }
 
-    public Vector3d normalize() {
+    public VectorM3d normalize() {
         double length = length();
-
-        return new Vector3d(x / length, y / length, z / length);
+        this.x /= length;
+        this.y /= length;
+        this.z /= length;
+        return this;
     }
 
-    public double distanceSquared(Vector3d other) {
+    public double distanceSquared(VectorM3d other) {
         double distX = (x - other.x) * (x - other.x);
         double distY = (y - other.y) * (y - other.y);
         double distZ = (z - other.z) * (z - other.z);
@@ -271,8 +268,26 @@ public class Vector3d implements VectorInterface3d {
         return "X: " + x + ", Y: " + y + ", Z: " + z;
     }
 
-    public static Vector3d zero() {
-        return new Vector3d();
+    public static VectorM3d zero() {
+        return new VectorM3d();
+    }
+
+    @NotNull
+    public VectorM3d setX(double x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public VectorM3d setY(double y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public VectorM3d setZ(double z) {
+        this.z = z;
+        return this;
     }
 
     public int getBlockX() {
@@ -288,9 +303,9 @@ public class Vector3d implements VectorInterface3d {
     }
 
     @NotNull
-    public Vector3d clone() {
+    public VectorM3d clone() {
         try {
-            return (Vector3d) super.clone();
+            return (VectorM3d) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3d.java
@@ -35,9 +35,9 @@ import org.jetbrains.annotations.NotNull;
  * You can use this to represent an array if you really want.
  *
  * @author retrooper
- * @since 1.8
+ * @since 2.7.1
  */
-public class VectorM3d implements VectorInterface3d {
+public class VectorMutable3d implements VectorInterface3d {
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -54,7 +54,7 @@ public class VectorM3d implements VectorInterface3d {
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
      */
-    public VectorM3d() {
+    public VectorMutable3d() {
         this.x = 0.0;
         this.y = 0.0;
         this.z = 0.0;
@@ -67,7 +67,7 @@ public class VectorM3d implements VectorInterface3d {
      * @param y Y
      * @param z Z
      */
-    public VectorM3d(double x, double y, double z) {
+    public VectorMutable3d(double x, double y, double z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -81,7 +81,7 @@ public class VectorM3d implements VectorInterface3d {
      *
      * @param array Array.
      */
-    public VectorM3d(double[] array) {
+    public VectorMutable3d(double[] array) {
         if (array.length > 0) {
             x = array[0];
         } else {
@@ -106,28 +106,28 @@ public class VectorM3d implements VectorInterface3d {
         }
     }
 
-    public static VectorM3d read(PacketWrapper<?> wrapper) {
+    public static VectorMutable3d read(PacketWrapper<?> wrapper) {
         double x = wrapper.readDouble();
         double y = wrapper.readDouble();
         double z = wrapper.readDouble();
-        return new VectorM3d(x, y, z);
+        return new VectorMutable3d(x, y, z);
     }
 
-    public static void write(PacketWrapper<?> wrapper, VectorM3d vector) {
+    public static void write(PacketWrapper<?> wrapper, VectorMutable3d vector) {
         wrapper.writeDouble(vector.x);
         wrapper.writeDouble(vector.y);
         wrapper.writeDouble(vector.z);
     }
 
-    public static VectorM3d decode(NBT tag, ClientVersion version) {
+    public static VectorMutable3d decode(NBT tag, ClientVersion version) {
         NBTList<?> list = (NBTList<?>) tag;
         double x = ((NBTNumber) list.getTag(0)).getAsDouble();
         double y = ((NBTNumber) list.getTag(1)).getAsDouble();
         double z = ((NBTNumber) list.getTag(2)).getAsDouble();
-        return new VectorM3d(x, y, z);
+        return new VectorMutable3d(x, y, z);
     }
 
-    public static NBT encode(VectorM3d vector3d, ClientVersion version) {
+    public static NBT encode(VectorMutable3d vector3d, ClientVersion version) {
         NBTList<NBTDouble> list = new NBTList<>(NBTType.DOUBLE, 3);
         list.addTag(new NBTDouble(vector3d.x));
         list.addTag(new NBTDouble(vector3d.y));
@@ -152,7 +152,8 @@ public class VectorM3d implements VectorInterface3d {
 
     /**
      * Is the object we are comparing to equal to us?
-     * It must be of type Vector3d or Vector3i and all values must be equal to the values in this class.
+     * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f
+     * and all values must be equal to the values in this class.
      *
      * @param obj Compared object.
      * @return Are they equal?
@@ -162,12 +163,12 @@ public class VectorM3d implements VectorInterface3d {
         if (obj instanceof VectorInterface3d) {
             VectorInterface3d vec = (VectorInterface3d) obj;
             return x == vec.getX() && y == vec.getY() && z == vec.getZ();
-        } else if (obj instanceof Vector3f) {
-            Vector3f vec = (Vector3f) obj;
-            return x == vec.x && y == vec.y && z == vec.z;
-        } else if (obj instanceof Vector3i) {
-            Vector3i vec = (Vector3i) obj;
-            return x == (double) vec.x && y == (double) vec.y && z == (double) vec.z;
+        } else if (obj instanceof VectorInterface3f) {
+            VectorInterface3f vec = (VectorInterface3f) obj;
+            return x == vec.getX() && y == vec.getY() && z == vec.getZ();
+        } else if (obj instanceof VectorInterface3i) {
+            VectorInterface3i vec = (VectorInterface3i) obj;
+            return x == (double) vec.getX() && y == (double) vec.getY() && z == (double) vec.getZ();
         }
         return false;
     }
@@ -177,48 +178,48 @@ public class VectorM3d implements VectorInterface3d {
         return Objects.hash(x, y, z);
     }
 
-    public VectorM3d add(double x, double y, double z) {
+    public VectorMutable3d add(double x, double y, double z) {
         this.x += x;
         this.y += y;
         this.z += z;
         return this;
     }
 
-    public VectorM3d add(VectorM3d other) {
+    public VectorMutable3d add(VectorMutable3d other) {
         return add(other.x, other.y, other.z);
     }
 
-    public VectorM3d offset(BlockFace face) {
+    public VectorMutable3d offset(BlockFace face) {
         return add(face.getModX(), face.getModY(), face.getModZ());
     }
 
-    public VectorM3d subtract(double x, double y, double z) {
+    public VectorMutable3d subtract(double x, double y, double z) {
         this.x -= x;
         this.y -= y;
         this.z -= z;
         return this;
     }
 
-    public VectorM3d subtract(VectorM3d other) {
+    public VectorMutable3d subtract(VectorMutable3d other) {
         return subtract(other.x, other.y, other.z);
     }
 
-    public VectorM3d multiply(double x, double y, double z) {
+    public VectorMutable3d multiply(double x, double y, double z) {
         this.x -= x;
         this.y -= y;
         this.z -= z;
         return this;
     }
 
-    public VectorM3d multiply(VectorM3d other) {
+    public VectorMutable3d multiply(VectorMutable3d other) {
         return multiply(other.x, other.y, other.z);
     }
 
-    public VectorM3d multiply(double value) {
+    public VectorMutable3d multiply(double value) {
         return multiply(value, value, value);
     }
 
-    public VectorM3d crossProduct(VectorM3d other) {
+    public VectorMutable3d crossProduct(VectorMutable3d other) {
         double newX = this.y * other.z - other.y * this.z;
         double newY = this.z * other.x - other.z * this.x;
         double newZ = this.x * other.y - other.x * this.y;
@@ -228,11 +229,11 @@ public class VectorM3d implements VectorInterface3d {
         return this;
     }
 
-    public double dot(VectorM3d other) {
+    public double dot(VectorMutable3d other) {
         return this.x * other.x + this.y * other.y + this.z * other.z;
     }
 
-    public double distance(VectorM3d other) {
+    public double distance(VectorMutable3d other) {
         return Math.sqrt(distanceSquared(other));
     }
 
@@ -244,7 +245,7 @@ public class VectorM3d implements VectorInterface3d {
         return (x * x) + (y * y) + (z * z);
     }
 
-    public VectorM3d normalize() {
+    public VectorMutable3d normalize() {
         double length = length();
         this.x /= length;
         this.y /= length;
@@ -252,7 +253,7 @@ public class VectorM3d implements VectorInterface3d {
         return this;
     }
 
-    public double distanceSquared(VectorM3d other) {
+    public double distanceSquared(VectorMutable3d other) {
         double distX = (x - other.x) * (x - other.x);
         double distY = (y - other.y) * (y - other.y);
         double distZ = (z - other.z) * (z - other.z);
@@ -268,24 +269,24 @@ public class VectorM3d implements VectorInterface3d {
         return "X: " + x + ", Y: " + y + ", Z: " + z;
     }
 
-    public static VectorM3d zero() {
-        return new VectorM3d();
+    public static VectorMutable3d zero() {
+        return new VectorMutable3d();
     }
 
     @NotNull
-    public VectorM3d setX(double x) {
+    public VectorMutable3d setX(double x) {
         this.x = x;
         return this;
     }
 
     @NotNull
-    public VectorM3d setY(double y) {
+    public VectorMutable3d setY(double y) {
         this.y = y;
         return this;
     }
 
     @NotNull
-    public VectorM3d setZ(double z) {
+    public VectorMutable3d setZ(double z) {
         this.z = z;
         return this;
     }
@@ -303,9 +304,9 @@ public class VectorM3d implements VectorInterface3d {
     }
 
     @NotNull
-    public VectorM3d clone() {
+    public VectorMutable3d clone() {
         try {
-            return (VectorM3d) super.clone();
+            return (VectorMutable3d) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3d.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3d.java
@@ -150,6 +150,10 @@ public class VectorMutable3d implements VectorInterface3d {
         return z;
     }
 
+    public boolean equals(VectorMutable3d other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
@@ -111,6 +111,10 @@ public class VectorMutable3f implements VectorInterface3f {
         return z;
     }
 
+    public boolean equals(VectorMutable3f other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
@@ -19,7 +19,6 @@
 package com.github.retrooper.packetevents.util;
 
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
-
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,26 +28,26 @@ import org.jetbrains.annotations.NotNull;
  * You can use this to represent an array if you really want.
  *
  * @author retrooper
- * @since 1.8
+ * @since 2.7.1
  */
-public class Vector3f implements Cloneable {
+public class VectorMutable3f implements VectorInterface3f {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final float x;
+    public float x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final float y;
+    public float y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final float z;
+    public float z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
      */
-    public Vector3f() {
+    public VectorMutable3f() {
         this.x = 0.0f;
         this.y = 0.0f;
         this.z = 0.0f;
@@ -61,7 +60,7 @@ public class Vector3f implements Cloneable {
      * @param y Y
      * @param z Z
      */
-    public Vector3f(float x, float y, float z) {
+    public VectorMutable3f(float x, float y, float z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -75,7 +74,7 @@ public class Vector3f implements Cloneable {
      *
      * @param array Array.
      */
-    public Vector3f(float[] array) {
+    public VectorMutable3f(float[] array) {
         if (array.length > 0) {
             x = array[0];
         } else {
@@ -140,63 +139,59 @@ public class Vector3f implements Cloneable {
         return Objects.hash(x, y, z);
     }
 
-    public Vector3f add(float x, float y, float z) {
-        return new Vector3f(this.x + x, this.y + y, this.z + z);
+    public VectorMutable3f add(float x, float y, float z) {
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
     }
 
-    public Vector3f add(Vector3f other) {
+    public VectorMutable3f add(VectorMutable3f other) {
         return add(other.x, other.y, other.z);
     }
 
-    public Vector3f offset(BlockFace face) {
+    public VectorMutable3f offset(BlockFace face) {
         return add(face.getModX(), face.getModY(), face.getModZ());
     }
 
-    public Vector3f subtract(float x, float y, float z) {
-        return new Vector3f(this.x - x, this.y - y, this.z - z);
+    public VectorMutable3f subtract(float x, float y, float z) {
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
     }
 
-    public Vector3f subtract(Vector3f other) {
+    public VectorMutable3f subtract(VectorMutable3f other) {
         return subtract(other.x, other.y, other.z);
     }
 
-    public Vector3f multiply(float x, float y, float z) {
-        return new Vector3f(this.x * x, this.y * y, this.z * z);
+    public VectorMutable3f multiply(float x, float y, float z) {
+        this.x *= x;
+        this.y *= y;
+        this.z *= y;
+        return this;
     }
 
-    public Vector3f multiply(Vector3f other) {
+    public VectorMutable3f multiply(VectorMutable3f other) {
         return multiply(other.x, other.y, other.z);
     }
 
-    public Vector3f multiply(float value) {
+    public VectorMutable3f multiply(float value) {
         return multiply(value, value, value);
     }
 
-    public Vector3f crossProduct(Vector3f other) {
+    public VectorMutable3f crossProduct(VectorMutable3f other) {
         float newX = this.y * other.z - other.y * this.z;
         float newY = this.z * other.x - other.z * this.x;
         float newZ = this.x * other.y - other.x * this.y;
-        return new Vector3f(newX, newY, newZ);
+        this.x = newX;
+        this.y = newY;
+        this.z = newZ;
+        return this;
     }
 
-    public float dot(Vector3f other) {
+    public float dot(VectorMutable3f other) {
         return this.x * other.x + this.y * other.y + this.z * other.z;
-    }
-
-    public Vector3f with(Float x, Float y, Float z) {
-        return new Vector3f(x == null ? this.x : x, y == null ? this.y : y, z == null ? this.z : z);
-    }
-
-    public Vector3f withX(float x) {
-        return new Vector3f(x, this.y, this.z);
-    }
-
-    public Vector3f withY(float y) {
-        return new Vector3f(this.x, y, this.z);
-    }
-
-    public Vector3f withZ(float z) {
-        return new Vector3f(this.x, this.y, z);
     }
 
     @Override
@@ -204,14 +199,32 @@ public class Vector3f implements Cloneable {
         return "X: " + x + ", Y: " + y + ", Z: " + z;
     }
 
-    public static Vector3f zero() {
-        return new Vector3f();
+    public static VectorMutable3f zero() {
+        return new VectorMutable3f();
     }
 
     @NotNull
-    public Vector3f clone() {
+    public VectorMutable3f setX(float x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public VectorMutable3f setY(float y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public VectorMutable3f setZ(int z) {
+        this.z = z;
+        return this;
+    }
+
+    @NotNull
+    public VectorMutable3f clone() {
         try {
-            return (Vector3f) super.clone();
+            return (VectorMutable3f) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3f.java
@@ -185,12 +185,11 @@ public class VectorMutable3f implements VectorInterface3f {
     }
 
     public VectorMutable3f crossProduct(VectorMutable3f other) {
-        float newX = this.y * other.z - other.y * this.z;
-        float newY = this.z * other.x - other.z * this.x;
-        float newZ = this.x * other.y - other.x * this.y;
-        this.x = newX;
-        this.y = newY;
-        this.z = newZ;
+        float oldX = this.x;
+        float oldY = this.y;
+        this.x = this.y * other.z - other.y * this.z;
+        this.y = this.z * other.x - other.z * oldX;
+        this.z = oldX * other.y - this.x * oldY;
         return this;
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
@@ -195,7 +195,10 @@ public class VectorMutable3i implements VectorInterface3i {
     }
 
     public VectorMutable3i add(int x, int y, int z) {
-        return new VectorMutable3i(this.x + x, this.y + y, this.z + z);
+        this.x += x;
+        this.y += y;
+        this.z += z;
+        return this;
     }
 
     public VectorMutable3i add(VectorMutable3i other) {
@@ -207,7 +210,10 @@ public class VectorMutable3i implements VectorInterface3i {
     }
 
     public VectorMutable3i subtract(int x, int y, int z) {
-        return new VectorMutable3i(this.x - x, this.y - y, this.z - z);
+        this.x -= x;
+        this.y -= y;
+        this.z -= z;
+        return this;
     }
 
     public VectorMutable3i subtract(VectorMutable3i other) {
@@ -215,7 +221,10 @@ public class VectorMutable3i implements VectorInterface3i {
     }
 
     public VectorMutable3i multiply(int x, int y, int z) {
-        return new VectorMutable3i(this.x * x, this.y * y, this.z * z);
+        this.x *= x;
+        this.y *= y;
+        this.z *= z;
+        return this;
     }
 
     public VectorMutable3i multiply(VectorMutable3i other) {
@@ -227,10 +236,12 @@ public class VectorMutable3i implements VectorInterface3i {
     }
 
     public VectorMutable3i crossProduct(VectorMutable3i other) {
-        int newX = this.y * other.z - other.y * this.z;
-        int newY = this.z * other.x - other.z * this.x;
-        int newZ = this.x * other.y - other.x * this.y;
-        return new VectorMutable3i(newX, newY, newZ);
+        int oldX = this.x;
+        int oldY = this.y;
+        this.x = this.y * other.z - other.y * this.z;
+        this.y = this.z * other.x - other.z * oldX;
+        this.z = oldX * other.y - this.x * oldY;
+        return this;
     }
 
     public int dot(VectorMutable3i other) {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
@@ -158,6 +158,10 @@ public class VectorMutable3i implements VectorInterface3i {
         return z;
     }
 
+    public boolean equals(VectorMutable3i other) {
+        return this.x == other.x && this.y == other.y && this.z == other.z;
+    }
+
     /**
      * Is the object we are comparing to equal to us?
      * It must implement VectorInterface3i, VectorInterface3d, or VectorInterface3f

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VectorMutable3i.java
@@ -21,7 +21,6 @@ package com.github.retrooper.packetevents.util;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.world.BlockFace;
-
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,36 +31,36 @@ import org.jetbrains.annotations.NotNull;
  * PacketEvents usually uses this for block positions as they don't need any decimals.
  *
  * @author retrooper
- * @since 1.7
+ * @since 2.7.1
  */
-public class Vector3i implements Cloneable {
+public class VectorMutable3i implements VectorInterface3i {
     /**
      * X (coordinate/angle/whatever you wish)
      */
-    public final int x;
+    public int x;
     /**
      * Y (coordinate/angle/whatever you wish)
      */
-    public final int y;
+    public int y;
     /**
      * Z (coordinate/angle/whatever you wish)
      */
-    public final int z;
+    public int z;
 
     /**
      * Default constructor setting all coordinates/angles/values to their default values (=0).
      */
-    public Vector3i() {
+    public VectorMutable3i() {
         this.x = 0;
         this.y = 0;
         this.z = 0;
     }
 
-    public Vector3i(long val) {
+    public VectorMutable3i(long val) {
         this(val, PacketEvents.getAPI().getServerManager().getVersion());
     }
 
-    public Vector3i(long val, ServerVersion serverVersion) {
+    public VectorMutable3i(long val, ServerVersion serverVersion) {
         int x = (int) (val >> 38);
         int y;
         int z;
@@ -89,7 +88,7 @@ public class Vector3i implements Cloneable {
      * @param y Y
      * @param z Z
      */
-    public Vector3i(int x, int y, int z) {
+    public VectorMutable3i(int x, int y, int z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -103,7 +102,7 @@ public class Vector3i implements Cloneable {
      *
      * @param array Array.
      */
-    public Vector3i(int[] array) {
+    public VectorMutable3i(int[] array) {
         if (array.length > 0) {
             x = array[0];
         } else {
@@ -191,63 +190,81 @@ public class Vector3i implements Cloneable {
         return new Vector3d(x, y, z);
     }
 
-    public Vector3i add(int x, int y, int z) {
-        return new Vector3i(this.x + x, this.y + y, this.z + z);
+    public VectorMutable3i add(int x, int y, int z) {
+        return new VectorMutable3i(this.x + x, this.y + y, this.z + z);
     }
 
-    public Vector3i add(Vector3i other) {
+    public VectorMutable3i add(VectorMutable3i other) {
         return add(other.x, other.y, other.z);
     }
 
-    public Vector3i offset(BlockFace face) {
+    public VectorMutable3i offset(BlockFace face) {
         return add(face.getModX(), face.getModY(), face.getModZ());
     }
 
-    public Vector3i subtract(int x, int y, int z) {
-        return new Vector3i(this.x - x, this.y - y, this.z - z);
+    public VectorMutable3i subtract(int x, int y, int z) {
+        return new VectorMutable3i(this.x - x, this.y - y, this.z - z);
     }
 
-    public Vector3i subtract(Vector3i other) {
+    public VectorMutable3i subtract(VectorMutable3i other) {
         return subtract(other.x, other.y, other.z);
     }
 
-    public Vector3i multiply(int x, int y, int z) {
-        return new Vector3i(this.x * x, this.y * y, this.z * z);
+    public VectorMutable3i multiply(int x, int y, int z) {
+        return new VectorMutable3i(this.x * x, this.y * y, this.z * z);
     }
 
-    public Vector3i multiply(Vector3i other) {
+    public VectorMutable3i multiply(VectorMutable3i other) {
         return multiply(other.x, other.y, other.z);
     }
 
-    public Vector3i multiply(int value) {
+    public VectorMutable3i multiply(int value) {
         return multiply(value, value, value);
     }
 
-    public Vector3i crossProduct(Vector3i other) {
+    public VectorMutable3i crossProduct(VectorMutable3i other) {
         int newX = this.y * other.z - other.y * this.z;
         int newY = this.z * other.x - other.z * this.x;
         int newZ = this.x * other.y - other.x * this.y;
-        return new Vector3i(newX, newY, newZ);
+        return new VectorMutable3i(newX, newY, newZ);
     }
 
-    public int dot(Vector3i other) {
+    public int dot(VectorMutable3i other) {
         return this.x * other.x + this.y * other.y + this.z * other.z;
     }
 
-    public Vector3i with(Integer x, Integer y, Integer z) {
-        return new Vector3i(x == null ? this.x : x, y == null ? this.y : y, z == null ? this.z : z);
+    public VectorMutable3i with(Integer x, Integer y, Integer z) {
+        return new VectorMutable3i(x == null ? this.x : x, y == null ? this.y : y, z == null ? this.z : z);
     }
 
-    public Vector3i withX(int x) {
-        return new Vector3i(x, this.y, this.z);
+    public VectorMutable3i withX(int x) {
+        return new VectorMutable3i(x, this.y, this.z);
     }
 
-    public Vector3i withY(int y) {
-        return new Vector3i(this.x, y, this.z);
+    public VectorMutable3i withY(int y) {
+        return new VectorMutable3i(this.x, y, this.z);
     }
 
-    public Vector3i withZ(int z) {
-        return new Vector3i(this.x, this.y, z);
+    public VectorMutable3i withZ(int z) {
+        return new VectorMutable3i(this.x, this.y, z);
+    }
+
+    @NotNull
+    public VectorMutable3i setX(int x) {
+        this.x = x;
+        return this;
+    }
+
+    @NotNull
+    public VectorMutable3i setY(int y) {
+        this.y = y;
+        return this;
+    }
+
+    @NotNull
+    public VectorMutable3i setZ(int z) {
+        this.z = z;
+        return this;
     }
 
     @Override
@@ -255,14 +272,14 @@ public class Vector3i implements Cloneable {
         return "X: " + x + ", Y: " + y + ", Z: " + z;
     }
 
-    public static Vector3i zero() {
-        return new Vector3i();
+    public static VectorMutable3i zero() {
+        return new VectorMutable3i();
     }
 
     @NotNull
-    public Vector3i clone() {
+    public VectorMutable3i clone() {
         try {
-            return (Vector3i) super.clone();
+            return (VectorMutable3i) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new Error(e);
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VersionMapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VersionMapper.java
@@ -50,6 +50,7 @@ public class VersionMapper {
             }
             index--;
         }
+
         //Give them the oldest version
         return 0;
     }


### PR DESCRIPTION
Allow Vector3d, f, and i classes to be cloned and add setX, setY, and setZ methods to match Bukkit Vector abilities.

This is intended as part of the work in porting Grim to being multi-platform, which involves removing all usage of Bukkit Vectors, nevertheless we need to replace their functionality and would like to remain compatible with upstream PE.

I can understand if mutability in Vector3d, f, and i are things that you don't want changed, and if that's the case I'll instead work with you in finding a solution that allows us to not break from using PE vectors, such as  adding new Vector3dI, Vector3fI, etc.. classes as immutable variants and having Vector3d and Vector3dI share the same interface which is used internally in PE code that takes the vectors as arguments instead of `Vector3d`. 

This would allow developers to choose immutability if they so wish and use them with the PE methods that take Vector objects as arguments (there aren't that many so it'll be an easy fix).