### PR TITLE
Adding ability to add player-specific packet listeners

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents;
 
+import com.github.retrooper.packetevents.event.BaseEventManager;
 import com.github.retrooper.packetevents.event.EventManager;
 import com.github.retrooper.packetevents.injector.ChannelInjector;
 import com.github.retrooper.packetevents.manager.player.PlayerManager;
@@ -34,7 +35,7 @@ import com.github.retrooper.packetevents.util.updatechecker.UpdateChecker;
 import java.util.logging.Logger;
 
 public abstract class PacketEventsAPI<T> {
-    private final EventManager eventManager = new EventManager();
+    private final EventManager eventManager = new BaseEventManager();
     private final PacketEventsSettings settings = new PacketEventsSettings();
     private final UpdateChecker updateChecker = new UpdateChecker();
     private final LogManager logManager = new LogManager();

--- a/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
@@ -18,9 +18,8 @@
 
 package com.github.retrooper.packetevents;
 
-import com.github.retrooper.packetevents.event.BaseEventManager;
 import com.github.retrooper.packetevents.event.EventManager;
-import com.github.retrooper.packetevents.event.RootEventManager;
+import com.github.retrooper.packetevents.event.inheritable.GlobalEventManager;
 import com.github.retrooper.packetevents.injector.ChannelInjector;
 import com.github.retrooper.packetevents.manager.player.PlayerManager;
 import com.github.retrooper.packetevents.manager.protocol.ProtocolManager;
@@ -36,7 +35,7 @@ import com.github.retrooper.packetevents.util.updatechecker.UpdateChecker;
 import java.util.logging.Logger;
 
 public abstract class PacketEventsAPI<T> {
-    private final EventManager eventManager = new RootEventManager();
+    private final EventManager eventManager = new GlobalEventManager();
     private final PacketEventsSettings settings = new PacketEventsSettings();
     private final UpdateChecker updateChecker = new UpdateChecker();
     private final LogManager logManager = new LogManager();

--- a/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/PacketEventsAPI.java
@@ -20,6 +20,7 @@ package com.github.retrooper.packetevents;
 
 import com.github.retrooper.packetevents.event.BaseEventManager;
 import com.github.retrooper.packetevents.event.EventManager;
+import com.github.retrooper.packetevents.event.RootEventManager;
 import com.github.retrooper.packetevents.injector.ChannelInjector;
 import com.github.retrooper.packetevents.manager.player.PlayerManager;
 import com.github.retrooper.packetevents.manager.protocol.ProtocolManager;
@@ -35,7 +36,7 @@ import com.github.retrooper.packetevents.util.updatechecker.UpdateChecker;
 import java.util.logging.Logger;
 
 public abstract class PacketEventsAPI<T> {
-    private final EventManager eventManager = new BaseEventManager();
+    private final EventManager eventManager = new RootEventManager();
     private final PacketEventsSettings settings = new PacketEventsSettings();
     private final UpdateChecker updateChecker = new UpdateChecker();
     private final LogManager logManager = new LogManager();

--- a/api/src/main/java/com/github/retrooper/packetevents/event/BaseEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/BaseEventManager.java
@@ -41,7 +41,7 @@ import java.util.logging.Level;
  *
  */
 
-public class BaseEventManager implements EventManager {
+public class BaseEventManager extends EventManager {
 
     //Using a ConcurrentHashMap is faster and more secure here, compared to Collections.synchronizedMap(new EnumMap<>(PacketListenerPriority.class))
     //This is mainly due to:

--- a/api/src/main/java/com/github/retrooper/packetevents/event/BaseEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/BaseEventManager.java
@@ -1,0 +1,193 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2022 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.event;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.logging.Level;
+
+/**
+ * Class for event managing. Implements both, internal and API methods.
+ *
+ * @apiNote It is highly recommended to register the event listeners at server start-up,
+ * without frequent modifications during runtime, since this class needs to recalculate all of
+ * its event listeners during any modifications. In other words, it assumes that reads (events fired)
+ * greatly outnumber writes (listeners modifications). If your case requires frequent listener modifications,
+ * open a pull request on GitHub and describe your case.
+ *
+ * @author retrooper
+ * @author ShadowOfHeaven (optimization)
+ *
+ */
+
+public class BaseEventManager implements EventManager {
+
+    //Using a ConcurrentHashMap is faster and more secure here, compared to Collections.synchronizedMap(new EnumMap<>(PacketListenerPriority.class))
+    //This is mainly due to:
+    //1. On each modification Collections.synchronizedMap synchronizes the whole Map object, while ConcurrentHashMap only it's internal, currently modified Node
+    //2. ConcurrentHashMap won't fail in a multi-thread environment, while Collections.synchronizedMap is said to have a lot of potential problems,
+    //being a generalized method for synchronization
+    private final Map<PacketListenerPriority, Set<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
+    //Since reads greatly outnumber writes, create an array for the best possible iteration time
+    //Updated as a whole on writes, no index modifications are allowed
+    private volatile PacketListenerCommon[] listeners = new PacketListenerCommon[0];
+
+
+    /**
+     * Call the PacketEvent.
+     * This method processes the event on all the registered dynamic packet event listeners.
+     * The {@link PacketListenerPriority#LOWEST} prioritized listeners will be processing first,
+     * the {@link PacketListenerPriority#MONITOR} will be processing last and can
+     * be the final decider whether the event has been cancelled or not.
+     *
+     * @param event {@link PacketEvent}
+     */
+    @Override
+    public void callEvent(PacketEvent event) {
+        callEvent(event, null);
+    }
+
+
+    /**
+     * Call the PacketEvent.
+     * This method processes the event on all the registered dynamic packet event listeners.
+     * The {@link PacketListenerPriority#LOWEST} prioritized listeners will be processing first,
+     * the {@link PacketListenerPriority#MONITOR} will be processing last and can
+     * be the final decider whether the event has been cancelled or not.
+     *
+     * @param event                  {@link PacketEvent}
+     * @param postCallListenerAction The action to be ran after all the listeners have finished processing
+     */
+    @Override
+    public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
+        for (PacketListenerCommon listener : listeners) {
+            try {
+                event.call(listener);
+            } catch (Exception t) {
+                // ignore handshake exceptions
+                if (t.getClass() != InvalidHandshakeException.class) {
+                    PacketEvents.getAPI().getLogger().log(Level.WARNING, "PacketEvents caught an unhandled exception while calling your listener.", t);
+                }
+            }
+            if (postCallListenerAction != null) {
+                postCallListenerAction.run();
+            }
+        }
+        // For performance reasons, we don't want to re-encode the packet if it's not needed.
+        if (event instanceof ProtocolPacketEvent && !((ProtocolPacketEvent) event).needsReEncode()) {
+            ((ProtocolPacketEvent) event).setLastUsedWrapper(null);
+        }
+    }
+
+    /**
+     * Register the dynamic packet event listener.
+     *
+     * @param listener {@link PacketListenerCommon}
+     * @param priority {@link PacketListenerPriority}
+     */
+    @Override
+    public PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority) {
+        PacketListenerCommon packetListenerAbstract = listener.asAbstract(priority);
+        return registerListener(packetListenerAbstract);
+    }
+
+    /**
+     * Register the dynamic packet event listener.
+     *
+     * @param listener {@link PacketListenerCommon}
+     */
+    @Override
+    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
+        this.registerListenerNoRecalculation(listener);
+        this.recalculateListeners();
+        return listener;
+    }
+
+    /**
+     * Register multiple dynamic packet event listeners with one method.
+     *
+     * @param listeners {@link PacketListenerCommon}
+     */
+    @Override
+    public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
+        for (PacketListenerCommon listener : listeners) {
+            this.registerListenerNoRecalculation(listener);
+        }
+        this.recalculateListeners();
+        return listeners;
+    }
+
+    @Override
+    public void unregisterListener(PacketListenerCommon listener) {
+        if (this.unregisterListenerNoRecalculation(listener)) this.recalculateListeners();
+    }
+
+    @Override
+    public void unregisterListeners(PacketListenerCommon... listeners) {
+        boolean modified = false;
+        for (PacketListenerCommon listener : listeners) {
+            modified |= this.unregisterListenerNoRecalculation(listener);//OR - at least one of these needs to be true to return true, meaning the boolean will permanently stay true if once set so
+        }
+        if (modified) this.recalculateListeners();
+    }
+
+
+    /**
+     * Unregister all dynamic packet event listeners.
+     */
+    @Override
+    public void unregisterAllListeners() {
+        this.listenersMap.clear();
+        synchronized (this) {//like booky10 said, the synchronization is necessary here
+            this.listeners = new PacketListenerCommon[0];
+        }
+    }
+
+    //Needs to be synchronized in order to avoid race conditions (for example where the 'listeners' variable
+    //is overridden by its non-up-to-date value, simply because it finished a bit later than the most recent update)
+    private void recalculateListeners() {
+        synchronized (this) {
+            List<PacketListenerCommon> list = new ArrayList<>();
+            //adds from LOWEST to MONITOR, so in the correct order
+            for (PacketListenerPriority priority : PacketListenerPriority.values()) {
+                Set<PacketListenerCommon> set = this.listenersMap.get(priority);
+                if (set != null) list.addAll(set);
+            }
+            this.listeners = list.toArray(new PacketListenerCommon[0]);
+        }
+    }
+
+    //Internal registration methods, specifically separated for lesser overhead when registering an array of Listeners
+
+    private void registerListenerNoRecalculation(PacketListenerCommon listener) {
+        Set<PacketListenerCommon> listenerSet = this.listenersMap.computeIfAbsent(listener.getPriority(), p -> new CopyOnWriteArraySet<>());
+        listenerSet.add(listener);
+    }
+
+    //Returns true if the listener was removed, so a modification occurred
+    private boolean unregisterListenerNoRecalculation(PacketListenerCommon listener) {
+        Set<PacketListenerCommon> listenerSet = this.listenersMap.get(listener.getPriority());
+        return listenerSet != null && listenerSet.remove(listener);
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -2,20 +2,20 @@ package com.github.retrooper.packetevents.event;
 
 import org.jetbrains.annotations.Nullable;
 
-public interface EventManager {
-    void callEvent(PacketEvent event);
+public abstract class EventManager {
+    public abstract void callEvent(PacketEvent event);
 
-    void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction);
+    public abstract void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction);
 
-    PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority);
+    public abstract PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority);
 
-    PacketListenerCommon registerListener(PacketListenerCommon listener);
+    public abstract PacketListenerCommon registerListener(PacketListenerCommon listener);
 
-    PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners);
+    public abstract PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners);
 
-    void unregisterListener(PacketListenerCommon listener);
+    public abstract void unregisterListener(PacketListenerCommon listener);
 
-    void unregisterListeners(PacketListenerCommon... listeners);
+    public abstract void unregisterListeners(PacketListenerCommon... listeners);
 
-    void unregisterAllListeners();
+    public abstract void unregisterAllListeners();
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -1,185 +1,21 @@
-/*
- * This file is part of packetevents - https://github.com/retrooper/packetevents
- * Copyright (C) 2022 retrooper and contributors
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package com.github.retrooper.packetevents.event;
 
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.logging.Level;
+public interface EventManager {
+    void callEvent(PacketEvent event);
 
-/**
- * Class for event managing. Implements both, internal and API methods.
- *
- * @apiNote It is highly recommended to register the event listeners at server start-up,
- * without frequent modifications during runtime, since this class needs to recalculate all of
- * its event listeners during any modifications. In other words, it assumes that reads (events fired)
- * greatly outnumber writes (listeners modifications). If your case requires frequent listener modifications,
- * open a pull request on GitHub and describe your case.
- *
- * @author retrooper
- * @author ShadowOfHeaven (optimization)
- *
- */
+    void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction);
 
-public class EventManager {
+    PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority);
 
-    //Using a ConcurrentHashMap is faster and more secure here, compared to Collections.synchronizedMap(new EnumMap<>(PacketListenerPriority.class))
-    //This is mainly due to:
-    //1. On each modification Collections.synchronizedMap synchronizes the whole Map object, while ConcurrentHashMap only it's internal, currently modified Node
-    //2. ConcurrentHashMap won't fail in a multi-thread environment, while Collections.synchronizedMap is said to have a lot of potential problems,
-    //being a generalized method for synchronization
-    private final Map<PacketListenerPriority, Set<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
-    //Since reads greatly outnumber writes, create an array for the best possible iteration time
-    //Updated as a whole on writes, no index modifications are allowed
-    private volatile PacketListenerCommon[] listeners = new PacketListenerCommon[0];
+    PacketListenerCommon registerListener(PacketListenerCommon listener);
 
+    PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners);
 
-    /**
-     * Call the PacketEvent.
-     * This method processes the event on all the registered dynamic packet event listeners.
-     * The {@link PacketListenerPriority#LOWEST} prioritized listeners will be processing first,
-     * the {@link PacketListenerPriority#MONITOR} will be processing last and can
-     * be the final decider whether the event has been cancelled or not.
-     *
-     * @param event {@link PacketEvent}
-     */
-    public void callEvent(PacketEvent event) {
-        callEvent(event, null);
-    }
+    void unregisterListener(PacketListenerCommon listener);
 
+    void unregisterListeners(PacketListenerCommon... listeners);
 
-    /**
-     * Call the PacketEvent.
-     * This method processes the event on all the registered dynamic packet event listeners.
-     * The {@link PacketListenerPriority#LOWEST} prioritized listeners will be processing first,
-     * the {@link PacketListenerPriority#MONITOR} will be processing last and can
-     * be the final decider whether the event has been cancelled or not.
-     *
-     * @param event                  {@link PacketEvent}
-     * @param postCallListenerAction The action to be ran after all the listeners have finished processing
-     */
-    public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
-        for (PacketListenerCommon listener : listeners) {
-            try {
-                event.call(listener);
-            } catch (Exception t) {
-                // ignore handshake exceptions
-                if (t.getClass() != InvalidHandshakeException.class) {
-                    PacketEvents.getAPI().getLogger().log(Level.WARNING, "PacketEvents caught an unhandled exception while calling your listener.", t);
-                }
-            }
-            if (postCallListenerAction != null) {
-                postCallListenerAction.run();
-            }
-        }
-        // For performance reasons, we don't want to re-encode the packet if it's not needed.
-        if (event instanceof ProtocolPacketEvent && !((ProtocolPacketEvent) event).needsReEncode()) {
-            ((ProtocolPacketEvent) event).setLastUsedWrapper(null);
-        }
-    }
-
-    /**
-     * Register the dynamic packet event listener.
-     *
-     * @param listener {@link PacketListenerCommon}
-     * @param priority {@link PacketListenerPriority}
-     */
-    public PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority) {
-        PacketListenerCommon packetListenerAbstract = listener.asAbstract(priority);
-        return registerListener(packetListenerAbstract);
-    }
-
-    /**
-     * Register the dynamic packet event listener.
-     *
-     * @param listener {@link PacketListenerCommon}
-     */
-    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
-        this.registerListenerNoRecalculation(listener);
-        this.recalculateListeners();
-        return listener;
-    }
-
-    /**
-     * Register multiple dynamic packet event listeners with one method.
-     *
-     * @param listeners {@link PacketListenerCommon}
-     */
-    public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
-        for (PacketListenerCommon listener : listeners) {
-            this.registerListenerNoRecalculation(listener);
-        }
-        this.recalculateListeners();
-        return listeners;
-    }
-
-    public void unregisterListener(PacketListenerCommon listener) {
-        if (this.unregisterListenerNoRecalculation(listener)) this.recalculateListeners();
-    }
-
-    public void unregisterListeners(PacketListenerCommon... listeners) {
-        boolean modified = false;
-        for (PacketListenerCommon listener : listeners) {
-            modified |= this.unregisterListenerNoRecalculation(listener);//OR - at least one of these needs to be true to return true, meaning the boolean will permanently stay true if once set so
-        }
-        if (modified) this.recalculateListeners();
-    }
-
-
-    /**
-     * Unregister all dynamic packet event listeners.
-     */
-    public void unregisterAllListeners() {
-        this.listenersMap.clear();
-        synchronized (this) {//like booky10 said, the synchronization is necessary here
-            this.listeners = new PacketListenerCommon[0];
-        }
-    }
-
-    //Needs to be synchronized in order to avoid race conditions (for example where the 'listeners' variable
-    //is overridden by its non-up-to-date value, simply because it finished a bit later than the most recent update)
-    private void recalculateListeners() {
-        synchronized (this) {
-            List<PacketListenerCommon> list = new ArrayList<>();
-            //adds from LOWEST to MONITOR, so in the correct order
-            for (PacketListenerPriority priority : PacketListenerPriority.values()) {
-                Set<PacketListenerCommon> set = this.listenersMap.get(priority);
-                if (set != null) list.addAll(set);
-            }
-            this.listeners = list.toArray(new PacketListenerCommon[0]);
-        }
-    }
-
-    //Internal registration methods, specifically separated for lesser overhead when registering an array of Listeners
-
-    private void registerListenerNoRecalculation(PacketListenerCommon listener) {
-        Set<PacketListenerCommon> listenerSet = this.listenersMap.computeIfAbsent(listener.getPriority(), p -> new CopyOnWriteArraySet<>());
-        listenerSet.add(listener);
-    }
-
-    //Returns true if the listener was removed, so a modification occurred
-    private boolean unregisterListenerNoRecalculation(PacketListenerCommon listener) {
-        Set<PacketListenerCommon> listenerSet = this.listenersMap.get(listener.getPriority());
-        return listenerSet != null && listenerSet.remove(listener);
-    }
+    void unregisterAllListeners();
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -1,11 +1,54 @@
 package com.github.retrooper.packetevents.event;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class InheritableEventManager {
-    private ListenerStore selfStore;
+public class InheritableEventManager extends EventManager {
+
+    @Override
+    public void callEvent(PacketEvent event) {
+
+    }
+
+    @Override
+    public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
+
+    }
+
+    @Override
+    public PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority) {
+        return null;
+    }
+
+    @Override
+    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
+        return null;
+    }
+
+    @Override
+    public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
+        return new PacketListenerCommon[0];
+    }
+
+    @Override
+    public void unregisterListener(PacketListenerCommon listener) {
+
+    }
+
+    @Override
+    public void unregisterListeners(PacketListenerCommon... listeners) {
+
+    }
+
+    @Override
+    public void unregisterAllListeners() {
+
+    }
+
+    private ListenerStore store;
     /**
      * We store the listeners in a sorted manner aka:
      * 1) We sort by their priority

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -1,0 +1,90 @@
+package com.github.retrooper.packetevents.event;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class InheritableEventManager {
+    private ListenerStore selfStore;
+    /**
+     * We store the listeners in a sorted manner aka:
+     * 1) We sort by their priority
+     * 2) We sort by their creation time (this is to ensure thread-safety)
+     * 3) We sort by their identity hashcode (this to ensure that even in the case that two listeners are created at the same time, it would still register)
+     */
+    private static final Comparator<PacketListenerCommon> LISTENER_COMPARATOR = Comparator
+            .<PacketListenerCommon>comparingInt(listener -> listener.getPriority().ordinal())
+            .thenComparingLong(PacketListenerCommon::getCreationTimeStamp)
+            .thenComparingInt(System::identityHashCode);
+
+    /**
+     * This store is very speedy & thread safe.
+     * <p>
+     * Features
+     * <p>
+     * - Add/Remove listeners using CAS
+     * <p>
+     * - Iterate based on array snapshots
+     * <p>
+     * TODO: If needed could make this completely thread safe and so it tracks changed made to the store
+     */
+    public static class ListenerStore {
+        private final AtomicReference<PacketListenerCommon[]> stored = new AtomicReference<>();
+
+        public PacketListenerCommon[] get() {
+            return this.stored.get();
+        }
+
+        public void register(PacketListenerCommon listener) {
+            PacketListenerCommon[] current;
+            PacketListenerCommon[] modified;
+
+            do {
+                current = this.stored.get();
+                if (current == null) {
+                    modified = new PacketListenerCommon[]{listener};
+                    continue;
+                }
+
+                modified = Arrays.copyOf(current, current.length + 1);
+
+                // Find insertion point
+                int insertionPoint = Arrays.binarySearch(current, listener, LISTENER_COMPARATOR);
+                if (insertionPoint < 0) {
+                    insertionPoint = -insertionPoint - 1;
+                }
+
+                // Copy current into modified + 1
+                System.arraycopy(current, insertionPoint, modified, insertionPoint + 1, current.length - insertionPoint);
+                modified[insertionPoint] = listener;
+
+            } while (!this.stored.compareAndSet(current, modified));
+        }
+
+        public void remove(PacketListenerCommon listener) {
+            PacketListenerCommon[] current;
+            PacketListenerCommon[] modified;
+
+            do {
+                current = this.stored.get();
+
+                final int index = Arrays.binarySearch(current, listener, LISTENER_COMPARATOR);
+                if (index != 0) {
+                    return;
+                }
+
+                modified = Arrays.copyOf(current, current.length - 1);
+
+                System.arraycopy(current, 0, modified, 0, index);
+                System.arraycopy(current, index + 1, modified, index, current.length - index - 1);
+
+            } while (!this.stored.compareAndSet(current, modified));
+        }
+
+        public void call(UserConnectEvent event) {
+            for (final PacketListenerCommon listener : this.stored.get()) {
+                listener.onUserConnect(event);
+            }
+        }
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -1,53 +1,15 @@
 package com.github.retrooper.packetevents.event;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 public class InheritableEventManager extends EventManager {
-
-    @Override
-    public void callEvent(PacketEvent event) {
-
-    }
-
-    @Override
-    public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
-
-    }
-
-    @Override
-    public PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority) {
-        return null;
-    }
-
-    @Override
-    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
-        return null;
-    }
-
-    @Override
-    public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
-        return new PacketListenerCommon[0];
-    }
-
-    @Override
-    public void unregisterListener(PacketListenerCommon listener) {
-
-    }
-
-    @Override
-    public void unregisterListeners(PacketListenerCommon... listeners) {
-
-    }
-
-    @Override
-    public void unregisterAllListeners() {
-
-    }
-
     private ListenerStore store;
     /**
      * We store the listeners in a sorted manner aka:
@@ -59,6 +21,71 @@ public class InheritableEventManager extends EventManager {
             .<PacketListenerCommon>comparingInt(listener -> listener.getPriority().ordinal())
             .thenComparingLong(PacketListenerCommon::getCreationTimeStamp)
             .thenComparingInt(System::identityHashCode);
+
+    @Override
+    public void callEvent(PacketEvent event) {
+        this.callEvent(event, null);
+    }
+
+    @Override
+    public void callEvent(PacketEvent event, @Nullable Runnable postCallListenerAction) {
+        for (final PacketListenerCommon listener : this.store.get()) {
+            try {
+                event.call(listener);
+            } catch (Exception t) {
+                // ignore handshake exceptions
+                if (t.getClass() != InvalidHandshakeException.class) {
+                    PacketEvents.getAPI().getLogger().log(Level.WARNING, "PacketEvents caught an unhandled exception while calling your listener.", t);
+                }
+            }
+            if (postCallListenerAction != null) {
+                postCallListenerAction.run();
+            }
+        }
+
+        // For performance reasons, we don't want to re-encode the packet if it's not needed.
+        if (event instanceof ProtocolPacketEvent && !((ProtocolPacketEvent) event).needsReEncode()) {
+            ((ProtocolPacketEvent) event).setLastUsedWrapper(null);
+        }
+    }
+
+    @Override
+    public PacketListenerCommon registerListener(PacketListener listener, PacketListenerPriority priority) {
+        final PacketListenerCommon packetListenerAbstract = listener.asAbstract(priority);
+        return this.registerListener(packetListenerAbstract);
+    }
+
+    @Override
+    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
+        this.registerListeners(listener);
+        return listener;
+    }
+
+    @Override
+    public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
+        for (final PacketListenerCommon listener : listeners) {
+            this.store.add(listener);
+        }
+
+        return listeners;
+    }
+
+    @Override
+    public void unregisterListener(PacketListenerCommon listener) {
+        this.store.remove(listener);
+    }
+
+    @Override
+    public void unregisterListeners(PacketListenerCommon... listeners) {
+        for (final PacketListenerCommon listener : listeners) {
+            this.store.remove(listener);
+        }
+    }
+
+    @Override
+    public void unregisterAllListeners() {
+        this.store.clear();
+    }
 
     /**
      * This store is very speedy & thread safe.
@@ -78,7 +105,7 @@ public class InheritableEventManager extends EventManager {
             return this.stored.get();
         }
 
-        public void register(PacketListenerCommon listener) {
+        public void add(PacketListenerCommon listener) {
             PacketListenerCommon[] current;
             PacketListenerCommon[] modified;
 
@@ -128,6 +155,16 @@ public class InheritableEventManager extends EventManager {
             for (final PacketListenerCommon listener : this.stored.get()) {
                 listener.onUserConnect(event);
             }
+        }
+
+        public void clear() {
+            PacketListenerCommon[] current;
+            PacketListenerCommon[] modified;
+
+            do {
+                current = this.stored.get();
+                modified = null;
+            } while (!this.stored.compareAndSet(current, modified));
         }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 public class InheritableEventManager extends EventManager {
-    private ListenerStore store;
+    private final ListenerStore store;
     /**
      * We store the listeners in a sorted manner aka:
      * 1) We sort by their priority

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -108,11 +108,11 @@ public class InheritableEventManager extends EventManager {
      * TODO: If needed could make this completely thread safe and so it tracks changed made to the store
      */
     public static class ListenerStore {
-        private final AtomicReference<PacketListenerCommon[]> stored = new AtomicReference<>();
+        private final AtomicReference<PacketListenerCommon[]> stored = new AtomicReference<>(new PacketListenerCommon[0]);
 
         @Override
         public ListenerStore clone() {
-            if (this.stored.get() == null) {
+            if (this.stored.get().length == 0) {
                 return new ListenerStore();
             }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/InheritableEventManager.java
@@ -22,6 +22,14 @@ public class InheritableEventManager extends EventManager {
             .thenComparingLong(PacketListenerCommon::getCreationTimeStamp)
             .thenComparingInt(System::identityHashCode);
 
+    public InheritableEventManager(ListenerStore store) {
+        this.store = store;
+    }
+
+    public InheritableEventManager() {
+        this(new ListenerStore());
+    }
+
     @Override
     public void callEvent(PacketEvent event) {
         this.callEvent(event, null);
@@ -38,6 +46,7 @@ public class InheritableEventManager extends EventManager {
                     PacketEvents.getAPI().getLogger().log(Level.WARNING, "PacketEvents caught an unhandled exception while calling your listener.", t);
                 }
             }
+
             if (postCallListenerAction != null) {
                 postCallListenerAction.run();
             }
@@ -57,14 +66,14 @@ public class InheritableEventManager extends EventManager {
 
     @Override
     public PacketListenerCommon registerListener(PacketListenerCommon listener) {
-        this.registerListeners(listener);
+        this.store.add(listener);
         return listener;
     }
 
     @Override
     public PacketListenerCommon[] registerListeners(PacketListenerCommon... listeners) {
         for (final PacketListenerCommon listener : listeners) {
-            this.store.add(listener);
+            this.registerListener(listener);
         }
 
         return listeners;
@@ -78,7 +87,7 @@ public class InheritableEventManager extends EventManager {
     @Override
     public void unregisterListeners(PacketListenerCommon... listeners) {
         for (final PacketListenerCommon listener : listeners) {
-            this.store.remove(listener);
+            this.unregisterListener(listener);
         }
     }
 
@@ -101,11 +110,24 @@ public class InheritableEventManager extends EventManager {
     public static class ListenerStore {
         private final AtomicReference<PacketListenerCommon[]> stored = new AtomicReference<>();
 
+        @Override
+        public ListenerStore clone() {
+            if (this.stored.get() == null) {
+                return new ListenerStore();
+            }
+
+            final ListenerStore clone = new ListenerStore();
+            final PacketListenerCommon[] copying = this.stored.get();
+            clone.stored.set(Arrays.copyOf(copying, copying.length));
+
+            return clone;
+        }
+
         public PacketListenerCommon[] get() {
             return this.stored.get();
         }
 
-        public void add(PacketListenerCommon listener) {
+        public boolean add(PacketListenerCommon listener) {
             PacketListenerCommon[] current;
             PacketListenerCommon[] modified;
 
@@ -120,18 +142,24 @@ public class InheritableEventManager extends EventManager {
 
                 // Find insertion point
                 int insertionPoint = Arrays.binarySearch(current, listener, LISTENER_COMPARATOR);
-                if (insertionPoint < 0) {
-                    insertionPoint = -insertionPoint - 1;
+
+                if (insertionPoint >= 0) {
+                    return false;
                 }
+
+                // To index
+                insertionPoint = -insertionPoint - 1;
 
                 // Copy current into modified + 1
                 System.arraycopy(current, insertionPoint, modified, insertionPoint + 1, current.length - insertionPoint);
                 modified[insertionPoint] = listener;
 
             } while (!this.stored.compareAndSet(current, modified));
+
+            return true;
         }
 
-        public void remove(PacketListenerCommon listener) {
+        public boolean remove(PacketListenerCommon listener) {
             PacketListenerCommon[] current;
             PacketListenerCommon[] modified;
 
@@ -139,16 +167,17 @@ public class InheritableEventManager extends EventManager {
                 current = this.stored.get();
 
                 final int index = Arrays.binarySearch(current, listener, LISTENER_COMPARATOR);
-                if (index != 0) {
-                    return;
+                if (index < 0 || current[index] != listener) {
+                    return false;
                 }
 
                 modified = Arrays.copyOf(current, current.length - 1);
 
                 System.arraycopy(current, 0, modified, 0, index);
                 System.arraycopy(current, index + 1, modified, index, current.length - index - 1);
-
             } while (!this.stored.compareAndSet(current, modified));
+
+            return true;
         }
 
         public void call(UserConnectEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketEvent.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketEvent.java
@@ -32,8 +32,9 @@ public abstract class PacketEvent implements CallableEvent {
     private final long timestamp;
 
     public PacketEvent() {
-        TimeStampMode timeStampMode = PacketEvents.getAPI().getSettings()
-                .getTimeStampMode();
+        TimeStampMode timeStampMode = PacketEvents.getAPI() == null
+                ? TimeStampMode.NANO
+                : PacketEvents.getAPI().getSettings().getTimeStampMode();
         switch (timeStampMode) {
             case MILLIS:
                 timestamp = System.currentTimeMillis();

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
@@ -18,10 +18,6 @@
 
 package com.github.retrooper.packetevents.event;
 
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Abstract packet listener.
  *
@@ -30,13 +26,20 @@ import java.util.Map;
  */
 public abstract class PacketListenerCommon {
     private final PacketListenerPriority priority;
+    private final long creationTimeStamp;
 
     public PacketListenerCommon(PacketListenerPriority priority) {
         this.priority = priority;
+        this.creationTimeStamp = System.nanoTime();
     }
 
     public PacketListenerCommon() {
         this.priority = PacketListenerPriority.NORMAL;
+        this.creationTimeStamp = System.nanoTime();
+    }
+
+    public long getCreationTimeStamp() {
+        return this.creationTimeStamp;
     }
 
     public PacketListenerPriority getPriority() {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
@@ -4,29 +4,71 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class RootEventManager extends InheritableEventManager {
     private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
     private final Map<WeakKey, EventManager> children = new ConcurrentHashMap<>();
-    private InheritableEventManager.ListenerStore store;
+    private final ReadWriteLock listenerConsistencyLock = new ReentrantReadWriteLock();
+    private final InheritableEventManager.ListenerStore store = new ListenerStore();
 
     @Override
     public PacketListenerCommon registerListener(PacketListenerCommon listener) {
         this.cleanup();
-        return super.registerListener(listener);
+
+        this.listenerConsistencyLock.readLock().lock();
+        try {
+            if (!this.store.add(listener)) {
+                return listener;
+            }
+
+            for (final EventManager eventManager : this.children.values()) {
+                eventManager.registerListener(listener);
+            }
+
+            return listener;
+        } finally {
+            this.listenerConsistencyLock.readLock().lock();
+        }
     }
 
     @Override
     public void unregisterListener(PacketListenerCommon listener) {
         this.cleanup();
-        super.unregisterListener(listener);
+
+        this.listenerConsistencyLock.readLock().lock();
+        try {
+            if (!this.store.remove(listener)) {
+                return;
+            }
+
+            for (final EventManager eventManager : this.children.values()) {
+                eventManager.unregisterListener(listener);
+            }
+        } finally {
+            this.listenerConsistencyLock.readLock().unlock();
+        }
+    }
+
+    public int childrenCount() {
+        this.cleanup();
+
+        return this.children.size();
     }
 
     public EventManager getChildren(Object key) {
         this.cleanup();
 
         final WeakKey weakKey = new WeakKey(key, this.queue);
-        return this.children.computeIfAbsent(weakKey, ($) -> new InheritableEventManager());
+        return this.children.computeIfAbsent(weakKey, ($) -> {
+            this.listenerConsistencyLock.writeLock().lock();
+            try {
+                return new InheritableEventManager(this.store.clone());
+            } finally {
+                this.listenerConsistencyLock.writeLock().unlock();
+            }
+        });
     }
 
     private void cleanup() {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
@@ -29,7 +29,7 @@ public class RootEventManager extends InheritableEventManager {
 
             return listener;
         } finally {
-            this.listenerConsistencyLock.readLock().lock();
+            this.listenerConsistencyLock.readLock().unlock();
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/RootEventManager.java
@@ -1,0 +1,70 @@
+package com.github.retrooper.packetevents.event;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RootEventManager extends InheritableEventManager {
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+    private final Map<WeakKey, EventManager> children = new ConcurrentHashMap<>();
+    private InheritableEventManager.ListenerStore store;
+
+    @Override
+    public PacketListenerCommon registerListener(PacketListenerCommon listener) {
+        this.cleanup();
+        return super.registerListener(listener);
+    }
+
+    @Override
+    public void unregisterListener(PacketListenerCommon listener) {
+        this.cleanup();
+        super.unregisterListener(listener);
+    }
+
+    public EventManager getChildren(Object key) {
+        this.cleanup();
+
+        final WeakKey weakKey = new WeakKey(key, this.queue);
+        return this.children.computeIfAbsent(weakKey, ($) -> new InheritableEventManager());
+    }
+
+    private void cleanup() {
+        WeakKey weakKey;
+        while ((weakKey = (WeakKey) this.queue.poll()) != null) {
+            this.children.remove(weakKey);
+        }
+    }
+
+    public static class WeakKey extends WeakReference<Object> {
+        private final int hashCode;
+
+        public WeakKey(Object referent, ReferenceQueue<Object> queue) {
+            super(referent, queue);
+            this.hashCode = System.identityHashCode(referent);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+
+            if (!(obj instanceof WeakKey)) {
+                return false;
+            }
+
+            final WeakKey other = (WeakKey) obj;
+            final Object thisReferent = this.get();
+            final Object otherReferent = other.get();
+
+            // Check hashcode incase both been GC'ed
+            return this.hashCode == other.hashCode && thisReferent == otherReferent;
+        }
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/event/inheritable/GlobalEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/inheritable/GlobalEventManager.java
@@ -1,4 +1,7 @@
-package com.github.retrooper.packetevents.event;
+package com.github.retrooper.packetevents.event.inheritable;
+
+import com.github.retrooper.packetevents.event.EventManager;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -7,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class RootEventManager extends InheritableEventManager {
+public class GlobalEventManager extends InheritableEventManager {
     private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
     private final Map<WeakKey, EventManager> children = new ConcurrentHashMap<>();
     private final ReadWriteLock listenerConsistencyLock = new ReentrantReadWriteLock();

--- a/api/src/main/java/com/github/retrooper/packetevents/event/inheritable/InheritableEventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/inheritable/InheritableEventManager.java
@@ -1,6 +1,7 @@
-package com.github.retrooper.packetevents.event;
+package com.github.retrooper.packetevents.event.inheritable;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.*;
 import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -20,7 +20,7 @@ package com.github.retrooper.packetevents.protocol.player;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.EventManager;
-import com.github.retrooper.packetevents.event.RootEventManager;
+import com.github.retrooper.packetevents.event.inheritable.GlobalEventManager;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
@@ -70,8 +70,8 @@ public class User implements IRegistryHolder {
         this.profile = profile;
         this.eventManager = PacketEvents.getAPI().getEventManager();
 
-        if (this.eventManager instanceof RootEventManager) {
-            this.eventManager = ((RootEventManager) this.eventManager).getChildren(channel);
+        if (this.eventManager instanceof GlobalEventManager) {
+            this.eventManager = ((GlobalEventManager) this.eventManager).getChildren(channel);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -19,6 +19,8 @@
 package com.github.retrooper.packetevents.protocol.player;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.EventManager;
+import com.github.retrooper.packetevents.event.RootEventManager;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
@@ -37,13 +39,7 @@ import com.github.retrooper.packetevents.util.adventure.AdventureSerializer;
 import com.github.retrooper.packetevents.util.mappings.IRegistry;
 import com.github.retrooper.packetevents.util.mappings.IRegistryHolder;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChatMessage;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerCloseWindow;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleSubtitle;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleText;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleTimes;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSystemChatMessage;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTitle;
+import com.github.retrooper.packetevents.wrapper.play.server.*;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -54,16 +50,15 @@ import java.util.Map;
 import java.util.UUID;
 
 public class User implements IRegistryHolder {
-
     private final Object channel;
+    private final UserProfile profile;
+    private final Map<ResourceLocation, IRegistry<?>> registries = new HashMap<>();
     private ConnectionState decoderState;
     private ConnectionState encoderState;
     private ClientVersion clientVersion;
-    private final UserProfile profile;
     private int entityId = -1;
-
+    private EventManager eventManager;
     private DimensionType dimensionType = DimensionTypes.OVERWORLD;
-    private final Map<ResourceLocation, IRegistry<?>> registries = new HashMap<>();
 
     public User(Object channel,
                 ConnectionState connectionState, ClientVersion clientVersion,
@@ -73,6 +68,11 @@ public class User implements IRegistryHolder {
         this.encoderState = connectionState;
         this.clientVersion = clientVersion;
         this.profile = profile;
+        this.eventManager = PacketEvents.getAPI().getEventManager();
+
+        if (this.eventManager instanceof RootEventManager) {
+            this.eventManager = ((RootEventManager) this.eventManager).getChildren(channel);
+        }
     }
 
     @ApiStatus.Internal
@@ -87,16 +87,16 @@ public class User implements IRegistryHolder {
     }
 
     public Object getChannel() {
-        return channel;
+        return this.channel;
     }
 
     public InetSocketAddress getAddress() {
-        return (InetSocketAddress) ChannelHelper.remoteAddress(channel);
+        return (InetSocketAddress) ChannelHelper.remoteAddress(this.channel);
     }
 
     public ConnectionState getConnectionState() {
-        ConnectionState decoderState = this.decoderState;
-        ConnectionState encoderState = this.encoderState;
+        final ConnectionState decoderState = this.decoderState;
+        final ConnectionState encoderState = this.encoderState;
         if (decoderState != encoderState) {
             throw new IllegalArgumentException("Can't get common connection state: " + decoderState + " != " + encoderState);
         }
@@ -129,7 +129,7 @@ public class User implements IRegistryHolder {
     }
 
     public ClientVersion getClientVersion() {
-        return clientVersion;
+        return this.clientVersion;
     }
 
     public void setClientVersion(ClientVersion clientVersion) {
@@ -137,19 +137,23 @@ public class User implements IRegistryHolder {
     }
 
     public UserProfile getProfile() {
-        return profile;
+        return this.profile;
     }
 
     public String getName() {
-        return profile.getName();
+        return this.profile.getName();
     }
 
     public UUID getUUID() {
-        return profile.getUUID();
+        return this.profile.getUUID();
+    }
+
+    public EventManager getEventManager() {
+        return this.eventManager;
     }
 
     public int getEntityId() {
-        return entityId;
+        return this.entityId;
     }
 
     public void setEntityId(int entityId) {
@@ -157,59 +161,59 @@ public class User implements IRegistryHolder {
     }
 
     public void sendPacket(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().sendPacket(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().sendPacket(this.channel, buffer);
     }
 
     public void sendPacket(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().sendPacket(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().sendPacket(this.channel, wrapper);
     }
 
     public void sendPacketSilently(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().sendPacketSilently(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().sendPacketSilently(this.channel, buffer);
     }
 
     public void sendPacketSilently(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().sendPacketSilently(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().sendPacketSilently(this.channel, wrapper);
     }
 
     public void writePacket(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().writePacket(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().writePacket(this.channel, buffer);
     }
 
     public void writePacket(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().writePacket(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().writePacket(this.channel, wrapper);
     }
 
     public void writePacketSilently(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().writePacketSilently(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().writePacketSilently(this.channel, buffer);
     }
 
     public void writePacketSilently(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().writePacketSilently(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().writePacketSilently(this.channel, wrapper);
     }
 
     public void receivePacket(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().receivePacket(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().receivePacket(this.channel, buffer);
     }
 
     public void receivePacket(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().receivePacket(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().receivePacket(this.channel, wrapper);
     }
 
     public void receivePacketSilently(Object buffer) {
-        PacketEvents.getAPI().getProtocolManager().receivePacketSilently(channel, buffer);
+        PacketEvents.getAPI().getProtocolManager().receivePacketSilently(this.channel, buffer);
     }
 
     public void receivePacketSilently(PacketWrapper<?> wrapper) {
-        PacketEvents.getAPI().getProtocolManager().receivePacketSilently(channel, wrapper);
+        PacketEvents.getAPI().getProtocolManager().receivePacketSilently(this.channel, wrapper);
     }
 
     public void flushPackets() {
-        ChannelHelper.flush(channel);
+        ChannelHelper.flush(this.channel);
     }
 
     public void closeConnection() {
-        ChannelHelper.close(channel);
+        ChannelHelper.close(this.channel);
     }
 
     //Might be tough with the message signing
@@ -220,27 +224,27 @@ public class User implements IRegistryHolder {
     }*/
 
     public void closeInventory() {
-        WrapperPlayServerCloseWindow closeWindow = new WrapperPlayServerCloseWindow(0);
-        PacketEvents.getAPI().getProtocolManager().sendPacket(channel, closeWindow);
+        final WrapperPlayServerCloseWindow closeWindow = new WrapperPlayServerCloseWindow(0);
+        PacketEvents.getAPI().getProtocolManager().sendPacket(this.channel, closeWindow);
     }
 
     public void sendMessage(String legacyMessage) {
-        Component component = AdventureSerializer.fromLegacyFormat(legacyMessage);
-        sendMessage(component);
+        final Component component = AdventureSerializer.fromLegacyFormat(legacyMessage);
+        this.sendMessage(component);
     }
 
     public void sendMessage(Component component) {
-        sendMessage(component, ChatTypes.CHAT);
+        this.sendMessage(component, ChatTypes.CHAT);
     }
 
     public void sendMessage(Component component, ChatType type) {
-        ServerVersion version = PacketEvents.getAPI().getInjector().isProxy() ? getClientVersion().toServerVersion() :
+        final ServerVersion version = PacketEvents.getAPI().getInjector().isProxy() ? this.getClientVersion().toServerVersion() :
                 PacketEvents.getAPI().getServerManager().getVersion();
-        PacketWrapper<?> chatPacket;
+        final PacketWrapper<?> chatPacket;
         if (version.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             chatPacket = new WrapperPlayServerSystemChatMessage(false, component);
         } else {
-            ChatMessage message;
+            final ChatMessage message;
             if (version.isNewerThanOrEquals(ServerVersion.V_1_16)) {
                 message = new ChatMessage_v1_16(component, type, new UUID(0L, 0L));
             } else {
@@ -248,21 +252,21 @@ public class User implements IRegistryHolder {
             }
             chatPacket = new WrapperPlayServerChatMessage(message);
         }
-        PacketEvents.getAPI().getProtocolManager().sendPacket(channel, chatPacket);
+        PacketEvents.getAPI().getProtocolManager().sendPacket(this.channel, chatPacket);
     }
 
     public void sendTitle(String legacyTitle, String legacySubtitle,
                           int fadeInTicks, int stayTicks, int fadeOutTicks) {
-        Component title = AdventureSerializer.fromLegacyFormat(legacyTitle);
-        Component subtitle = AdventureSerializer.fromLegacyFormat(legacySubtitle);
-        sendTitle(title, subtitle, fadeInTicks, stayTicks, fadeOutTicks);
+        final Component title = AdventureSerializer.fromLegacyFormat(legacyTitle);
+        final Component subtitle = AdventureSerializer.fromLegacyFormat(legacySubtitle);
+        this.sendTitle(title, subtitle, fadeInTicks, stayTicks, fadeOutTicks);
     }
 
     public void sendTitle(Component title, Component subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks) {
-        ClientVersion version = PacketEvents.getAPI().getInjector().isProxy() ? getClientVersion() :
+        final ClientVersion version = PacketEvents.getAPI().getInjector().isProxy() ? this.getClientVersion() :
                 PacketEvents.getAPI().getServerManager().getVersion().toClientVersion();
-        boolean modern = version.isNewerThanOrEquals(ClientVersion.V_1_17);
-        PacketWrapper<?> animation;
+        final boolean modern = version.isNewerThanOrEquals(ClientVersion.V_1_17);
+        final PacketWrapper<?> animation;
         PacketWrapper<?> setTitle = null;
         PacketWrapper<?> setSubtitle = null;
         if (modern) {
@@ -288,12 +292,12 @@ public class User implements IRegistryHolder {
                         0, 0, 0);
             }
         }
-        sendPacket(animation);
+        this.sendPacket(animation);
         if (setTitle != null) {
-            sendPacket(setTitle);
+            this.sendPacket(setTitle);
         }
         if (setSubtitle != null) {
-            sendPacket(setSubtitle);
+            this.sendPacket(setSubtitle);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PacketEventsImplHelper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PacketEventsImplHelper.java
@@ -58,7 +58,7 @@ public final class PacketEventsImplHelper {
         int preProcessIndex = ByteBufHelper.readerIndex(buffer);
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(channel, user, player, buffer, autoProtocolTranslation);
         int processIndex = ByteBufHelper.readerIndex(buffer);
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> {
+        user.getEventManager().callEvent(packetSendEvent, () -> {
             ByteBufHelper.readerIndex(buffer, processIndex);
         });
         if (!packetSendEvent.isCancelled()) {
@@ -98,7 +98,7 @@ public final class PacketEventsImplHelper {
         int preProcessIndex = ByteBufHelper.readerIndex(buffer);
         PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(channel, user, player, buffer, autoProtocolTranslation);
         int processIndex = ByteBufHelper.readerIndex(buffer);
-        PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> {
+        user.getEventManager().callEvent(packetReceiveEvent, () -> {
             ByteBufHelper.readerIndex(buffer, processIndex);
         });
         if (!packetReceiveEvent.isCancelled()) {
@@ -131,7 +131,7 @@ public final class PacketEventsImplHelper {
 
             if (user != null) {
                 UserDisconnectEvent disconnectEvent = new UserDisconnectEvent(user);
-                PacketEvents.getAPI().getEventManager().callEvent(disconnectEvent);
+                user.getEventManager().callEvent(disconnectEvent);
                 PacketEvents.getAPI().getProtocolManager().removeUser(user.getChannel());
             }
 

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/InheritableEventManagerTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/InheritableEventManagerTest.java
@@ -1,6 +1,7 @@
 package com.github.retrooper.packetevents.test.event;
 
 import com.github.retrooper.packetevents.event.*;
+import com.github.retrooper.packetevents.event.inheritable.GlobalEventManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class InheritableEventManagerTest {
 
     @Test
     void shouldDestroyChildrenAfterGC() throws Throwable {
-        final RootEventManager rootEventManager = new RootEventManager();
+        final GlobalEventManager rootEventManager = new GlobalEventManager();
         Object children = new Object();
 
         rootEventManager.getChildren(children);
@@ -48,7 +49,7 @@ public class InheritableEventManagerTest {
 
     @Test
     void shouldCallBothListeners() {
-        final RootEventManager rootEventManager = new RootEventManager();
+        final GlobalEventManager rootEventManager = new GlobalEventManager();
         final EventManager children = rootEventManager.getChildren(new Object());
         final List<String> calls = new ArrayList<>();
 

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/InheritableEventManagerTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/InheritableEventManagerTest.java
@@ -1,0 +1,62 @@
+package com.github.retrooper.packetevents.test.event;
+
+import com.github.retrooper.packetevents.event.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InheritableEventManagerTest {
+    static PacketListenerCommon mockListener() {
+        return mockListener(PacketListenerPriority.NORMAL, () -> {});
+    }
+
+    static PacketListenerCommon mockListener(Runnable onAccept) {
+        return mockListener(PacketListenerPriority.NORMAL, onAccept);
+    }
+
+    static PacketListenerCommon mockListener(PacketListenerPriority priority, Runnable onAccept) {
+        return new PacketListenerCommon(priority) {
+            @Override
+            public void onUserConnect(UserConnectEvent event) {
+                super.onUserConnect(event);
+                onAccept.run();
+            }
+        };
+    }
+
+    @Test
+    void shouldDestroyChildrenAfterGC() throws Throwable {
+        final RootEventManager rootEventManager = new RootEventManager();
+        Object children = new Object();
+
+        rootEventManager.getChildren(children);
+        rootEventManager.getChildren(children);
+        assertEquals(1, rootEventManager.childrenCount());
+
+        children = null;
+        System.gc();
+
+        TimeUnit.SECONDS.sleep(1);
+
+        assertEquals(0, rootEventManager.childrenCount());
+    }
+
+    @Test
+    void shouldCallBothListeners() {
+        final RootEventManager rootEventManager = new RootEventManager();
+        final EventManager children = rootEventManager.getChildren(new Object());
+        final List<String> calls = new ArrayList<>();
+
+        children.registerListener(mockListener(() -> calls.add("children")));
+        rootEventManager.registerListener(mockListener(() -> calls.add("root")));
+
+        children.callEvent(new UserConnectEvent(null));
+
+        assertEquals(Arrays.asList("children", "root"), calls);
+    }
+}

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
@@ -1,6 +1,6 @@
 package com.github.retrooper.packetevents.test.event;
 
-import com.github.retrooper.packetevents.event.InheritableEventManager;
+import com.github.retrooper.packetevents.event.inheritable.InheritableEventManager;
 import com.github.retrooper.packetevents.event.PacketListenerCommon;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.event.UserConnectEvent;

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
@@ -52,6 +52,19 @@ public class ListenerStoreTest {
     }
 
     @Test
+    void shouldNotAddDuplicateListener() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        listenerStore.add(mockListener());
+
+        final PacketListenerCommon packetListenerCommon = mockListener(() -> {});
+        listenerStore.add(packetListenerCommon);
+        listenerStore.add(mockListener());
+        listenerStore.add(packetListenerCommon);
+
+        assertEquals(3, listenerStore.get().length);
+    }
+
+    @Test
     void shouldRunInTheRightOrderByPriority() {
         final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
         final List<PacketListenerPriority> result = new ArrayList<>();

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
@@ -1,0 +1,83 @@
+package com.github.retrooper.packetevents.test.event;
+
+import com.github.retrooper.packetevents.event.InheritableEventManager;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.UserConnectEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ListenerStoreTest {
+    static PacketListenerCommon mockListener(Runnable onAccept) {
+        return new PacketListenerCommon() {
+            @Override
+            public void onUserConnect(UserConnectEvent event) {
+                super.onUserConnect(event);
+                onAccept.run();
+            }
+        };
+    }
+
+    static PacketListenerCommon mockListener(PacketListenerPriority priority, Runnable onAccept) {
+        return new PacketListenerCommon(priority) {
+            @Override
+            public void onUserConnect(UserConnectEvent event) {
+                super.onUserConnect(event);
+                onAccept.run();
+            }
+        };
+    }
+
+    @Test
+    void testSuccessAdd() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        final PacketListenerCommon packetListenerCommon = mockListener(() -> {});
+        listenerStore.register(packetListenerCommon);
+
+        assertEquals(1, listenerStore.get().length);
+        assertSame(listenerStore.get()[0], packetListenerCommon);
+    }
+
+    @Test
+    void testSuccessRemove() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        final PacketListenerCommon packetListenerCommon = mockListener(() -> {});
+        listenerStore.register(packetListenerCommon);
+        listenerStore.remove(packetListenerCommon);
+
+        assertEquals(0, listenerStore.get().length);
+    }
+
+    @Test
+    void shouldRunInTheRightOrderByPriority() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        final List<PacketListenerPriority> result = new ArrayList<>();
+        for (final PacketListenerPriority priority : PacketListenerPriority.values()) {
+            final PacketListenerCommon packetListenerCommon = mockListener(priority, () -> result.add(priority));
+            listenerStore.register(packetListenerCommon);
+        }
+
+        listenerStore.call(new UserConnectEvent(null));
+        assertEquals(Arrays.asList(PacketListenerPriority.values()), result);
+    }
+
+    @Test
+    void shouldRunInTheRightOrderByRegistration() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        final List<Integer> executionOrder = new ArrayList<>();
+
+        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(1)));
+        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(2)));
+        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(3)));
+
+        listenerStore.call(new UserConnectEvent(null));
+
+        assertEquals(Arrays.asList(1, 2, 3), executionOrder);
+    }
+}

--- a/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/event/ListenerStoreTest.java
@@ -10,18 +10,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ListenerStoreTest {
+    static PacketListenerCommon mockListener() {
+        return mockListener(PacketListenerPriority.NORMAL, () -> {});
+    }
+
     static PacketListenerCommon mockListener(Runnable onAccept) {
-        return new PacketListenerCommon() {
-            @Override
-            public void onUserConnect(UserConnectEvent event) {
-                super.onUserConnect(event);
-                onAccept.run();
-            }
-        };
+        return mockListener(PacketListenerPriority.NORMAL, onAccept);
     }
 
     static PacketListenerCommon mockListener(PacketListenerPriority priority, Runnable onAccept) {
@@ -38,7 +35,7 @@ public class ListenerStoreTest {
     void testSuccessAdd() {
         final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
         final PacketListenerCommon packetListenerCommon = mockListener(() -> {});
-        listenerStore.register(packetListenerCommon);
+        listenerStore.add(packetListenerCommon);
 
         assertEquals(1, listenerStore.get().length);
         assertSame(listenerStore.get()[0], packetListenerCommon);
@@ -48,7 +45,7 @@ public class ListenerStoreTest {
     void testSuccessRemove() {
         final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
         final PacketListenerCommon packetListenerCommon = mockListener(() -> {});
-        listenerStore.register(packetListenerCommon);
+        listenerStore.add(packetListenerCommon);
         listenerStore.remove(packetListenerCommon);
 
         assertEquals(0, listenerStore.get().length);
@@ -60,7 +57,7 @@ public class ListenerStoreTest {
         final List<PacketListenerPriority> result = new ArrayList<>();
         for (final PacketListenerPriority priority : PacketListenerPriority.values()) {
             final PacketListenerCommon packetListenerCommon = mockListener(priority, () -> result.add(priority));
-            listenerStore.register(packetListenerCommon);
+            listenerStore.add(packetListenerCommon);
         }
 
         listenerStore.call(new UserConnectEvent(null));
@@ -72,12 +69,23 @@ public class ListenerStoreTest {
         final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
         final List<Integer> executionOrder = new ArrayList<>();
 
-        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(1)));
-        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(2)));
-        listenerStore.register(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(3)));
+        listenerStore.add(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(1)));
+        listenerStore.add(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(2)));
+        listenerStore.add(mockListener(PacketListenerPriority.NORMAL, () -> executionOrder.add(3)));
 
         listenerStore.call(new UserConnectEvent(null));
 
         assertEquals(Arrays.asList(1, 2, 3), executionOrder);
+    }
+
+    @Test
+    void shouldClearSuccessfully() {
+        final InheritableEventManager.ListenerStore listenerStore = new InheritableEventManager.ListenerStore();
+        listenerStore.add(mockListener());
+        listenerStore.add(mockListener());
+        listenerStore.add(mockListener());
+
+        listenerStore.clear();
+        assertNull(listenerStore.get());
     }
 }

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
@@ -56,7 +56,7 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
             PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(ctx.channel(),
                     user, player, transformed, false);
             int readerIndex = transformed.readerIndex();
-            PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            user.getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
             if (!packetReceiveEvent.isCancelled()) {
                 if (packetReceiveEvent.getLastUsedWrapper() != null) {
                     ByteBufHelper.clear(packetReceiveEvent.getByteBuf());

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -54,7 +54,7 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(ctx.channel(), user, player,
                 buffer, false);
         int readerIndex = buffer.readerIndex();
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        user.getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
         if (!packetSendEvent.isCancelled()) {
             if (packetSendEvent.getLastUsedWrapper() != null) {
                 ByteBufHelper.clear(packetSendEvent.getByteBuf());

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/processor/InternalBungeeProcessor.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/processor/InternalBungeeProcessor.java
@@ -67,6 +67,6 @@ public class InternalBungeeProcessor implements Listener {
             return;
         }
         UserLoginEvent loginEvent = new UserLoginEvent(user, player);
-        PacketEvents.getAPI().getEventManager().callEvent(loginEvent);
+        user.getEventManager().callEvent(loginEvent);
     }
 }

--- a/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
+++ b/fabric/src/main/java/io/github/retrooper/packetevents/mixin/PlayerListMixin.java
@@ -82,7 +82,7 @@ public class PlayerListMixin {
             return;
         }
 
-        api.getEventManager().callEvent(new UserLoginEvent(user, player));
+        user.getEventManager().callEvent(new UserLoginEvent(user, player));
     }
 
     /**

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
@@ -47,7 +47,7 @@ public class SpigotChannelInjector implements ChannelInjector {
     private int connectionChannelsListIndex = -1;
 
     public void updatePlayer(User user, Object player) {
-        PacketEvents.getAPI().getEventManager().callEvent(new UserLoginEvent(user, player));
+        user.getEventManager().callEvent(new UserLoginEvent(user, player));
         Object channel = user.getChannel();
         if (channel == null) {
             channel = PacketEvents.getAPI().getPlayerManager().getChannel(player);

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/SpongeChannelInjector.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/SpongeChannelInjector.java
@@ -47,7 +47,7 @@ public class SpongeChannelInjector implements ChannelInjector {
     private int connectionChannelsListIndex = -1;
 
     public void updatePlayer(User user, Object player) {
-        PacketEvents.getAPI().getEventManager().callEvent(new UserLoginEvent(user, player));
+        user.getEventManager().callEvent(new UserLoginEvent(user, player));
         Object channel = user.getChannel();
         if (channel == null) {
             channel = PacketEvents.getAPI().getPlayerManager().getChannel(player);

--- a/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
@@ -54,7 +54,7 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
             PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(ctx.channel(), user, player,
                     transformed, false);
             int readerIndex = transformed.readerIndex();
-            PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            user.getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
             if (!packetReceiveEvent.isCancelled()) {
                 if (packetReceiveEvent.getLastUsedWrapper() != null) {
                     ByteBufHelper.clear(packetReceiveEvent.getByteBuf());

--- a/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -43,7 +43,7 @@ public class PacketEventsEncoder extends MessageToByteEncoder<ByteBuf> {
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(ctx.channel(), user, player, buffer,
                 false);
         int readerIndex = buffer.readerIndex();
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        user.getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
         if (!packetSendEvent.isCancelled()) {
             if (packetSendEvent.getLastUsedWrapper() != null) {
                 ByteBufHelper.clear(packetSendEvent.getByteBuf());

--- a/velocity/src/main/java/io/github/retrooper/packetevents/velocity/factory/VelocityPacketEventsBuilder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/velocity/factory/VelocityPacketEventsBuilder.java
@@ -212,7 +212,7 @@ public class VelocityPacketEventsBuilder {
                                 return;
 
                             UserLoginEvent loginEvent = new UserLoginEvent(user, player);
-                            PacketEvents.getAPI().getEventManager().callEvent(loginEvent);
+                            user.getEventManager().callEvent(loginEvent);
                         });
                 if (settings.shouldCheckForUpdates()) {
                     getUpdateChecker().handleUpdateCheck();


### PR DESCRIPTION
My motivate for this PR is simple, I'm too performance obsessed and doing ConcurrentHashMap calls to get data based is not for me, maybe others feel the same way, so the whole point of this PR is to make so you can register player-specific listeners so you can store state within the listener itself.

TODO:

- [x] Separate EventManager impl to BaseEventManager
- [x] Recreate the whole EventManager structure to allow inheriting packet listeners
- [x] Store EventManager in user object itself
- [x] Change the calls to be made for the User EventManager not global.