### PR TITLE
Fix Setting RelativeFlags

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/teleport/RelativeFlag.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/teleport/RelativeFlag.java
@@ -74,7 +74,9 @@ public final class RelativeFlag {
     }
 
     public RelativeFlag set(int flags, boolean relative) {
-        int ret = relative ? (byte) (flags | this.mask) : (byte) (flags & ~this.mask);
+        int ret = relative
+                ? (this.mask | flags)      // turn singular bit on
+                : (this.mask & ~flags);    // turn singular bit off
         return new RelativeFlag(ret);
     }
 


### PR DESCRIPTION
Setting relative flags is currently broken.

`teleport.setRelative(RelativeFlag.X, false);`, for example sets all relative flags to false instead of only X. This is caused by overlooked simple logic error.