### PR TITLE
[Fix] Disconnected `null` due to invalid packet console log

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsDecoder.java
@@ -115,8 +115,8 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
                 FoliaScheduler.getEntityScheduler().runDelayed(player, (Plugin) PacketEvents.getAPI().getPlugin(), (o) -> player.kickPlayer("Invalid packet"), null, 1);
             }
 
-            if (user != null) {
-                PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to invalid packet!");
+            if (user != null && user.getProfile().getName() != null) {
+                PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to an invalid packet!");
             }
         }
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -143,9 +143,10 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
                     FoliaScheduler.getEntityScheduler().runDelayed(player, (Plugin) PacketEvents.getAPI().getPlugin(), (o) -> player.kickPlayer("Invalid packet"), null, 1);
                 }
 
-                if (user != null) {
-                    PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to invalid packet!");
-                }}
+                if (user != null && user.getProfile().getName() != null) {
+                    PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to an invalid packet!");
+                }
+            }
         }
 
         super.exceptionCaught(ctx, cause);

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsDecoder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsDecoder.java
@@ -93,7 +93,9 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
                             .execute(() -> Sponge.server().player(player).get().kick(Component.text("Invalid packet"))).build());
                 }
 
-                PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to invalid packet!");
+                if (user != null && user.getProfile().getName() != null) {
+                    PacketEvents.getAPI().getLogManager().warn("Disconnected " + user.getProfile().getName() + " due to an invalid packet!");
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed an issue where `getName()` could return null, resulting in the console message: `[packetevents] Disconnected null due to invalid packet!`. While the error is harmless, the fix addresses frequent questions about the log by preventing it altogether.