### PR TITLE
fix: thread save packet type init

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
@@ -364,7 +364,8 @@ import java.util.Map;
 
 public final class PacketType {
 
-    private static boolean PREPARED = false;
+    private static volatile boolean PREPARED = false;
+    private static final Object PREPARE_LOCK = new Object();
 
     //TODO UPDATE Update packet type mappings (clientbound pt. 1)
     private static final VersionMapper CLIENTBOUND_PLAY_VERSION_MAPPER = new VersionMapper(
@@ -438,11 +439,22 @@ public final class PacketType {
             ClientVersion.V_1_21_9);
 
     public static void prepare() {
-        PacketType.Play.Client.load();
-        PacketType.Play.Server.load();
-        PacketType.Configuration.Client.load();
-        PacketType.Configuration.Server.load();
-        PREPARED = true;
+        if (PREPARED) {
+            return;
+        }
+
+        synchronized (PREPARE_LOCK) {
+            if (PREPARED) {
+                return;
+            }
+
+            PacketType.Play.Client.load();
+            PacketType.Play.Server.load();
+            PacketType.Configuration.Client.load();
+            PacketType.Configuration.Server.load();
+
+            PREPARED = true;
+        }
     }
 
     public static boolean isPrepared() {
@@ -842,9 +854,8 @@ public final class PacketType {
             }
 
             public static @Nullable PacketTypeCommon getById(ClientVersion version, int packetId) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = SERVERBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
                 Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
                 return map.get(packetId);
@@ -857,9 +868,8 @@ public final class PacketType {
 
             @Override
             public int getId(ClientVersion version) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = SERVERBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
                 return this.ids[index];
             }
@@ -976,9 +986,8 @@ public final class PacketType {
             }
 
             public static @Nullable PacketTypeCommon getById(ClientVersion version, int packetId) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = CLIENTBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
                 Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
                 return map.get(packetId);
@@ -991,9 +1000,8 @@ public final class PacketType {
 
             @Override
             public int getId(ClientVersion version) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = CLIENTBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
                 return this.ids[index];
             }
@@ -1186,9 +1194,8 @@ public final class PacketType {
 
             @Nullable
             public static PacketTypeCommon getById(ClientVersion version, int packetId) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = SERVERBOUND_PLAY_VERSION_MAPPER.getIndex(version);
                 Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index, k -> new HashMap<>());
                 return packetIdMap.get(packetId);
@@ -1236,9 +1243,8 @@ public final class PacketType {
             }
 
             public int getId(ClientVersion version) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = SERVERBOUND_PLAY_VERSION_MAPPER.getIndex(version);
                 return ids[index];
             }
@@ -1588,18 +1594,16 @@ public final class PacketType {
             }
 
             public int getId(ClientVersion version) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
                 return ids[index];
             }
 
             @Nullable
             public static PacketTypeCommon getById(ClientVersion version, int packetId) {
-                if (!PREPARED) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
+
                 int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
                 Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
                 return map.get(packetId);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
@@ -438,6 +438,10 @@ public final class PacketType {
             ClientVersion.V_1_21_6,
             ClientVersion.V_1_21_9);
 
+    private PacketType() {
+    }
+
+    @ApiStatus.Internal
     public static void prepare() {
         if (PREPARED) {
             return;
@@ -457,6 +461,7 @@ public final class PacketType {
         }
     }
 
+    @ApiStatus.Internal
     public static boolean isPrepared() {
         return PREPARED;
     }

--- a/api/src/test/java/com/github/retrooper/packetevents/test/base/TestPacketEventsBuilder.java
+++ b/api/src/test/java/com/github/retrooper/packetevents/test/base/TestPacketEventsBuilder.java
@@ -97,9 +97,7 @@ public class TestPacketEventsBuilder {
                     PacketEvents.SERVER_CHANNEL_HANDLER_NAME = "pe-connection-initializer-" + id;
                     PacketEvents.TIMEOUT_HANDLER_NAME = "pe-timeout-handler-" + id;
 
-                    if (!PacketType.isPrepared()) {
-                        PacketType.prepare();
-                    }
+                    PacketType.prepare();
 
                     loaded = true;
                 }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/factory/spigot/SpigotPacketEventsBuilder.java
@@ -114,9 +114,7 @@ public class SpigotPacketEventsBuilder {
                         throw new IllegalStateException(ex);
                     }
 
-                    if (!PacketType.isPrepared()) {
-                        PacketType.prepare();
-                    }
+                    PacketType.prepare();
 
                     //Server hasn't bound to the port yet.
                     lateBind = !injector.isServerBound();

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/factory/SpongePacketEventsBuilder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/factory/SpongePacketEventsBuilder.java
@@ -106,9 +106,7 @@ public class SpongePacketEventsBuilder {
                     throw new IllegalStateException(ex);
                 }
 
-                if (!PacketType.isPrepared()) {
-                    PacketType.prepare();
-                }
+                PacketType.prepare();
 
                 // Server hasn't bound to the port yet.
                 lateBind = !injector.isServerBound();


### PR DESCRIPTION
This pull request addresses a concurrency issue in [PacketType::prepare](https://github.com/retrooper/packetevents/blob/2.0/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java#L440) that can result in a disconnect for players. Under heavy parallel load, prepare may be invoked concurrently, but the method is not thread safe. This can lead to to the following exception:

```
java.lang.ArrayIndexOutOfBoundsException: Index 24 out of bounds for length 23
    at com.github.retrooper.packetevents.protocol.packettype.PacketType$Play$Client.loadPacketIds(PacketType.java:1202)
    at com.github.retrooper.packetevents.protocol.packettype.PacketType$Play$Client.load(PacketType.java:1224)
    at com.github.retrooper.packetevents.protocol.packettype.PacketType.prepare(PacketType.java:441)
    ...
```

This failure was observed when integrating PacketEvents with GrimAC, where multiple players joining at the exact same moment triggered concurrent calls to prepare before packet types were fully initialized.

To resolve this, the PR introduces a simple exclusive lock around the prepare method. The lock ensures that any concurrent calls wait until packet IDs are fully loaded, preventing data races and guaranteeing consistent initialization.