### PR TITLE
fix: minecraft:air isn't empty in <1.11

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
@@ -579,13 +579,12 @@ public class ItemStack {
     }
 
     public boolean isEmpty() {
-        if (this.version.isNewerThanOrEquals(ClientVersion.V_1_13)) {
-            return this.type == ItemTypes.AIR || this.amount <= 0;
-        } else if (this.version.isNewerThanOrEquals(ClientVersion.V_1_11)) {
-            return this.type == ItemTypes.AIR || this.amount <= 0
-                    || this.legacyData < (short) (1 << 15) || this.legacyData > (1 << 16);
+        boolean baseEmpty = this.type == ItemTypes.AIR || this.amount <= 0;
+        if (this.version.isOlderThanOrEquals(ClientVersion.V_1_12_2)) {
+            return baseEmpty || this.legacyData < Short.MIN_VALUE || this.legacyData > (1 << 16);
+        } else {
+            return baseEmpty;
         }
-        return this.amount <= 0;
     }
 
     public ClientVersion getVersion() {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStackSerialization.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStackSerialization.java
@@ -80,7 +80,7 @@ public final class ItemStackSerialization {
      * Removed with 1.20.5
      */
     private static void writeLegacy(PacketWrapper<?> wrapper, ItemStack stack) {
-        if (wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_13_2)) {
+        if (wrapper.getServerVersion().isOlderThanOrEquals(ServerVersion.V_1_12_2)) {
             int typeId = stack.isEmpty() ? -1 : stack.getType().getId(wrapper.getServerVersion().toClientVersion());
             wrapper.writeShort(typeId);
             if (typeId != -1) {


### PR DESCRIPTION
Fixed a issue that make `minecraft:air` return `isEmpty = false` in 1.8
Close #1218 
![QQ20250506-181149](https://github.com/user-attachments/assets/38017a97-ea8a-402d-8249-cad871e624e1)


This PR also fixes the legacyData error condition of isEmpty (Short.MIN_VALUE in NMS) and wrong version condition in `ItemStackSerialization.writeLegacy` (that's not for 1.13 😭)