### PR TITLE
Fix recursive field lookup

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/reflection/Reflection.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/reflection/Reflection.java
@@ -37,7 +37,11 @@ public final class Reflection {
 		}
 		final Field[] declaredFields = cls.getDeclaredFields();
 		for (final Field f : declaredFields) {
-			f.setAccessible(true);
+			try {
+				f.setAccessible(true);
+			} catch (Throwable ignored) {
+				// empty catch block
+			}
 		}
 		return declaredFields;
 	}
@@ -54,6 +58,8 @@ public final class Reflection {
 			if (cls.getSuperclass() != null) {
 				return getField(cls.getSuperclass(), name);
 			}
+		} catch (Throwable ignored) {
+			// empty catch block
 		}
 		return null;
 	}


### PR DESCRIPTION
Fix this error caused when recursive field lookup falls on `java.lang.Enum`:
```
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.String java.lang.Enum.name accessible: module java.base does not "opens java.lang" to unnamed module @2422f75e
	at java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:391) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:367) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:315) ~[?:?]
	at java.lang.reflect.Field.checkCanSetAccessible(Field.java:183) ~[?:?]
	at java.lang.reflect.Field.setAccessible(Field.java:177) ~[?:?]
```