### PR TITLE
Cleanup gradle configuration mess

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,13 +22,15 @@ java {
 dependencies {
     compileOnlyApi(libs.bundles.adventure)
     compileOnlyApi(libs.bundles.adventure.serializers)
+
     implementation(libs.adventure.api)
-    api(project(":patch:adventure-text-serializer-gson", "shadow")) {
-        excludeAdventure()
+    project(":patch:adventure-text-serializer-gson", "shadow").apply {
+        // I am not sure why, but to override the real adventure serializer our
+        // dependency has to be in the "api" configuration...
+        api(this) { excludeAdventure() }
+        shadowAndPublish(this) { excludeAdventure() }
     }
-    api(libs.adventure.text.serializer.legacy) {
-        excludeAdventure()
-    }
+    shadowAndPublish(libs.adventure.text.serializer.legacy) { excludeAdventure() }
     compileOnly(libs.gson)
 
     testImplementation(libs.bundles.adventure)
@@ -85,15 +87,6 @@ tasks {
 
     test {
         useJUnitPlatform()
-    }
-
-    shadowJar {
-        exclude {
-            val path = it.path
-            path.startsWith("net/kyori") && !path.startsWith("net/kyori/adventure/text/serializer") && !path.startsWith(
-                "net/kyori/option"
-            )
-        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,9 @@ tasks {
     }
 
     register("printVersion") {
-        println(project.version)
+        doLast {
+            println(project.version)
+        }
     }
 
     defaultTasks("build")
@@ -43,6 +45,11 @@ allprojects {
         withType<Jar> {
             archiveBaseName = "${rootProject.name}-${project.name}"
             archiveVersion = rootProject.ext["versionNoHash"] as String
+        }
+        withType<AbstractArchiveTask> {
+            // make builds reproducible
+            isPreserveFileTimestamps = false
+            isReproducibleFileOrder = true
         }
     }
 }

--- a/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/packetevents.shadow-conventions.gradle.kts
@@ -6,95 +6,60 @@ plugins {
     com.gradleup.shadow
 }
 
-val compileShadowOnly: Configuration by configurations.creating {
-    configurations.compileOnly.get().extendsFrom(this)
+// configuration which is added to runtime classpath and shadowed in the published jar
+val shadowAndPublish: Configuration by configurations.creating {
+    configurations.implementation.get().extendsFrom(this)
 }
 
 tasks {
     shadowJar {
-        configurations.add(compileShadowOnly)
-
         destinationDirectory = rootProject.layout.buildDirectory.dir("libs")
-        archiveFileName = "packetevents-${project.name}-${rootProject.ext["versionNoHash"]}.jar"
         archiveClassifier = null
-
-        relocate("net.kyori.adventure.text.serializer", "io.github.retrooper.packetevents.adventure.serializer")
-        relocate("net.kyori.option", "io.github.retrooper.packetevents.adventure.option")
-        relocate("org.bstats", "io.github.retrooper.packetevents.bstats")
-
-        dependencies {
-            exclude(dependency("com.google.code.gson:gson:.*"))
-        }
-
-        mergeServiceFiles()
     }
 
-    create<ShadowJar>("shadowNoAdventure") {
-        group = rootProject.name
-        description = "Create a combined JAR of project and runtime dependencies without Adventure dependencies."
-        archiveFileName = "packetevents-${project.name}-no-adv-${rootProject.ext["versionNoHash"]}.jar"
-        archiveClassifier = null
+    register<ShadowJar>("shadowJarPublish") {
+        archiveClassifier = "publish"
 
-        val shadowJar = shadowJar.get()
-        val sourceSets = project.extensions.getByType<SourceSetContainer>()
+        // include own actual source set
+        from(project.tasks.named<Jar>("jar"))
+        // include dependencies which should be shadowed in published jar
+        configurations = listOf(shadowAndPublish)
+    }
 
-        manifest.inheritFrom(shadowJar.manifest)
+    val shadowNoAdventureTask = register<ShadowJar>("shadowNoAdventure") {
+        destinationDirectory = rootProject.layout.buildDirectory.dir("libs")
+        archiveClassifier = "no-adv"
 
-        from(sourceSets.main.get().output)
-        configurations = shadowJar.configurations
+        // include own actual source set
+        from(project.tasks.named<Jar>("jar"))
+        // include entire runtime classpath dependencies
+        configurations = listOf(project.configurations.runtimeClasspath.get())
 
-        relocate("net.kyori.adventure.text.serializer", "io.github.retrooper.packetevents.adventure.serializer")
-        relocate("net.kyori.option", "io.github.retrooper.packetevents.adventure.option")
-        relocate("org.bstats", "io.github.retrooper.packetevents.bstats")
-
+        // exclude all adventure dependencies
         dependencies {
             exclude(dependency("net.kyori:adventure-api:.*"))
             exclude(dependency("net.kyori:adventure-key:.*"))
             exclude(dependency("net.kyori:adventure-nbt:.*"))
             exclude(dependency("net.kyori:examination-api:.*"))
             exclude(dependency("net.kyori:examination-string:.*"))
-            exclude(dependency("com.google.code.gson:gson:.*"))
-            exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "module-info.class")
         }
+    }
 
+    withType<ShadowJar> {
+        // always relocate this; we sadly can't relocate adventure because it would
+        // break plugins which depend on packetevents
+        relocate("net.kyori.adventure.text.serializer", "io.github.retrooper.packetevents.adventure.serializer")
+        relocate("net.kyori.option", "io.github.retrooper.packetevents.adventure.option")
+        relocate("org.bstats", "io.github.retrooper.packetevents.bstats")
+
+        // always merge service files; this should be the default
         mergeServiceFiles()
     }
 
     assemble {
         dependsOn(shadowJar)
-    }
-
-    if (project.properties.contains("no-adv")) {
-        assemble {
-            dependsOn("shadowNoAdventure")
+        if (hasProperty("no-adv")) {
+            dependsOn(shadowNoAdventureTask)
         }
-    }
-}
-
-configurations.implementation.get().extendsFrom(configurations.shadow.get())
-
-// TODO properly publish correct shadow references instead of this mess
-gradle.taskGraph.whenReady {
-    if (gradle.startParameter.taskNames.any {
-            it.contains("publish") && !it.equals(
-                "publishMods",
-                ignoreCase = true
-            )
-        }) {
-        logger.info("Adding shadow configuration to shadowJar tasks in module ${project.name}.")
-        tasks.withType<ShadowJar> {
-            dependencies {
-                project.configurations.shadow.get().resolvedConfiguration.firstLevelModuleDependencies.forEach {
-                    exclude(it)
-                }
-            }
-        }
-    }
-}
-
-fun DependencyFilter.exclude(dependency: ResolvedDependency) {
-    exclude(dependency("${dependency.moduleGroup}:${dependency.moduleName}:.*"))
-    dependency.children.forEach {
-        exclude(it)
     }
 }

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -10,8 +10,9 @@ repositories {
 
 dependencies {
     compileOnly(libs.bungeecord)
-    shadow(libs.bundles.adventure)
-    compileShadowOnly(libs.bstats.bungeecord)
-    shadow(project(":api", "shadow"))
-    shadow(project(":netty-common"))
+    apiAndPublish(libs.bundles.adventure)
+
+    apiAndPublish(project(":api"))
+    apiAndPublish(project(":netty-common"))
+    shadowAndPublish(libs.bstats.bungeecord)
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -25,11 +25,11 @@ val loader_version: String by project
 
 dependencies {
     api(libs.bundles.adventure)
-    api(project(":api", "shadow"))
+    api(project(":api"))
     api(project(":netty-common"))
 
     include(libs.bundles.adventure)
-    include(project(":api", "shadow"))
+    include(project(":api"))
     include(project(":netty-common"))
 
     // To change the versions, see the gradle.properties file

--- a/netty-common/build.gradle.kts
+++ b/netty-common/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 
 dependencies {
     compileOnly(libs.netty)
-    shadow(project(":api", "shadow"))
+    apiAndPublish(project(":api"))
 }

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -13,10 +13,11 @@ repositories {
 
 dependencies {
     compileOnly(libs.netty)
-    shadow(libs.bundles.adventure)
-    compileShadowOnly(libs.bstats.bukkit)
-    shadow(project(":api", "shadow"))
-    shadow(project(":netty-common"))
+    apiAndPublish(libs.bundles.adventure)
+
+    apiAndPublish(project(":api"))
+    apiAndPublish(project(":netty-common"))
+    shadowAndPublish(libs.bstats.bukkit)
 
     compileOnly(libs.paper)
     compileOnly(libs.via.version)

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -38,12 +38,13 @@ sponge {
 
 dependencies {
     compileOnly(libs.netty)
-    shadow(libs.adventure.nbt) {
-        isTransitive = false
-    }
-    shadow(project(":api", "shadow"))
-    shadow(project(":netty-common"))
-    compileShadowOnly(libs.bstats.sponge)
+
+    // we just need adventure nbt...
+    apiAndPublish(libs.adventure.nbt) { isTransitive = false }
+
+    apiAndPublish(project(":api"))
+    apiAndPublish(project(":netty-common"))
+    shadowAndPublish(libs.bstats.sponge)
 
     compileOnly(libs.via.version)
 }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
     compileOnly(libs.netty)
     compileOnly(libs.velocity)
     annotationProcessor(libs.velocity)
-    shadow(project(":api", "shadow"))
-    shadow(project(":netty-common"))
-    compileShadowOnly(libs.bstats.velocity)
-    // Velocity already bundles with adventure
+
+    apiAndPublish(project(":api"))
+    apiAndPublish(project(":netty-common"))
+    shadowAndPublish(libs.bstats.velocity)
 }
 
 tasks {


### PR DESCRIPTION
Introduces two new configurations to allow for the existing publishing setup to function correctly:
* `apiAndPublish` is used for adding a dependency to the runtime classpath and publishing it to the maven metadata as a dependency
* `shadowAndPublish` is used for adding a dependency to the runtime classpath and shadowing it in the published jar

Prior to these changes, the `shadowJar` task would have been modified to exclude a few dependencies if executed gradle tasks contained the word "`publish`" (resulting in the v2.9.0 issue caused by the task name `publishMods`...)
This now introduces a separate ShadowJar-task which builds a jar for publishing, to separate building and publishing completely

(This also fixes the fabric platform jar containing the api twice)