### PR TITLE
Propagate exception while reading NBT

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/codec/NBTCodec.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/codec/NBTCodec.java
@@ -160,8 +160,8 @@ public class NBTCodec {
                 final boolean named = serverVersion.isOlderThan(ServerVersion.V_1_20_2);
                 return DefaultNBTSerializer.INSTANCE.deserializeTag(
                         limiter, new ByteBufInputStream(byteBuf), named);
-            } catch (IOException e) {
-                e.printStackTrace();
+            } catch (IOException ex) {
+                throw new IllegalStateException(ex);
             }
         }
         else {
@@ -180,7 +180,6 @@ public class NBTCodec {
                 throw new IllegalStateException(ex);
             }
         }
-        return null;
     }
 
     public static void writeNBTToBuffer(Object byteBuf, ServerVersion serverVersion, NBTCompound tag) {


### PR DESCRIPTION
There is a way to actually force PacketEvents to print exception forever leading the server to crash, there is no reason to eat the exception in that spot, we are not doing it anywhere