### PR TITLE
Fix grass_path (dirt_path) in WrappedBlockState

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -412,14 +412,15 @@ public class WrappedBlockState {
                     StateType type = StateTypes.getByName(typeString);
                     if (type == null) {
                         // Let's update the state type to a modern version
+                        String updatedString = typeString;
                         for (Map.Entry<String, String> stringEntry : STRING_UPDATER.entrySet()) {
-                            typeString = typeString.replace(stringEntry.getKey(), stringEntry.getValue());
+                            updatedString = typeString.replace(stringEntry.getKey(), stringEntry.getValue());
                         }
 
-                        type = StateTypes.getByName(typeString);
+                        type = StateTypes.getByName(updatedString);
 
                         if (type == null) {
-                            PacketEvents.getAPI().getLogger().warning("Unknown block type: " + typeString);
+                            PacketEvents.getAPI().getLogger().warning("Unknown block type: " + typeString + "/" + updatedString);
                             element.skip();
                             continue;
                         }


### PR DESCRIPTION
Fixes https://github.com/retrooper/packetevents/issues/1144
Fixes https://github.com/GrimAnticheat/Grim/issues/1733

**_Brief retelling of the issue_**
Due to the change in the name of the path block in version 1.17 (`grass_path` -> `dirt_path`) and `STRING_UPDATER` in `WrappedBlockState`, getting WrappedBlockState by name in versions <1.17 was broken and returns `AIR` (in fact null), instead of a real object

**Causes of problem**
`STRING_UPDATER` iteration replaced the `typeString`, which later replaced the block key in the Map and did not allow to get BlockState by its real name

**Tests**
```java
public void onEnable() {
    // 1.16.4
    System.out.println("V1.16.4 (dirt, grass)");
    printDebug(ClientVersion.V1_16_4);

    // 1.17
    System.out.println("V1.17 (dirt, grass)");
    printDebug(ClientVersion.V1_17);

    // 1.17.1
    System.out.println("V1.17.1 (dirt, grass)");
    printDebug(ClientVersion.V1_17_1);

    // 1.19.4
    System.out.println("V1.19.4 (dirt, grass)");
    printDebug(ClientVersion.V1_19_4);
}

private void printDebug(ClientVersion clientVersion) {
    System.out.println(WrappedBlockState.getByString(clientVersion, "minecraft:dirt_path").toString());
    System.out.println(WrappedBlockState.getByString(clientVersion, "minecraft:grass_path").toString());
}
```

output:
```
[06:56:40 INFO]: V1.16.4 (dirt, grass)
[06:56:40 INFO]: air
[06:56:40 INFO]: grass_path
[06:56:40 INFO]: V1.17 (dirt, grass)
[06:56:40 INFO]: dirt_path
[06:56:40 INFO]: air
[06:56:40 INFO]: V1.17.1 (dirt, grass)
[06:56:40 INFO]: dirt_path
[06:56:40 INFO]: air
[06:56:40 INFO]: V1.19.4 (dirt, grass)
[06:56:40 INFO]: dirt_path
[06:56:40 INFO]: air
```