### PR TITLE
Keep block property order to fix conversions

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -41,13 +41,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.logging.Logger;
 
 import static com.github.retrooper.packetevents.util.adventure.AdventureIndexUtil.indexValueOrThrow;
@@ -379,7 +373,7 @@ public class WrappedBlockState {
                     SequentialNBTReader.Compound dataContent = (SequentialNBTReader.Compound) element.getValue();
                     StateCacheValue stateCache;
                     if (dataContent.hasNext()) { // only try to read if there is data available
-                        Map<StateValue, Object> dataMap = new HashMap<>(3);
+                        Map<StateValue, Object> dataMap = new LinkedHashMap<>(3);
                         for (Map.Entry<String, NBT> props : dataContent) {
                             StateValue state = StateValue.byName(props.getKey());
                             if (state == null) {
@@ -481,7 +475,7 @@ public class WrappedBlockState {
                     SequentialNBTReader.Compound dataContent = (SequentialNBTReader.Compound) nbt;
                     StateCacheValue stateCache;
                     if (dataContent.hasNext()) { // only try to read if there is data available
-                        Map<StateValue, Object> dataMap = new HashMap<>(3);
+                        Map<StateValue, Object> dataMap = new LinkedHashMap<>(3);
                         for (Map.Entry<String, NBT> props : dataContent) {
                             StateValue state = StateValue.byName(props.getKey());
                             if (state == null) {

--- a/api/src/test/java/com/github/retrooper/packetevents/test/BlockDataConversionTest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/BlockDataConversionTest.java
@@ -1,0 +1,23 @@
+package com.github.retrooper.packetevents.test;
+
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
+import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
+import com.github.retrooper.packetevents.test.base.BaseDummyAPITest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BlockDataConversionTest extends BaseDummyAPITest {
+
+    @Test
+    @DisplayName("Test BlockData string conversions")
+    public void testMaterialConversions() {
+        // this was generated from using: Material.WARPED_DOOR.createBlockData().getAsString(false)
+        String warpedDoorString = "minecraft:warped_door[facing=north,half=lower,hinge=left,open=false,powered=false]";
+        WrappedBlockState state = WrappedBlockState.getByString(ClientVersion.V_1_20_3, warpedDoorString, false);
+        assertEquals(StateTypes.WARPED_DOOR, state.getType());
+    }
+
+}


### PR DESCRIPTION
The vanilla ordering of block data properties isn't being preserved breaking methods such as the SpigotConversionUtil's fromBukkitBlockData method for certain blocks.