### PR TITLE
WrappedBlockState.getByString() hotfix

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -1561,7 +1561,13 @@ public class WrappedBlockState {
             if (this.string == null) {
                 StringBuilder builder = new StringBuilder();
                 for (Map.Entry<StateValue, Object> entry : this.map.entrySet()) {
-                    builder.append(entry.getKey().getName()).append('=').append(entry.getValue()).append(',');
+                    builder.append(entry.getKey().getName()).append('=').append(
+                            // This is technically incorrect as NBT is case sensitive, but doesn't matter for our use case
+                            // Should replace this for future proofing (Mojang is gonna "registrize" and "componentize" everything sooner or later)
+                            // and modded support
+                            // Doing so would however break this.getInternalData()
+                            entry.getValue().toString().toLowerCase(Locale.ROOT)
+                    ).append(',');
                 }
                 this.string = builder.length() == 0 ? "" : '[' + builder.substring(0, builder.length() - 1) + ']';
             }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -1561,7 +1561,7 @@ public class WrappedBlockState {
             if (this.string == null) {
                 StringBuilder builder = new StringBuilder();
                 for (Map.Entry<StateValue, Object> entry : this.map.entrySet()) {
-                    builder.append(entry.getKey()).append('=').append(entry.getValue()).append(',');
+                    builder.append(entry.getKey().getName()).append('=').append(entry.getValue()).append(',');
                 }
                 this.string = builder.length() == 0 ? "" : '[' + builder.substring(0, builder.length() - 1) + ']';
             }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/enums/West.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/enums/West.java
@@ -18,6 +18,8 @@
 
 package com.github.retrooper.packetevents.protocol.world.states.enums;
 
+import java.util.Locale;
+
 public enum West {
     FALSE,
     LOW,
@@ -25,5 +27,10 @@ public enum West {
     SIDE,
     TALL,
     TRUE,
-    UP
+    UP;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase(Locale.ROOT);
+    }
 }


### PR DESCRIPTION
Does what it says in title, I would recommend you merge this immediately given the urgency of this issue.

However I'm not really happy with this, as my comment notes
```
  // This is technically incorrect as NBT is case sensitive, but doesn't matter for our use case
  // Should replace this for future proofing (Mojang is gonna "registrize" and "componentize" everything sooner or later)
  // and modded support
  // Doing so would however break this.getInternalData()
```
Are you fine with me replacing this with a registry system? 

(If you're worried about performance btw microbenchmarking shows overall performance is actually slightly better since you don't have to call toString().ToUpperCase() for NBTByte and NBTInts in the parser)