### PR TITLE
Fix CLICK_WINDOW wrapper write length

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -435,16 +435,6 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
         return map;
     }
 
-    public <K, V> void writeOptionalMap(Map<K, Optional<V>> map, Writer<K> keyConsumer, Writer<V> valueConsumer) {
-        writeVarInt(map.size());
-        for (Map.Entry<K, Optional<V>> entry : map.entrySet()) {
-            K key = entry.getKey();
-            Optional<V> value = entry.getValue();
-            keyConsumer.accept(this, key);
-            value.ifPresent(v -> valueConsumer.accept(this, v));
-        }
-    }
-
     public <K, V> void writeMap(Map<K, V> map, Writer<K> keyConsumer, Writer<V> valueConsumer) {
         writeVarInt(map.size());
         for (Map.Entry<K, V> entry : map.entrySet()) {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClickWindow.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientClickWindow.java
@@ -162,8 +162,8 @@ public class WrapperPlayClientClickWindow extends PacketWrapper<WrapperPlayClien
         }
         this.writeVarInt(this.windowClickType.ordinal());
         if (this.serverVersion.isNewerThanOrEquals(ServerVersion.V_1_21_5)) {
-            this.writeOptionalMap(this.hashedSlots != null ? this.hashedSlots : Collections.emptyMap(),
-                    PacketWrapper::writeShort, HashedStack::write);
+            this.writeMap(this.hashedSlots != null ? this.hashedSlots : Collections.emptyMap(),
+                    PacketWrapper::writeShort, HashedStack::writeOptional);
             HashedStack.write(this, this.carriedHashedStack);
         } else {
             if (v1_17) {


### PR DESCRIPTION
The previous `PacketWrapper#writeOptionalMap()` incorrectly did not write a boolean to indicate the presence of the `HashedStack`. This PR fixes this by using the normal `PacketWrapper#writeMap()` and using `HashedStack#writeOptional()` instead, which correctly writes false if the optional is empty.