### PR TITLE
Fix NPE in SpigotChannelInjector#isPlayerSet

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/SpigotChannelInjector.java
@@ -58,10 +58,10 @@ public class SpigotChannelInjector implements ChannelInjector {
     public boolean isPlayerSet(Object channel) {
         if (channel == null) return false;
         PacketEventsEncoder encoder = getEncoder((Channel) channel);
-        if (encoder.player != null) return true;
+        if (encoder != null && encoder.player != null) return true;
 
         PacketEventsDecoder decoder = getDecoder((Channel) channel);
-        return decoder.player != null;
+        return decoder != null && decoder.player != null;
     }
 
     @Override


### PR DESCRIPTION
Prevent SpigotChannelInjector#isPlayerSet from throwing NPE when encoder/decoder isn't present