### PR TITLE
Forced order personal packet transformers

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/PacketTransformer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/PacketTransformer.java
@@ -1,0 +1,18 @@
+package com.github.retrooper.packetevents.protocol;
+
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.player.User;
+
+public class PacketTransformer {
+   protected final User user;
+
+   public PacketTransformer(User user) {
+      this.user = user;
+   }
+
+   public void onPreReceive(PacketReceiveEvent event) {}
+   public void onPostReceive(PacketReceiveEvent event) {}
+   public void onPreSend(PacketSendEvent event) {}
+   public void onPostSend(PacketSendEvent event) {}
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/User.java
@@ -24,6 +24,7 @@ import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.netty.channel.ChannelHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.PacketTransformer;
 import com.github.retrooper.packetevents.protocol.chat.ChatType;
 import com.github.retrooper.packetevents.protocol.chat.ChatTypes;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage;
@@ -49,11 +50,13 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTi
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 public class User implements IRegistryHolder {
@@ -61,6 +64,7 @@ public class User implements IRegistryHolder {
     private final Object channel;
     private ConnectionState decoderState;
     private ConnectionState encoderState;
+    private PacketTransformer transformer = new PacketTransformer(this); // personal packet transformer
     private ClientVersion clientVersion;
     private final UserProfile profile;
     private int entityId = -1;
@@ -76,6 +80,14 @@ public class User implements IRegistryHolder {
         this.encoderState = connectionState;
         this.clientVersion = clientVersion;
         this.profile = profile;
+    }
+
+    public void setTransformer(@NotNull PacketTransformer transformer) {
+        this.transformer = Objects.requireNonNull(transformer);
+    }
+
+    public @NotNull PacketTransformer getTransformer() {
+        return transformer;
     }
 
     @ApiStatus.Internal

--- a/api/src/main/java/com/github/retrooper/packetevents/util/PacketEventsImplHelper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/PacketEventsImplHelper.java
@@ -58,9 +58,17 @@ public final class PacketEventsImplHelper {
         int preProcessIndex = ByteBufHelper.readerIndex(buffer);
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(channel, user, player, buffer, autoProtocolTranslation);
         int processIndex = ByteBufHelper.readerIndex(buffer);
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> {
+        user.getTransformer().onPreSend(packetSendEvent);
+        ByteBufHelper.readerIndex(buffer, processIndex);
+        if(!packetSendEvent.isCancelled()) {
+            PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> {
+                ByteBufHelper.readerIndex(buffer, processIndex);
+            });
+        }
+        if(!packetSendEvent.isCancelled()) {
+            user.getTransformer().onPostSend(packetSendEvent);
             ByteBufHelper.readerIndex(buffer, processIndex);
-        });
+        }
         if (!packetSendEvent.isCancelled()) {
             //Did they ever use a wrapper?
             if (packetSendEvent.getLastUsedWrapper() != null) {
@@ -98,9 +106,17 @@ public final class PacketEventsImplHelper {
         int preProcessIndex = ByteBufHelper.readerIndex(buffer);
         PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(channel, user, player, buffer, autoProtocolTranslation);
         int processIndex = ByteBufHelper.readerIndex(buffer);
-        PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> {
+        user.getTransformer().onPreReceive(packetReceiveEvent);
+        ByteBufHelper.readerIndex(buffer, processIndex);
+        if(!packetReceiveEvent.isCancelled()) {
+            PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> {
+                ByteBufHelper.readerIndex(buffer, processIndex);
+            });
+        }
+        if(!packetReceiveEvent.isCancelled()) {
+            user.getTransformer().onPostReceive(packetReceiveEvent);
             ByteBufHelper.readerIndex(buffer, processIndex);
-        });
+        }
         if (!packetReceiveEvent.isCancelled()) {
             //Did they ever use a wrapper?
             if (packetReceiveEvent.getLastUsedWrapper() != null) {

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
@@ -56,7 +56,15 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
             PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(ctx.channel(),
                     user, player, transformed, false);
             int readerIndex = transformed.readerIndex();
-            PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            user.getTransformer().onPreReceive(packetReceiveEvent);
+            ByteBufHelper.readerIndex(transformed, readerIndex);
+            if(!packetReceiveEvent.isCancelled()) {
+                PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            }
+            if(!packetReceiveEvent.isCancelled()) {
+                user.getTransformer().onPostReceive(packetReceiveEvent);
+                ByteBufHelper.readerIndex(transformed, readerIndex);
+            }
             if (!packetReceiveEvent.isCancelled()) {
                 if (packetReceiveEvent.getLastUsedWrapper() != null) {
                     ByteBufHelper.clear(packetReceiveEvent.getByteBuf());

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -55,7 +55,15 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(ctx.channel(), user, player,
                 buffer, false);
         int readerIndex = buffer.readerIndex();
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        user.getTransformer().onPreSend(packetSendEvent);
+        ByteBufHelper.readerIndex(buffer, readerIndex);
+        if(!packetSendEvent.isCancelled()) {
+            PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        }
+        if(!packetSendEvent.isCancelled()) {
+            user.getTransformer().onPostSend(packetSendEvent);
+            ByteBufHelper.readerIndex(buffer, readerIndex);
+        }
         if (!packetSendEvent.isCancelled()) {
             if (packetSendEvent.getLastUsedWrapper() != null) {
                 ByteBuf newBuffer;

--- a/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsDecoder.java
@@ -54,7 +54,15 @@ public class PacketEventsDecoder extends MessageToMessageDecoder<ByteBuf> {
             PacketReceiveEvent packetReceiveEvent = EventCreationUtil.createReceiveEvent(ctx.channel(), user, player,
                     transformed, false);
             int readerIndex = transformed.readerIndex();
-            PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            user.getTransformer().onPreReceive(packetReceiveEvent);
+            ByteBufHelper.readerIndex(transformed, readerIndex);
+            if(!packetReceiveEvent.isCancelled()) {
+                PacketEvents.getAPI().getEventManager().callEvent(packetReceiveEvent, () -> transformed.readerIndex(readerIndex));
+            }
+            if(!packetReceiveEvent.isCancelled()) {
+                user.getTransformer().onPostReceive(packetReceiveEvent);
+                ByteBufHelper.readerIndex(transformed, readerIndex);
+            }
             if (!packetReceiveEvent.isCancelled()) {
                 if (packetReceiveEvent.getLastUsedWrapper() != null) {
                     ByteBufHelper.clear(packetReceiveEvent.getByteBuf());

--- a/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/handlers/PacketEventsEncoder.java
@@ -43,7 +43,15 @@ public class PacketEventsEncoder extends MessageToByteEncoder<ByteBuf> {
         PacketSendEvent packetSendEvent = EventCreationUtil.createSendEvent(ctx.channel(), user, player, buffer,
                 false);
         int readerIndex = buffer.readerIndex();
-        PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        user.getTransformer().onPreSend(packetSendEvent);
+        ByteBufHelper.readerIndex(buffer, readerIndex);
+        if(!packetSendEvent.isCancelled()) {
+            PacketEvents.getAPI().getEventManager().callEvent(packetSendEvent, () -> buffer.readerIndex(readerIndex));
+        }
+        if(!packetSendEvent.isCancelled()) {
+            user.getTransformer().onPostSend(packetSendEvent);
+            ByteBufHelper.readerIndex(buffer, readerIndex);
+        }
         if (!packetSendEvent.isCancelled()) {
             if (packetSendEvent.getLastUsedWrapper() != null) {
                 ByteBufHelper.clear(packetSendEvent.getByteBuf());


### PR DESCRIPTION
Adds a PacketTransformer class which accepts PacketSendEvent and PacketReceiveEvent before and after any listeners are invoked. 

Primary reason is to allow to easily force order of some packet events, for example allow proper coordinate obfuscating/deobfuscating before packets hit the anticheat.

Secondary reason is probably to save a few nanoseconds in processing times for plugins which need to handle all packets (said coordinate obfuscators) to avoid doing something like PlayerData.get(event.getUser().getUUID()) rather directly giving ability to set transformer and pass user data into it.

Initially I wanted to make a map of transformers similar to netty pipeline, but didn't want to overcomplicate things, + there's always going to be a bold plugin which thinks that it's the most important one. 

That's how I use it in my coordinate obfuscator
```java
private class UserListener extends PacketListenerAbstract {
        @Override
        public void onUserLogin(UserLoginEvent event) {
            User user = event.getUser();
            user.setTransformer(new ObfuscatorTransformer(user, PlayerData.get(user.getUUID())));
        }
  }
  
  public class Transformer extends PacketTransformer {
        private final PlayerData data;

        public Transformer(User user, PlayerData data) {
            super(user);
            this.data = data;
        }

        @Override
        public void onPostSend(PacketSendEvent event) {
            data.obfuscate(event);
        }

        @Override
        public void onPreReceive(PacketReceiveEvent event) {
           data.deobfuscate(event);
        }
    }
  ```