### PR TITLE
correctly parse payload in WrapperCommonClientCustomClickAction

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -76,6 +76,7 @@ import com.github.retrooper.packetevents.protocol.item.ItemStackSerialization;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.nbt.NBT;
 import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
+import com.github.retrooper.packetevents.protocol.nbt.NBTEnd;
 import com.github.retrooper.packetevents.protocol.nbt.NBTLimiter;
 import com.github.retrooper.packetevents.protocol.nbt.codec.NBTCodec;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -511,6 +512,11 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
 
     public NBTCompound readNBT() {
         return (NBTCompound) this.readNBTRaw();
+    }
+
+    public @Nullable NBT readNullableNBT() {
+        NBT tag = this.readNBTRaw();
+        return tag == NBTEnd.INSTANCE ? null : tag;
     }
 
     public NBT readNBTRaw() {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonClientCustomClickAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonClientCustomClickAction.java
@@ -45,7 +45,7 @@ public class WrapperCommonClientCustomClickAction<T extends WrapperCommonClientC
     @Override
     public void read() {
         this.id = ResourceLocation.read(this);
-        this.payload = this.readLengthPrefixed(MAX_PAYLOAD_SIZE, PacketWrapper::readNBTRaw);
+        this.payload = this.readLengthPrefixed(MAX_PAYLOAD_SIZE, PacketWrapper::readNullableNBT);
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonClientCustomClickAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/common/client/WrapperCommonClientCustomClickAction.java
@@ -45,15 +45,13 @@ public class WrapperCommonClientCustomClickAction<T extends WrapperCommonClientC
     @Override
     public void read() {
         this.id = ResourceLocation.read(this);
-        this.payload = this.readLengthPrefixed(MAX_PAYLOAD_SIZE, ew ->
-                ew.readOptional(PacketWrapper::readNBTRaw));
+        this.payload = this.readLengthPrefixed(MAX_PAYLOAD_SIZE, PacketWrapper::readNBTRaw);
     }
 
     @Override
     public void write() {
         ResourceLocation.write(this, this.id);
-        this.writeLengthPrefixed(this.payload, (ew, val) ->
-                ew.writeOptional(val, PacketWrapper::writeNBTRaw));
+        this.writeLengthPrefixed(this.payload, PacketWrapper::writeNBTRaw);
     }
 
     @Override


### PR DESCRIPTION
The payload is either an NBT or NBTEnd, but no boolean byte. So we don't have to check optional 

close #1268