### PR TITLE
Refactor properties and equipment processing to dedicated method

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityEquipment.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerEntityEquipment.java
@@ -50,6 +50,12 @@ public class WrapperPlayServerEntityEquipment extends PacketWrapper<WrapperPlayS
         } else {
             entityId = readVarInt();
         }
+        readEquipment();
+    }
+
+    // allow this to be overridden by a subclass
+    // this could be used to save performance if you don't need to read the equipment
+    protected void readEquipment() {
         equipment = new ArrayList<>();
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_16)) {
             byte value;

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerUpdateAttributes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerUpdateAttributes.java
@@ -88,7 +88,10 @@ public class WrapperPlayServerUpdateAttributes extends PacketWrapper<WrapperPlay
         } else {
             entityID = readVarInt();
         }
+        readProperties();
+    }
 
+    protected void readProperties() {
         int propertyCount;
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_17)) {
             propertyCount = readVarInt();


### PR DESCRIPTION
Refactor equipment reading into a dedicated method, invoked only when needed. This allows subclasses to override the implementation or skip reading altogether, improving customization and optionally enabling better performance in specific use cases.