### PR TITLE
Automatic release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -27,10 +25,9 @@ jobs:
 
       - name: Extract changelog
         id: changelog
-        env:
-          REF: ${{ github.ref }}
         run: |
-          awk -v tag="${REF:10}" '
+          TAG_NAME="v$(./gradlew -q printVersion)"
+          awk -v tag="${TAG_NAME}" '
             $1 == "!!!!!" && $2 == tag {found=1; next}
             $1 == "!!!!!" && found {exit}
             found

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish Release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Extract changelog
+        id: changelog
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          awk -v tag="${REF:10}" '
+            $1 == "!!!!!" && $2 == tag {found=1; next}
+            $1 == "!!!!!" && found {exit}
+            found
+          ' CHANGELOG.md
+
+      - name: Publish plugin
+        env:
+          GITHUB_API_TOKEN: ${{ github.token }}
+          MODRINTH_API_TOKEN: ${{ secrets.MODRINTH_PUBLISH_TOKEN }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+        run: ./gradlew publishMods --no-daemon -PnoDryPublish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,19 @@ jobs:
       - name: Extract changelog
         id: changelog
         run: |
+          OUTPUT_DELIMITER="$(uuidgen)"
+          echo "changelog<<$OUTPUT_DELIMITER" >> "$GITHUB_OUTPUT"
+          
+          # extract tag name and use it to get changelog section
           TAG_NAME="v$(./gradlew -q --no-daemon printVersion)"
           awk -v tag="${TAG_NAME}" '
             $1 == "!!!!!" && $2 == tag {found=1; next}
             $1 == "!!!!!" && found {exit}
             found
-          ' CHANGELOG.md
+          ' CHANGELOG.md >> "$GITHUB_OUTPUT"
+          
+          # end output
+          echo "$OUTPUT_DELIMITER" >> "$GITHUB_OUTPUT"
 
       - name: Publish plugin
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,13 @@ jobs:
           java-version: 21
           distribution: temurin
 
+      - name: Prepare gradle
+        run: ./gradlew printVersion --no-daemon
+
       - name: Extract changelog
         id: changelog
         run: |
-          TAG_NAME="v$(./gradlew -q printVersion)"
+          TAG_NAME="v$(./gradlew -q --no-daemon printVersion)"
           awk -v tag="${TAG_NAME}" '
             $1 == "!!!!!" && $2 == tag {found=1; next}
             $1 == "!!!!!" && found {exit}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-!!!!! v2.9.0
-
-# PacketEvents 2.9.0 is out now! 🎉
-
-Epic update, go download now!
-
 !!!!! v2.8.0
 
 # PacketEvents 2.8.0 is out now! 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+!!!!! v2.9.0
+
+# PacketEvents 2.9.0 is out now! 🎉
+
+Epic update, go download now!
+
 !!!!! v2.8.0
 
 # PacketEvents 2.8.0 is out now! 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+!!!!! v2.8.0
+
+# PacketEvents 2.8.0 is out now! 🎉
+
+### New update now supports Minecraft version 1.21.5. Please update, as numerous bugs have been fixed.
+
+# Brief Announcement 📢⚠️
+
+### We have our very own website: https://packetevents.com
+
+### Documentation: https://docs.packetevents.com
+
+### JavaDocs: https://javadocs.packetevents.com
+
+## What's Changed? (Summary)
+
+* Added 1.21.5 support
+* Various bugs fixed
+
+**View Full Changelog**: https://github.com/retrooper/packetevents/compare/v2.7.0...v2.8.0
+
+## Contributors 🏅
+
+This update wouldn't be possible without these contributors ❤️: @booky10, @Axionize, @Bram1903, @ManInMyVan, @ytnoos,
+@AoElite, @HaHaWTH, @divinepablo, @scienziatopazzo, @bridgelol, @MachineBreaker, @Luuzzi, @Beaness, @Rubenicos, @Loyisa
+
+## New Contributors
+
+* @HaHaWTH made their first contribution in https://github.com/retrooper/packetevents/pull/1097
+* @divinepablo made their first contribution in https://github.com/retrooper/packetevents/pull/1098
+* @scienziatopazzo made their first contribution in https://github.com/retrooper/packetevents/pull/1105
+* @bridgelol made their first contribution in https://github.com/retrooper/packetevents/pull/1199
+* @Luuzzi made their first contribution in https://github.com/retrooper/packetevents/pull/1197
+* @Beaness made their first contribution in https://github.com/retrooper/packetevents/pull/1212
+* @Rubenicos made their first contribution in https://github.com/retrooper/packetevents/pull/1162
+* @Loyisa made their first contribution in https://github.com/retrooper/packetevents/pull/1220
+
+## If you want to support PacketEvents, consider sponsoring us on [GitHub Sponsors](https://github.com/sponsors/retrooper)
+
+## Maven/Gradle Dependency
+
+### **Check out**: https://docs.packetevents.com/getting-started
+
+!!!!!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,4 +41,83 @@ This update wouldn't be possible without these contributors ❤️: @booky10, @A
 
 ### **Check out**: https://docs.packetevents.com/getting-started
 
+!!!!! v2.7.0
+
+# PacketEvents v2.7.0 is out now! 🎉
+
+### New update with support of the latest Minecraft version. In addition to that, countless bugs were fixed.
+
+# Brief Announcement 📢⚠️
+
+### We have our own website: https://packetevents.com
+
+### Documentation: https://docs.packetevents.com
+
+### JavaDocs: https://javadocs.packetevents.com
+
+## What's Changed? (Summary)
+
+* Added 1.21.4 support
+* Fix: Potion contents item component for 1.21.2/1.21.3
+* Fix: NPC objects to have unique server team names
+* Add missing ServerVersion#V_1_9_1
+* Validation checks added for window click type
+
+**Full Changelog**: https://github.com/retrooper/packetevents/compare/v2.6.0...v2.7.0
+
+## New Contributors
+
+* @Axionize made their first contribution in https://github.com/retrooper/packetevents/pull/1048
+* @ShreyasAyyengar made their first contribution in https://github.com/retrooper/packetevents/pull/1044
+* @mfnalex made their first contribution in https://github.com/retrooper/packetevents/pull/1076
+
+## Contributors 🏅
+
+This update wouldn't be possible without these contributors ❤️: @booky10, @rafi67000, @ShreyasAyyengar, @AoElite,
+@Tecnio, @Axionize, @mfnalex
+
+### If you want to support PacketEvents, and any upcoming events we plan for the future, consider sponsoring us on [GitHub Sponsors](https://github.com/sponsors/retrooper)
+
+## Maven/Gradle Dependency
+
+### **Check out**: https://docs.packetevents.com/getting-started
+
+!!!!! v2.6.0
+
+# PacketEvents v2.6.0 is out now! 🎉
+
+### New update with support of new platforms & the latest Minecraft version. In addition to that, countless bugs were fixed.
+
+# Brief Announcement 📢⚠️
+
+### We have our own website: https://packetevents.com
+
+### Documentation: https://docs.packetevents.com
+
+### JavaDocs: https://javadocs.packetevents.com
+
+## What's Changed? (Summary)
+
+* 1.21.2 and 1.21.3 Minecraft support
+* Sponge support added
+* Fabric support added (also server-side)
+* Utilizing the proper bStats API
+* Registry element issues fixed
+* Mappings issues fixed
+* AdvancedSlimePaper issues fixed
+* BungeeCord issues fixed
+
+### **Full Changelog**: https://github.com/retrooper/packetevents/compare/v2.5.0...v2.6.0
+
+## Contributors 🏅
+
+This update wouldn't be possible without these contributors ❤️: @booky10, @ManInMyVan, @SamB440, @rafi67000, @Bram1903,
+@AbhigyaKrishna
+
+### If you want to support PacketEvents, and any upcoming events we plan for the future, consider sponsoring us on [GitHub Sponsors](https://github.com/sponsors/retrooper)
+
+## Maven/Gradle Dependency
+
+### **Check out**: https://docs.packetevents.com/getting-started
+
 !!!!!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,17 @@
-import java.io.ByteArrayOutputStream
-
 // TODO UPDATE
-val fullVersion = "2.9.0"
-val snapshot = true
+ext["fullVersion"] = "2.9.0"
+ext["snapshot"] = true
+
+ext["commitHash"] = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.map { it.trim() }.orElse("unknown")
+ext["versionMeta"] = if (ext["snapshot"] == true) "-SNAPSHOT" else ""
+ext["versionMetaWithHash"] = "+${ext["commitHash"]}${ext["versionMeta"]}"
+ext["versionNoHash"] = "${ext["fullVersion"]}${ext["versionMeta"]}"
 
 group = "com.github.retrooper"
 description = rootProject.name
-
-fun getVersionMeta(includeHash: Boolean): String {
-    if (!snapshot) {
-        return ""
-    }
-    var commitHash = ""
-    if (includeHash && file(".git").isDirectory) {
-        val stdout = ByteArrayOutputStream()
-        exec {
-            commandLine("git", "rev-parse", "--short", "HEAD")
-            standardOutput = stdout
-        }
-        commitHash = "+${stdout.toString().trim()}"
-    }
-    return "$commitHash-SNAPSHOT"
-}
-version = "$fullVersion${getVersionMeta(true)}"
-ext["versionNoHash"] = "$fullVersion${getVersionMeta(false)}"
+version = "${ext["fullVersion"]}${ext["versionMetaWithHash"]}"
 
 tasks {
     wrapper {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,9 @@ plugins {
     packetevents.`publish-conventions`
 }
 
+// properties are all set as string, convert to boolean
+ext["snapshot"] = ext["snapshot"].toString().toBooleanStrict()
+
 ext["commitHash"] = providers.exec {
     commandLine("git", "rev-parse", "--short", "HEAD")
 }.standardOutput.asText.map { it.trim() }.getOrElse("unknown")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,17 @@
-// TODO UPDATE
-ext["fullVersion"] = "2.9.0"
-ext["snapshot"] = true
+plugins {
+    packetevents.`publish-conventions`
+}
 
 ext["commitHash"] = providers.exec {
     commandLine("git", "rev-parse", "--short", "HEAD")
-}.standardOutput.asText.map { it.trim() }.orElse("unknown")
+}.standardOutput.asText.map { it.trim() }.getOrElse("unknown")
 ext["versionMeta"] = if (ext["snapshot"] == true) "-SNAPSHOT" else ""
 ext["versionMetaWithHash"] = "+${ext["commitHash"]}${ext["versionMeta"]}"
 ext["versionNoHash"] = "${ext["fullVersion"]}${ext["versionMeta"]}"
 
 group = "com.github.retrooper"
 description = rootProject.name
-version = "${ext["fullVersion"]}${ext["versionMetaWithHash"]}"
+version = "${ext["fullVersion"]}${ext[if (ext["snapshot"] == true) "versionMetaWithHash" else "versionMeta"]}"
 
 tasks {
     wrapper {
@@ -50,12 +50,17 @@ tasks {
         delete(rootProject.layout.buildDirectory)
     }
 
+    register("printVersion") {
+        println(project.version)
+    }
+
     defaultTasks("build")
 }
 
 allprojects {
     tasks {
         withType<Jar> {
+            archiveBaseName = "${rootProject.name}-${project.name}"
             archiveVersion = rootProject.ext["versionNoHash"] as String
         }
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,4 +21,5 @@ dependencies {
     implementation(libs.fast.util)
     implementation(libs.gson)
     implementation(libs.java.diff.utils)
+    implementation(libs.mod.publish)
 }

--- a/buildSrc/libs.versions.toml
+++ b/buildSrc/libs.versions.toml
@@ -5,6 +5,7 @@ via-nbt = "4.1.0"
 fast-util = "8.5.6"
 gson = "2.8.9"
 java-diff-utils = "4.12"
+mod-publish = "0.8.4"
 
 [libraries]
 shadow = { group = "com.gradleup.shadow", name = "shadow-gradle-plugin", version.ref = "shadow" }
@@ -13,3 +14,4 @@ via-nbt = { group = "com.viaversion", name = "nbt", version.ref = "via-nbt" }
 fast-util = { group = "it.unimi.dsi", name = "fastutil", version.ref = "fast-util" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 java-diff-utils = { group = "io.github.java-diff-utils", name = "java-diff-utils", version.ref = "java-diff-utils" }
+mod-publish = { group = "me.modmuss50", name = "mod-publish-plugin", version.ref = "mod-publish" }

--- a/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
@@ -60,6 +60,8 @@ configure<ModPublishExtension> {
                 start = property("publishing.modrinth.version.start").toString()
                 end = property("publishing.modrinth.version.end").toString()
             }
+            val loadersStr = property("publishing.modrinth.loaders").toString()
+            modLoaders.addAll(loadersStr.split(","))
         }
     }
 }

--- a/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
@@ -1,0 +1,35 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import me.modmuss50.mpp.ModPublishExtension
+
+plugins {
+    me.modmuss50.`mod-publish-plugin`
+}
+
+configure<ModPublishExtension> {
+    file = tasks.named<ShadowJar>("shadowJar").flatMap { it.archiveFile }
+    additionalFiles.from(tasks.named<Jar>("sourcesJar").flatMap { it.archiveFile })
+    changelog = providers.environmentVariable("CHANGELOG").getOrElse("No changelog provided")
+    type = if (rootProject.version.toString().endsWith("-SNAPSHOT")) BETA else STABLE
+    dryRun = !hasProperty("noDryPublish")
+
+    val platform = project.projectDir.name
+
+    github {
+        accessToken = providers.environmentVariable("GITHUB_API_TOKEN")
+        repository = providers.environmentVariable("GITHUB_REPOSITORY")
+        commitish = providers.environmentVariable("GITHUB_REF_NAME")
+        displayName = rootProject.version.toString()
+        // TODO parent
+    }
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_API_TOKEN")
+        var versionBob = "${rootProject.ext["fullVersion"]}+${platform}"
+        if (rootProject.ext["snapshot"] == true) {
+            // e.g. "0.0.0+platform.abcdefg"
+            version = "${versionBob}.${rootProject.ext["commitHash"]}"
+        } else {
+            // e.g. "0.0.0+platform"
+            version = versionBob
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
@@ -20,6 +20,7 @@ configure<ModPublishExtension> {
             accessToken = providers.environmentVariable("GITHUB_API_TOKEN")
             repository = providers.environmentVariable("GITHUB_REPOSITORY")
             commitish = providers.environmentVariable("GITHUB_REF_NAME")
+            tagName = version.map { "v${it}" }
             displayName = version
 
             // won't be empty, just so the publishing plugin won't complain

--- a/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
@@ -10,7 +10,7 @@ configure<ModPublishExtension> {
     changelog = providers.environmentVariable("CHANGELOG")
         .map { it.trim() }
         .getOrElse("No changelog provided")
-    type = if (project.version.toString().endsWith("-SNAPSHOT")) BETA else STABLE
+    type = if (rootProject.ext["snapshot"] == true) BETA else STABLE
     dryRun = !hasProperty("noDryPublish")
 
     // if there is no publishing platform set, assume this is the root task

--- a/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.publish-conventions.gradle.kts
@@ -1,35 +1,74 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import me.modmuss50.mpp.ModPublishExtension
+import me.modmuss50.mpp.PublishModTask
 
 plugins {
     me.modmuss50.`mod-publish-plugin`
 }
 
 configure<ModPublishExtension> {
-    file = tasks.named<ShadowJar>("shadowJar").flatMap { it.archiveFile }
-    additionalFiles.from(tasks.named<Jar>("sourcesJar").flatMap { it.archiveFile })
-    changelog = providers.environmentVariable("CHANGELOG").getOrElse("No changelog provided")
-    type = if (rootProject.version.toString().endsWith("-SNAPSHOT")) BETA else STABLE
+    changelog = providers.environmentVariable("CHANGELOG")
+        .map { it.trim() }
+        .getOrElse("No changelog provided")
+    type = if (project.version.toString().endsWith("-SNAPSHOT")) BETA else STABLE
     dryRun = !hasProperty("noDryPublish")
 
-    val platform = project.projectDir.name
+    // if there is no publishing platform set, assume this is the root task
+    // which is used to support github releases properly
+    if (!hasProperty("publishing.platform")) {
+        github {
+            accessToken = providers.environmentVariable("GITHUB_API_TOKEN")
+            repository = providers.environmentVariable("GITHUB_REPOSITORY")
+            commitish = providers.environmentVariable("GITHUB_REF_NAME")
+            displayName = version
 
-    github {
-        accessToken = providers.environmentVariable("GITHUB_API_TOKEN")
-        repository = providers.environmentVariable("GITHUB_REPOSITORY")
-        commitish = providers.environmentVariable("GITHUB_REF_NAME")
-        displayName = rootProject.version.toString()
-        // TODO parent
-    }
-    modrinth {
-        accessToken = providers.environmentVariable("MODRINTH_API_TOKEN")
-        var versionBob = "${rootProject.ext["fullVersion"]}+${platform}"
-        if (rootProject.ext["snapshot"] == true) {
-            // e.g. "0.0.0+platform.abcdefg"
-            version = "${versionBob}.${rootProject.ext["commitHash"]}"
-        } else {
-            // e.g. "0.0.0+platform"
-            version = versionBob
+            // won't be empty, just so the publishing plugin won't complain
+            allowEmptyFiles = true
         }
+
+        // iterate through all subprojects and search for configured release files
+        subprojects.filter { it.hasProperty("publishing.platform") }.forEach {
+            // add main platform publishing file after project has finished evaluating
+            it.afterEvaluate {
+                additionalFiles.from(publishMods.file)
+            }
+        }
+    } else {
+        if (!hasProperty("publishing.skip_files")) {
+            // setup files for this platform
+            file = tasks.named<ShadowJar>("shadowJar").flatMap { it.archiveFile }
+            additionalFiles.from(tasks.named<Jar>("sourcesJar").flatMap { it.archiveFile })
+        }
+
+        val platform = property("publishing.platform").toString()
+        val fancyPlatform = platform.replaceFirstChar { it.titlecaseChar() }
+
+        // setup per-platform modrinth publishing
+        modrinth {
+            accessToken = providers.environmentVariable("MODRINTH_API_TOKEN")
+            var versionBob = "${rootProject.ext["fullVersion"]}+${platform}"
+            if (rootProject.ext["snapshot"] == true) {
+                // e.g. "0.0.0+platform.abcdefg"
+                version = "${versionBob}.${rootProject.ext["commitHash"]}"
+            } else {
+                // e.g. "0.0.0+platform"
+                version = versionBob
+            }
+            displayName = "${rootProject.ext["publishing.display_name"]} ${rootProject.version} ${fancyPlatform}"
+            projectId = property("publishing.modrinth.project").toString()
+            minecraftVersionRange {
+                start = property("publishing.modrinth.version.start").toString()
+                end = property("publishing.modrinth.version.end").toString()
+            }
+        }
+    }
+}
+
+if (hasProperty("publishing.platform")
+    && !hasProperty("publishing.skip_files")
+) {
+    tasks.withType<PublishModTask> {
+        dependsOn(tasks.named<ShadowJar>("shadowJar"))
+        dependsOn(tasks.named<Jar>("sourcesJar"))
     }
 }

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     packetevents.`shadow-conventions`
     packetevents.`library-conventions`
+    packetevents.`publish-conventions`
 }
 
 repositories {

--- a/bungeecord/gradle.properties
+++ b/bungeecord/gradle.properties
@@ -1,0 +1,4 @@
+publishing.platform=bungeecord
+publishing.modrinth.loaders=bungeecord,waterfall
+publishing.modrinth.version.start=1.8.8
+publishing.modrinth.version.end=latest

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,5 +1,11 @@
+import me.modmuss50.mpp.ModPublishExtension
+import me.modmuss50.mpp.PublishModTask
+import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.RemapSourcesJarTask
+
 plugins {
     packetevents.`library-conventions`
+    packetevents.`publish-conventions`
     alias(libs.plugins.fabric.loom)
 }
 
@@ -44,12 +50,18 @@ tasks {
     }
 
     remapJar {
-        archiveBaseName = "${rootProject.name}-fabric"
+        archiveBaseName = "${rootProject.name}-${project.name}"
         archiveVersion = rootProject.ext["versionNoHash"] as String
     }
 
     remapSourcesJar {
+        archiveBaseName = "${rootProject.name}-${project.name}"
         archiveVersion = rootProject.ext["versionNoHash"] as String
+    }
+
+    withType<PublishModTask> {
+        dependsOn(named<RemapJarTask>("remapJar"))
+        dependsOn(named<RemapSourcesJarTask>("remapSourcesJar"))
     }
 }
 
@@ -63,4 +75,9 @@ loom {
     }
     accessWidenerPath = sourceSets.main.get().resources.srcDirs.single()
         .resolve("${rootProject.name}.accesswidener")
+}
+
+configure<ModPublishExtension> {
+    file = tasks.named<RemapJarTask>("remapJar").flatMap { it.archiveFile }
+    additionalFiles.from(tasks.named<RemapSourcesJarTask>("remapSourcesJar").flatMap { it.archiveFile })
 }

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -8,3 +8,9 @@ minecraft_version=1.21.6
 parchment_mappings=2025.06.01
 parchment_minecraft_version=1.21.5
 loader_version=0.16.14
+
+publishing.skip_files=true
+publishing.platform=fabric
+publishing.modrinth.loaders=fabric
+publishing.modrinth.version.start=1.21
+publishing.modrinth.version.end=latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2000m
 
 # TODO UPDATE
 fullVersion=2.9.0
-snapshot=false
+snapshot=true
 
 publishing.display_name=PacketEvents
-publishing.modrinth.project=eAqNJSbO
+publishing.modrinth.project=HYKaKraK

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
 org.gradle.jvmargs=-Xmx2000m
+
+# TODO UPDATE
+fullVersion=2.9.0
+snapshot=true
+
+publishing.display_name=PacketEvents
+publishing.modrinth.project=HYKaKraK

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx2000m
 
 # TODO UPDATE
-fullVersion=2.9.1
+fullVersion=2.9.0
 snapshot=true
 
 publishing.display_name=PacketEvents
-publishing.modrinth.project=eAqNJSbO
+publishing.modrinth.project=HYKaKraK

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx2000m
 
 # TODO UPDATE
-fullVersion=2.9.0
+fullVersion=2.9.1
 snapshot=true
 
 publishing.display_name=PacketEvents
-publishing.modrinth.project=HYKaKraK
+publishing.modrinth.project=eAqNJSbO

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2000m
 
 # TODO UPDATE
 fullVersion=2.9.0
-snapshot=true
+snapshot=false
 
 publishing.display_name=PacketEvents
-publishing.modrinth.project=HYKaKraK
+publishing.modrinth.project=eAqNJSbO

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -38,8 +38,8 @@ velocity = { group = "com.velocitypowered", name = "velocity-api", version.ref =
 classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref = "classgraph" }
 
 [bundles]
-adventure = [ "adventure-api", "adventure-nbt", "adventure-key", "adventure-examination-api", "adventure-examination-string" ]
-adventure-serializers = [ "adventure-text-serializer-gson", "adventure-text-serializer-json-legacy", "adventure-text-serializer-legacy" ]
+adventure = ["adventure-api", "adventure-nbt", "adventure-key", "adventure-examination-api", "adventure-examination-string"]
+adventure-serializers = ["adventure-text-serializer-gson", "adventure-text-serializer-json-legacy", "adventure-text-serializer-legacy"]
 
 [plugins]
 run-paper = { id = "xyz.jpenilla.run-paper", version.ref = "run-paper" }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     packetevents.`shadow-conventions`
     packetevents.`library-conventions`
+    packetevents.`publish-conventions`
     alias(libs.plugins.run.paper)
 }
 

--- a/spigot/gradle.properties
+++ b/spigot/gradle.properties
@@ -1,0 +1,4 @@
+publishing.platform=spigot
+publishing.modrinth.loaders=bukkit,spigot,paper,folia,purpur
+publishing.modrinth.version.start=1.8.8
+publishing.modrinth.version.end=latest

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -4,6 +4,7 @@ import org.spongepowered.plugin.metadata.model.PluginDependency
 plugins {
     packetevents.`shadow-conventions`
     packetevents.`library-conventions`
+    packetevents.`publish-conventions`
     alias(libs.plugins.spongeGradle)
 }
 

--- a/sponge/gradle.properties
+++ b/sponge/gradle.properties
@@ -1,0 +1,4 @@
+publishing.platform=sponge
+publishing.modrinth.loaders=sponge
+publishing.modrinth.version.start=1.21
+publishing.modrinth.version.end=latest

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     packetevents.`shadow-conventions`
     packetevents.`library-conventions`
+    packetevents.`publish-conventions`
     alias(libs.plugins.run.velocity)
 }
 

--- a/velocity/gradle.properties
+++ b/velocity/gradle.properties
@@ -1,0 +1,4 @@
+publishing.platform=velocity
+publishing.modrinth.loaders=velocity
+publishing.modrinth.version.start=1.7.10
+publishing.modrinth.version.end=latest


### PR DESCRIPTION
Adds a github workflow which adds automatic publishing to github releases and modrinth using https://github.com/modmuss50/mod-publish-plugin

I've tested this on my fork repository and a private modrinth project to work with both snapshot publishing and release publishing

To allow for modrinth publishing to work, @retrooper needs to add a github actions secret called `MODRINTH_PUBLISH_TOKEN` with a modrinth PAT which has access to creating versions

## How to do a release

1. Write changelog to `CHANGELOG.md`, set `snapshot` to `false` in `gradle.properties` and commit+push
2. Wait until github actions has finished building and trigger javadocs update workflow [here](https://github.com/packetevents/packetevents.github.io/actions/workflows/javadoc.yml)
3. Wait until github actions has finished updating javadocs and trigger release workflow [here](https://github.com/retrooper/packetevents/actions/workflows/release.yml)
4. Wait until github actions has finished publishing release, increment `fullVersion` + activate `snapshot` in `gradle.properties` and commit+push
5. Manually upload spigot platform release jar to spigotmc
6. Update version in wiki
7. Update version on documentation