### PR TITLE
Always try to fetch netty version

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
@@ -35,7 +35,13 @@ public class ServerChannelHandler extends ChannelInboundHandlerAdapter {
 
     private static PEVersion resolveNettyVersion() {
         Map<String, Version> nettyArtifacts = Version.identify();
+
         Version version = nettyArtifacts.getOrDefault("netty-common", nettyArtifacts.get("netty-all"));
+
+        if (version == null && !nettyArtifacts.values().isEmpty()) {
+            version = nettyArtifacts.values().iterator().next();
+        }
+
         if (version != null) {
             String stringVersion = version.artifactVersion();
 


### PR DESCRIPTION
If netty-common or netty-all is not present it will fallback by fetching any possible netty lib version