### PR TITLE
Add constructor with data array to ListPalette

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
@@ -27,6 +27,8 @@ package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
+import java.util.Arrays;
+
 /**
  * A palette backed by a List.
  */
@@ -66,11 +68,13 @@ public class ListPalette implements Palette {
 
     public ListPalette(int bitsPerEntry, int[] data) {
         this.bits = bitsPerEntry;
-        this.data = data;
-        this.nextId = data.length;
-        if (this.nextId > (1 << this.bits)) {
+        final int expectedSize = (1 << this.bits);
+        if (data.length > expectedSize) {
             throw new IllegalArgumentException("Data length exceeds the max size the bits can hold");
+        } else {
+            this.data = Arrays.copyOf(data, expectedSize);
         }
+        this.nextId = data.length;
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
@@ -35,11 +35,12 @@ public class ListPalette implements Palette {
 
     private final int bits;
     private final int[] data;
-    private int nextId = 0;
+    private int nextId;
 
     public ListPalette(int bitsPerEntry) {
         this.bits = bitsPerEntry;
         this.data = new int[1 << bitsPerEntry];
+        this.nextId = 0;
     }
 
     @Deprecated
@@ -61,6 +62,12 @@ public class ListPalette implements Palette {
             this.data[i] = wrapper.readVarInt();
         }
         this.nextId = paletteLength;
+    }
+
+    public ListPalette(int bitsPerEntry, int[] data) {
+        this.bits = bitsPerEntry;
+        this.data = data;
+        this.nextId = data.length;
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/ListPalette.java
@@ -68,6 +68,9 @@ public class ListPalette implements Palette {
         this.bits = bitsPerEntry;
         this.data = data;
         this.nextId = data.length;
+        if (this.nextId > (1 << this.bits)) {
+            throw new IllegalArgumentException("Data length exceeds the max size the bits can hold");
+        }
     }
 
     @Override


### PR DESCRIPTION
No longer needs [clumpy way](https://github.com/Rothes/ESU/blob/17c8960d06a7fac2858a0c85ec7fce15a66e2f2e/bukkit/version/v1_18/src/main/kotlin/io/github/rothes/esu/bukkit/module/networkthrottle/chunkdatathrottle/v1_18/ChunkDataThrottleHandlerImpl.kt#L866) to do it