### PR TITLE
Check if Velocity anti-bots closed the channel before initializing

### DIFF
--- a/velocity/src/main/java/io/github/retrooper/packetevents/injector/VelocityChannelInitializer.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/injector/VelocityChannelInitializer.java
@@ -36,6 +36,9 @@ public class VelocityChannelInitializer extends ChannelInitializer<Channel> {
 
     @Override
     protected void initChannel(@NotNull Channel channel) throws Exception {
+        if (!channel.isActive()) {
+            return;
+        }
         if (INIT_CHANNEL == null) {
             INIT_CHANNEL = ChannelInitializer.class.getDeclaredMethod("initChannel", Channel.class);
             INIT_CHANNEL.setAccessible(true);


### PR DESCRIPTION
This fixes compatibility with [VeloFlame](https://veloflame.com/) and any other anti-bots or forks running before packet events.