### PR TITLE
fix: remove duplicate setter for userProfile | WrapperPlayServerPlayerInfo

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerPlayerInfo.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerPlayerInfo.java
@@ -250,6 +250,7 @@ public class WrapperPlayServerPlayerInfo extends PacketWrapper<WrapperPlayServer
             this(displayName, userProfile, gameMode, null, ping);
         }
 
+        @Nullable
         public UserProfile getUserProfile() {
             return userProfile;
         }
@@ -264,15 +265,6 @@ public class WrapperPlayServerPlayerInfo extends PacketWrapper<WrapperPlayServer
 
         public void setSignatureData(SignatureData signatureData) {
             this.signatureData = signatureData;
-        }
-
-        @Nullable
-        public UserProfile getUser() {
-            return userProfile;
-        }
-
-        public void setUser(@Nullable UserProfile userProfile) {
-            this.userProfile = userProfile;
         }
 
         @Nullable


### PR DESCRIPTION
Edit `WrapperPlayServerPlayerInfo`, remove duplicated setter for `userProfile` in `PlayerData`