### PR TITLE
fix: correct default buffer size to match comment

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/NBTLimiter.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/NBTLimiter.java
@@ -25,7 +25,7 @@ import org.jspecify.annotations.NullMarked;
 @ApiStatus.NonExtendable
 public interface NBTLimiter {
 
-    int DEFAULT_MAX_SIZE = Integer.getInteger("packetevents.nbt.default-max-size", 1 << 20); // 2MiB
+    int DEFAULT_MAX_SIZE = Integer.getInteger("packetevents.nbt.default-max-size", 2 << 20); // 2MiB
     int DEFAULT_MAX_DEPTH = Integer.getInteger("packetevents.nbt.default-max-depth", 512);
 
     static NBTLimiter noop() {


### PR DESCRIPTION
The code previously used 1 << 20 bytes (1MiB) for DEFAULT_MAX_SIZE, but the comment stated 2MiB. This updates the value to 2 << 20 bytes to match the comment and intended behavior.