### PR TITLE
fix direction vector mismatch with vanilla

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/Direction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/Direction.java
@@ -29,7 +29,7 @@ public enum Direction {
     NORTH(0, Axis.Y, new Vector3i(0 , 0, -1)),
     SOUTH(1, Axis.Y, new Vector3i(0 ,0 ,1)),
     WEST(2, Axis.X, new Vector3i(-1, 0 ,0)),
-    EAST(3, Axis.X, new Vector3i(-1, 0, 0));
+    EAST(3, Axis.X, new Vector3i(1, 0, 0));
 
     private final int horizontalIndex;
     private final Axis axis;


### PR DESCRIPTION
vanilla:
![image](https://github.com/user-attachments/assets/422d0f9d-58e0-47e0-8bdc-d91e014622b3)
