### PR TITLE
Fix Fabric Platform Events

### DIFF
--- a/fabric/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
+++ b/fabric/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
@@ -18,15 +18,27 @@
 
 package io.github.retrooper.packetevents.handler;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
+import com.github.retrooper.packetevents.exception.CancelPacketException;
+import com.github.retrooper.packetevents.exception.InvalidDisconnectPacketSend;
+import com.github.retrooper.packetevents.exception.PacketProcessException;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.PacketSide;
 import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.ExceptionUtil;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDisconnect;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public class PacketEncoder extends ChannelOutboundHandlerAdapter {
@@ -34,6 +46,7 @@ public class PacketEncoder extends ChannelOutboundHandlerAdapter {
     private final PacketSide side;
     public User user;
     public Player player;
+    private ChannelPromise promise;
 
     public PacketEncoder(PacketSide side, User user) {
         this.side = side;
@@ -46,15 +59,100 @@ public class PacketEncoder extends ChannelOutboundHandlerAdapter {
             ctx.write(msg, promise);
             return;
         }
+
+        // Handle promise management first (matches Spigot)
+        ChannelPromise oldPromise = this.promise != null && !this.promise.isSuccess() ? this.promise : null;
+        promise.addListener(p -> this.promise = oldPromise);
+        this.promise = promise;
+
+        // Process the packet and execute post-send tasks (matches Spigot)
+        handlePacket(ctx, in, promise);
+
+        // Check for empty packets last (matches Spigot)
         if (!in.isReadable()) {
             in.release();
+            throw CancelPacketException.INSTANCE;
+        }
+
+        // Forward the packet if readable
+        ctx.write(in, promise);
+    }
+
+    private @Nullable ProtocolPacketEvent handlePacket(ChannelHandlerContext ctx, ByteBuf buffer, ChannelPromise promise) throws Exception {
+        // Process the packet using PacketEventsImplHelper (similar to Spigot)
+        ProtocolPacketEvent protocolPacketEvent = PacketEventsImplHelper.handlePacket(
+            ctx.channel(), this.user, this.player, buffer, false, this.side
+        );
+
+        // Execute post-send tasks (required for cross-platform support)
+        if (protocolPacketEvent instanceof PacketSendEvent packetSendEvent && packetSendEvent.hasTasksAfterSend()) {
+            promise.addListener((p) -> {
+                for (Runnable task : packetSendEvent.getTasksAfterSend()) {
+                    task.run();
+                }
+            });
+        }
+        return protocolPacketEvent;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        // Handle CancelPacketException (similar to Spigot)
+        if (ExceptionUtil.isException(cause, CancelPacketException.class)) {
             return;
         }
 
-        PacketEventsImplHelper.handlePacket(ctx.channel(),
-                this.user, this.player, in, false, this.side);
-        if (in.isReadable()) {
-            ctx.write(in, promise);
+        // Handle InvalidDisconnectPacketSend (similar to Spigot)
+        if (ExceptionUtil.isException(cause, InvalidDisconnectPacketSend.class)) {
+            return;
         }
+
+        // Handle PacketProcessException (similar to Spigot)
+        boolean didWeCauseThis = ExceptionUtil.isException(cause, PacketProcessException.class);
+        if (didWeCauseThis && (user == null || user.getEncoderState() != ConnectionState.HANDSHAKING)) {
+            if (!isMinecraftServerInstanceDebugging()) {
+                if (PacketEvents.getAPI().getSettings().isFullStackTraceEnabled()) {
+                    cause.printStackTrace();
+                } else {
+                    PacketEvents.getAPI().getLogManager().warn(cause.getMessage());
+                }
+            }
+
+            if (PacketEvents.getAPI().getSettings().isKickOnPacketExceptionEnabled()) {
+                try {
+                    if (user != null && player instanceof ServerPlayer) {
+                        // Use cross-platform PacketEvents wrapper for disconnect packet
+                        WrapperPlayServerDisconnect disconnectPacket = new WrapperPlayServerDisconnect(
+                            net.kyori.adventure.text.Component.text("Invalid packet")
+                        );
+                        user.sendPacket(disconnectPacket);
+                    }
+                } catch (Exception ignored) {
+                    // Ignore exceptions during disconnect (similar to Spigot)
+                }
+                ctx.channel().close();
+
+                if (player instanceof ServerPlayer serverPlayer) {
+                    // Schedule delayed kick (Fabric-specific, using Minecraft's scheduler)
+                    serverPlayer.getServer().execute(() -> {
+                        serverPlayer.connection.disconnect(Component.literal("Invalid packet"));
+                    });
+                }
+
+                if (user != null) {
+                    PacketEvents.getAPI().getLogManager().warn(
+                        "Disconnected " + user.getProfile().getName() + " due to invalid packet!"
+                    );
+                }
+            }
+        }
+
+        super.exceptionCaught(ctx, cause);
+    }
+
+    // Placeholder for Minecraft server debugging check (Fabric-specific)
+    private boolean isMinecraftServerInstanceDebugging() {
+        // TODO: Implement Fabric-specific debugging check
+        return false;
     }
 }

--- a/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
+++ b/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
@@ -19,8 +19,13 @@
 package io.github.retrooper.packetevents.mixin;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.event.UserLoginEvent;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.FakeChannelUtil;
 import io.netty.channel.Channel;
 import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.players.PlayerList;
@@ -41,10 +46,43 @@ public class PlayerListMixin {
             at = @At("HEAD")
     )
     private void preNewPlayerPlace(
-            Connection connection, ServerPlayer player,
-            CommonListenerCookie cookie, CallbackInfo ci
+        Connection connection, ServerPlayer player,
+        CommonListenerCookie cookie, CallbackInfo ci
     ) {
         PacketEvents.getAPI().getInjector().setPlayer(connection.channel, player);
+    }
+
+    /**
+     * @reason Associate connection instance with player instance and handle login event
+     */
+    @Inject(
+            method = "placeNewPlayer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/players/PlayerList;broadcastAll(Lnet/minecraft/network/protocol/Packet;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void onPlayerLogin(
+        Connection connection, ServerPlayer player,
+        CommonListenerCookie cookie, CallbackInfo ci
+    ) {
+        PacketEventsAPI<?> api = PacketEvents.getAPI();
+
+        User user = api.getPlayerManager().getUser(player);
+        if (user == null) {
+            Object channelObj = api.getPlayerManager().getChannel(player);
+
+            // Check if it's a fake connection
+            if (!FakeChannelUtil.isFakeChannel(channelObj) &&
+                (!api.isTerminated() || api.getSettings().isKickIfTerminated())) {
+                // Kick the player if they're not a fake player
+                player.connection.disconnect(Component.literal("PacketEvents 2.0 failed to inject"));
+            }
+            return;
+        }
+
+        api.getEventManager().callEvent(new UserLoginEvent(user, player));
     }
 
     /**

--- a/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
+++ b/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
@@ -46,8 +46,8 @@ public class PlayerListMixin {
             at = @At("HEAD")
     )
     private void preNewPlayerPlace(
-        Connection connection, ServerPlayer player,
-        CommonListenerCookie cookie, CallbackInfo ci
+            Connection connection, ServerPlayer player,
+            CommonListenerCookie cookie, CallbackInfo ci
     ) {
         PacketEvents.getAPI().getInjector().setPlayer(connection.channel, player);
     }


### PR DESCRIPTION
Execute getTasksAfterSend() on fabric and replicate other PacketEncoder behaviours on other platforms