### PR TITLE
Fix Goat Horn Cooldown

### DIFF
--- a/mappings/item_base_components/V_1_21_2.json
+++ b/mappings/item_base_components/V_1_21_2.json
@@ -4801,7 +4801,8 @@
     "item_model": "E21pbmVjcmFmdDpnb2F0X2hvcm4=",
     "item_name": "CggACXRyYW5zbGF0ZQAYaXRlbS5taW5lY3JhZnQuZ29hdF9ob3JuAA==",
     "max_stack_size": "AQ==",
-    "rarity": "AQ=="
+    "rarity": "AQ==",
+    "use_cooldown": "QOAAAAETbWluZWNyYWZ0OmdvYXRfaG9ybg=="
   },
   "goat_spawn_egg": {
     "item_model": "GG1pbmVjcmFmdDpnb2F0X3NwYXduX2VnZw==",

--- a/mappings/item_base_components/V_1_21_4.json
+++ b/mappings/item_base_components/V_1_21_4.json
@@ -4835,7 +4835,8 @@
     "item_model": "E21pbmVjcmFmdDpnb2F0X2hvcm4=",
     "item_name": "CggACXRyYW5zbGF0ZQAYaXRlbS5taW5lY3JhZnQuZ29hdF9ob3JuAA==",
     "max_stack_size": "AQ==",
-    "rarity": "AQ=="
+    "rarity": "AQ==",
+    "use_cooldown": "QOAAAAETbWluZWNyYWZ0OmdvYXRfaG9ybg=="
   },
   "goat_spawn_egg": {
     "item_model": "GG1pbmVjcmFmdDpnb2F0X3NwYXduX2VnZw==",


### PR DESCRIPTION
Closes https://github.com/GrimAnticheat/Grim/issues/2053. Goat horn cooldown is 7 seconds

Note that we need a way to specify the cooldown group for the future. Right now it doesn't matter because it falls back minecraft:goat_horn in vanilla which is only used for that item.