### PR TITLE
Allow PacketEvents to override sign text limit per player

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
@@ -23,14 +23,32 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This message is sent from the client to the server when the "Done" button is pushed after placing a sign.
  */
 public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClientUpdateSign> {
+    private static final int DEFAULT_MAX_LENGTH = 384;
+    private static final Map<UUID, Integer> PLAYER_LIMITS = new ConcurrentHashMap<>();
+
     private Vector3i blockPosition;
     private String[] textLines;
     private boolean isFrontText;
+
+    public static void setPlayerMaxLength(UUID uuid, int length) {
+        PLAYER_LIMITS.put(uuid, length);
+    }
+
+    public static void removePlayerMaxLength(UUID uuid) {
+        PLAYER_LIMITS.remove(uuid);
+    }
+
+    private static int getPlayerMaxLength(UUID uuid) {
+        return PLAYER_LIMITS.getOrDefault(uuid, DEFAULT_MAX_LENGTH);
+    }
 
     public WrapperPlayClientUpdateSign(PacketReceiveEvent event) {
         super(event);
@@ -58,9 +76,13 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
         } else {
             isFrontText = true;
         }
+        int max = DEFAULT_MAX_LENGTH;
+        if (this.user != null) {
+            max = getPlayerMaxLength(this.user.getUUID());
+        }
         textLines = new String[4];
         for (int i = 0; i < 4; i++) {
-            this.textLines[i] = readString(384);
+            this.textLines[i] = readString(max);
         }
     }
 


### PR DESCRIPTION
This PR lets PacketEvents override the default sign text limit per player. Minecraft normally caps sign lines at 384 characters, but right now that limit is hardcoded. With this change, other plugins can set custom limits for each player as needed.

It's a straightforward change and doesn't affect anything unless explicitly used by another plugin. The implementation is thread-safe and efficient.

This is not really necessary to me anymore, if it doesn't fit in with PacketEvents it can be removed.