### PR TITLE
Add version and registry context to ItemStacks

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStackSerialization.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStackSerialization.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.component.PatchableComponentMa
 import com.github.retrooper.packetevents.protocol.item.type.ItemType;
 import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.Nullable;
 
@@ -65,11 +66,14 @@ public final class ItemStackSerialization {
             return ItemStack.EMPTY;
         }
 
-        ItemType type = ItemTypes.getRegistry().getById(wrapper.getServerVersion().toClientVersion(), typeId);
+        ClientVersion version = wrapper.getServerVersion().toClientVersion();
+        ItemType type = ItemTypes.getRegistry().getByIdOrThrow(version, typeId);
         int amount = wrapper.readByte();
         int legacyData = v1_13_2 ? -1 : wrapper.readShort();
         NBTCompound nbt = wrapper.readNBT();
-        return ItemStack.builder().type(type).amount(amount).nbt(nbt).legacyData(legacyData).build();
+        return ItemStack.builder().type(type).amount(amount)
+                .nbt(nbt).legacyData(legacyData)
+                .wrapper(wrapper).build();
     }
 
     /**
@@ -120,7 +124,7 @@ public final class ItemStackSerialization {
         int presentCount = wrapper.readVarInt();
         int absentCount = wrapper.readVarInt();
         if (presentCount == 0 && absentCount == 0) {
-            return ItemStack.builder().type(itemType).amount(count).build();
+            return ItemStack.builder().type(itemType).amount(count).wrapper(wrapper).build();
         }
 
         PatchableComponentMap components = new PatchableComponentMap(
@@ -158,7 +162,7 @@ public final class ItemStackSerialization {
             components.unset(wrapper.readMappedEntity(ComponentTypes.getRegistry()));
         }
 
-        return ItemStack.builder().type(itemType).amount(count).components(components).build();
+        return ItemStack.builder().type(itemType).amount(count).components(components).wrapper(wrapper).build();
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleItemStackData.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/particle/data/ParticleItemStackData.java
@@ -45,8 +45,8 @@ public class ParticleItemStackData extends ParticleData implements LegacyConvert
             return new ParticleItemStackData(wrapper.readItemStack());
         } else {
             return new ParticleItemStackData(ItemStack.builder()
-                    .type(ItemTypes.getById(wrapper.getClientVersion(), wrapper.readVarInt()))
-                    .build());
+                    .type(ItemTypes.getRegistry().getByIdOrThrow(wrapper.getClientVersion(), wrapper.readVarInt()))
+                    .wrapper(wrapper).build());
         }
     }
 


### PR DESCRIPTION
As logic related to ItemStack has changed quite a lot throughout the versions, this now adds a version (and registry) field to ItemStacks
These fields are populated by packetevents automatically when reading ItemStacks

Using this new version field, this PR properly updates the ItemStack api methods to how vanilla handles stuff now
Additionally, this should fix issues related to modern handling of item amounts breaking legacy negative stack sizes
(See e.g. https://github.com/retrooper/packetevents/pull/1192 and https://github.com/retrooper/packetevents/pull/1062)