### PR TITLE
Validate Sponge Adventure version & fix logging

### DIFF
--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/factory/SpongePacketEventsBuilder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/factory/SpongePacketEventsBuilder.java
@@ -73,14 +73,14 @@ public class SpongePacketEventsBuilder {
     }
 
     public static PacketEventsAPI<PluginContainer> buildNoCache(PluginContainer plugin, PacketEventsSettings inSettings) {
-        return new PacketEventsAPI<PluginContainer>() {
+        return new PacketEventsAPI<>() {
             private final PacketEventsSettings settings = inSettings;
             private final ProtocolManager protocolManager = new ProtocolManagerImpl();
             private final ServerManager serverManager = new ServerManagerImpl();
             private final PlayerManager playerManager = new PlayerManagerImpl();
             private final NettyManager nettyManager = new NettyManagerImpl();
             private final SpongeChannelInjector injector = new SpongeChannelInjector();
-            private final LogManager logManager = new SpongeLogManager();
+            private final LogManager logManager = new SpongeLogManager(plugin);
             private boolean loaded;
             private boolean initialized;
             private boolean terminated;


### PR DESCRIPTION
I keep having issues where the adventure version between Sponge and PacketEvents is mismatched since we aren't meant to shade on Sponge.

This adds automatic detection of the Adventure version Sponge and PacketEvents is using and outputs a useful log message if they aren't the same.
<img width="1124" height="106" alt="image" src="https://github.com/user-attachments/assets/4668453d-ed32-4086-81bf-d382cc590e57" />

I also fixed logging by using the actual plugin's logger, not trying to use systemSubject (colours using that just don't work). It now basically matches what the Fabric one does.