### PR TITLE
Fix components for 1.9-1.11.2 versions

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureSerializer.java
@@ -230,6 +230,7 @@ public final class AdventureSerializer implements NbtEncoder<Component>, NbtDeco
                                 .values(JSONOptions.byDataVersion().at(0))
                                 .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.BOTH)
                                 .value(JSONOptions.SHOW_ITEM_HOVER_DATA_MODE, JSONOptions.ShowItemHoverDataMode.EMIT_EITHER)
+                                // Ensure compatibility with versions 1.9 to 1.11.2
                                 .value(JSONOptions.EMIT_COMPACT_TEXT_COMPONENT, false);
                         if (this.version.isNewerThanOrEquals(ClientVersion.V_1_16)
                                 && !PacketEvents.getAPI().getSettings().shouldDownsampleColors()) {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureSerializer.java
@@ -229,7 +229,8 @@ public final class AdventureSerializer implements NbtEncoder<Component>, NbtDeco
                         builder
                                 .values(JSONOptions.byDataVersion().at(0))
                                 .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.BOTH)
-                                .value(JSONOptions.SHOW_ITEM_HOVER_DATA_MODE, JSONOptions.ShowItemHoverDataMode.EMIT_EITHER);
+                                .value(JSONOptions.SHOW_ITEM_HOVER_DATA_MODE, JSONOptions.ShowItemHoverDataMode.EMIT_EITHER)
+                                .value(JSONOptions.EMIT_COMPACT_TEXT_COMPONENT, false);
                         if (this.version.isNewerThanOrEquals(ClientVersion.V_1_16)
                                 && !PacketEvents.getAPI().getSettings().shouldDownsampleColors()) {
                             builder.value(JSONOptions.EMIT_RGB, true);

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -103,7 +103,6 @@ import com.github.retrooper.packetevents.util.mappings.GlobalRegistryHolder;
 import com.github.retrooper.packetevents.util.mappings.IRegistry;
 import com.github.retrooper.packetevents.util.mappings.IRegistryHolder;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.ApiStatus.Experimental;
@@ -626,10 +625,6 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
     }
 
     public void writeComponentAsJSON(Component component) {
-        // Plain component fix for 1.9-1.11.2 clients
-        if (clientVersion.isOlderThan(ClientVersion.V_1_12) && clientVersion.isNewerThanOrEquals(ClientVersion.V_1_9)) {
-            component = component.colorIfAbsent(NamedTextColor.WHITE);
-        }
         String jsonString = this.getSerializers().asJson(component);
         this.writeString(jsonString, this.getMaxMessageLength());
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -103,6 +103,7 @@ import com.github.retrooper.packetevents.util.mappings.GlobalRegistryHolder;
 import com.github.retrooper.packetevents.util.mappings.IRegistry;
 import com.github.retrooper.packetevents.util.mappings.IRegistryHolder;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.ApiStatus.Experimental;
@@ -625,6 +626,10 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
     }
 
     public void writeComponentAsJSON(Component component) {
+        // Plain component fix for 1.9-1.11.2 clients
+        if (clientVersion.isOlderThan(ClientVersion.V_1_12) && clientVersion.isNewerThanOrEquals(ClientVersion.V_1_9)) {
+            component = component.colorIfAbsent(NamedTextColor.WHITE);
+        }
         String jsonString = this.getSerializers().asJson(component);
         this.writeString(jsonString, this.getMaxMessageLength());
     }


### PR DESCRIPTION
This PR fixes an issue where components are encoded in a format not supported by these versions.

In these versions, the client disconnects when receiving a plain text component (i.e., a JSON containing only a string without a `text` key, style, or color), resulting in the following error:

<img width="803" height="214" alt="image" src="https://github.com/user-attachments/assets/30d17d03-95ad-4559-904f-1c7f5756a93b" />

**Background:**
Kyori Components generate a simplified JSON for plain text components. For example, instead of giving `{"text": "§csome text" }`, they return just `"§csome text"`, as the Minecraft client is expected to support this format.

Adding a default color to the components forces them to be encoded in the standard format, which is the approach used here.

Starting with version 1.9, Minecraft switched from using `Gson#fromJson()` to `JsonReader` to better handle lenient JSON strings. However, at that time, a bug in the Gson library caused Lenient exceptions when parsing plain JSON strings as shown above.

This issue was fixed in version 1.12 by upgrading to Gson 2.8.0, which resolves the problem.
