### PR TITLE
make itemstack type getter always return type

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
@@ -190,7 +190,7 @@ public class ItemStack {
     }
 
     public ItemType getType() {
-        return cachedIsEmpty ? ItemTypes.AIR : type;
+        return type;
     }
 
     public int getAmount() {


### PR DESCRIPTION
allows checking if the stack type is actually air without hacky stuff