### PR TITLE
ViaNBT, SpongeGradle, MockBukkit and shadow update

### DIFF
--- a/api/src/test/java/com/github/retrooper/packetevents/test/base/BaseDummyAPITest.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/base/BaseDummyAPITest.java
@@ -1,11 +1,11 @@
 package com.github.retrooper.packetevents.test.base;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.MockPlugin;
-import be.seeseemelk.mockbukkit.ServerMock;
 import com.github.retrooper.packetevents.PacketEvents;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
 import org.slf4j.Logger;
 
 public abstract class BaseDummyAPITest {
@@ -13,7 +13,7 @@ public abstract class BaseDummyAPITest {
     public static final Logger LOGGER = TestPacketEventsBuilder.LOGGER;
 
     private ServerMock server;
-    private MockPlugin plugin;
+    private PluginMock plugin;
 
     @BeforeEach
     public void setup() {

--- a/buildSrc/libs.versions.toml
+++ b/buildSrc/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-shadow = "8.3.3"
+shadow = "8.3.8"
 jetbrains-annotations = "23.0.0"
 via-nbt = "5.1.2"
 fast-util = "8.5.6"

--- a/buildSrc/libs.versions.toml
+++ b/buildSrc/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 shadow = "8.3.3"
 jetbrains-annotations = "23.0.0"
-via-nbt = "4.1.0"
+via-nbt = "5.1.2"
 fast-util = "8.5.6"
 gson = "2.8.9"
 java-diff-utils = "4.12"

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/CompressionUtil.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/CompressionUtil.kt
@@ -17,9 +17,9 @@
  */
 package com.github.retrooper.compression
 
-import com.github.steveice10.opennbt.tag.builtin.Tag
-import com.github.steveice10.opennbt.tag.io.NBTIO
-import com.github.steveice10.opennbt.tag.io.TagWriter
+import com.viaversion.nbt.tag.Tag
+import com.viaversion.nbt.io.NBTIO
+import com.viaversion.nbt.io.TagWriter
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonArrayCompressionStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonArrayCompressionStrategy.kt
@@ -23,12 +23,12 @@ import com.github.difflib.patch.ChangeDelta
 import com.github.difflib.patch.DeleteDelta
 import com.github.difflib.patch.InsertDelta
 import com.github.retrooper.compression.asStringList
-import com.github.steveice10.opennbt.tag.builtin.ByteTag
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag
-import com.github.steveice10.opennbt.tag.builtin.IntTag
-import com.github.steveice10.opennbt.tag.builtin.ListTag
-import com.github.steveice10.opennbt.tag.builtin.StringTag
-import com.github.steveice10.opennbt.tag.builtin.Tag
+import com.viaversion.nbt.tag.ByteTag
+import com.viaversion.nbt.tag.CompoundTag
+import com.viaversion.nbt.tag.IntTag
+import com.viaversion.nbt.tag.ListTag
+import com.viaversion.nbt.tag.StringTag
+import com.viaversion.nbt.tag.Tag
 import com.google.gson.JsonElement
 
 object JsonArrayCompressionStrategy : JsonCompressionStrategy() {

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonBase64DataStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonBase64DataStrategy.kt
@@ -18,10 +18,10 @@
 
 package com.github.retrooper.compression.strategy.json
 
-import com.github.steveice10.opennbt.tag.builtin.ByteArrayTag
-import com.github.steveice10.opennbt.tag.builtin.ByteTag
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag
-import com.github.steveice10.opennbt.tag.builtin.Tag
+import com.viaversion.nbt.tag.ByteArrayTag
+import com.viaversion.nbt.tag.ByteTag
+import com.viaversion.nbt.tag.CompoundTag
+import com.viaversion.nbt.tag.Tag
 import com.google.gson.JsonElement
 import java.util.*
 

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonCompressionStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonCompressionStrategy.kt
@@ -20,9 +20,9 @@ package com.github.retrooper.compression.strategy.json
 import com.github.retrooper.compression.CompressionUtil
 import com.github.retrooper.compression.EntryVersion
 import com.github.retrooper.compression.strategy.CompressionStrategy
-import com.github.steveice10.opennbt.tag.builtin.ByteTag
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag
-import com.github.steveice10.opennbt.tag.builtin.Tag
+import com.viaversion.nbt.tag.ByteTag
+import com.viaversion.nbt.tag.CompoundTag
+import com.viaversion.nbt.tag.Tag
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import java.nio.file.Path

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonObjectCompressionStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonObjectCompressionStrategy.kt
@@ -23,7 +23,7 @@ import com.github.difflib.patch.ChangeDelta
 import com.github.difflib.patch.DeleteDelta
 import com.github.difflib.patch.InsertDelta
 import com.github.retrooper.compression.asPrimitiveMap
-import com.github.steveice10.opennbt.tag.builtin.*
+import com.viaversion.nbt.tag.*
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
 

--- a/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonToNbtStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/github/retrooper/compression/strategy/json/JsonToNbtStrategy.kt
@@ -17,7 +17,7 @@
  */
 package com.github.retrooper.compression.strategy.json
 
-import com.github.steveice10.opennbt.tag.builtin.*
+import com.viaversion.nbt.tag.*
 import com.google.gson.JsonElement
 import com.google.gson.internal.LazilyParsedNumber
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,7 @@ bungeecord = "1.21-R0.1-SNAPSHOT"
 velocity = "3.4.0-SNAPSHOT"
 run-paper = "2.3.1"
 fabric-loom = "1.11.4"
-spongeGradle = "2.2.0"
+spongeGradle = "2.3.0"
 classgraph = "4.8.179"
 
 [libraries]

--- a/testlibs.versions.toml
+++ b/testlibs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-mockbukkit = "3.131.0"
+mockbukkit = "4.72.2"
 slf4j = "2.0.16"
 junit = "5.11.2"
 
 [libraries]
-mockbukkit = { group = "com.github.seeseemelk", name = "MockBukkit-v1.21", version.ref = "mockbukkit" }
+mockbukkit = { group = "org.mockbukkit.mockbukkit", name = "mockbukkit-v1.21", version.ref = "mockbukkit" }
 slf4j = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }


### PR DESCRIPTION
I updated ViaNBT (they relocated the path in 5.0), SpongeGradle, MockBukkit (also relocation, and renamed few classes)
it's probably one of last updates in shadow 8.x release cycle and it should be updated to 9.0 once it's released as stated [here](https://github.com/GradleUp/shadow/releases/tag/9.0.0-rc1)
Tests run successfully and packetevents compiled successfully