### PR TITLE
chore: bump adventure to 4.20.0

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-adventure = "4.18.0"
+adventure = "4.20.0"
 examination = "1.3.0"
 netty = "4.1.72.Final"
 jetbrains-annotations = "23.0.0"


### PR DESCRIPTION
Paper 1.21.4 is now on this version, adds text shadow support