### PR TITLE
Mark embedded channels as fake

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/FakeChannelUtil.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/FakeChannelUtil.java
@@ -21,7 +21,8 @@ package com.github.retrooper.packetevents.util;
 public class FakeChannelUtil {
     public static boolean isFakeChannel(Object channel) {
         if (channel.getClass().getSimpleName().equals("FakeChannel")
-                || channel.getClass().getSimpleName().equals("SpoofedChannel")) {
+                || channel.getClass().getSimpleName().equals("SpoofedChannel")
+                || channel.getClass().getSimpleName().equals("EmbeddedChannel")) {
             return true;
         }
         return false;


### PR DESCRIPTION
  Add EmbeddedChannel as a FakeChannel name
  - This prevents Carpet mod players from not fully existing/being invisible
  - EmbeddedChannel is a standard netty channel used to mock/simulate a netty channel, and isn't used for actual player connections on any platform
