### PR TITLE
Implement a custom Int2Int map for MapPalette

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
@@ -1,6 +1,7 @@
 package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Arrays;
 
@@ -11,20 +12,21 @@ import java.util.Arrays;
  * <p>
  * Greatly inspired by <a href="https://github.com/aeron-io/agrona/blob/5512dda83e1b1a8dc38a6286e440237b1a7e480c/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java">Int2IntHashMap.java</a>, licensed under the terms of the Apache License 2.0.
  */
+@NullMarked
 @ApiStatus.Internal
-class Int2IntHashMap {
+final class Int2IntHashMap {
 
     private static final float LOAD_FACTOR = 0.75f;
     public static final int EMPTY_VALUE = -1;
 
-    private int[] data;
+    private long[] data;
     private int size;
     private int threshold;
 
     public Int2IntHashMap(int expectedSize) {
         int capacity = tableSizeFor(expectedSize);
         this.threshold = (int) (capacity * LOAD_FACTOR);
-        this.data = new int[capacity * 2];
+        this.data = new long[capacity];
         Arrays.fill(this.data, EMPTY_VALUE);
     }
 
@@ -34,69 +36,82 @@ class Int2IntHashMap {
     }
 
     public int get(int key) {
-        int capacity = data.length >> 1;
-        int mask = capacity - 1;
-        int index = hash(key) & mask;
-        while (data[index * 2] != EMPTY_VALUE) {
-            if (data[index * 2] == key) {
-                return data[index * 2 + 1];
+        int mask = this.data.length - 1;
+        int index = this.hash(key) & mask;
+        long entry;
+        while ((entry = this.data[index]) != EMPTY_VALUE) {
+            if ((int) (entry & 0xFFFFFFFFL) == key) {
+                return (int) (entry >>> 32);
             }
+            // collision, advance
             index = (index + 1) & mask;
         }
         return EMPTY_VALUE;
     }
 
     public void put(int key, int value) {
-        if (size >= threshold) {
-            resize((data.length >> 1) * 2);
+        if (this.size >= this.threshold) {
+            this.resize(this.data.length << 1);
         }
-        int capacity = data.length >> 1;
-        int mask = capacity - 1;
-        int index = hash(key) & mask;
-        while (data[index * 2] != EMPTY_VALUE) {
-            if (data[index * 2] == key) {
-                data[index * 2 + 1] = value;
+        long[] data = this.data;
+        int mask = data.length - 1;
+        int index = this.hash(key) & mask;
+        long entry;
+        while ((entry = data[index]) != EMPTY_VALUE) {
+            if ((int) (entry & 0xFFFFFFFFL) == key) {
+                // replace existing entry
+                data[index] = (entry & 0xFFFFFFFFL) | ((value & 0xFFFFFFFFL) << 32);
                 return;
             }
+            // collision, advance
             index = (index + 1) & mask;
         }
-        data[index * 2] = key;
-        data[index * 2 + 1] = value;
-        size++;
+        // insert new entry at empty index
+        data[index] = (key & 0xFFFFFFFFL) | ((value & 0xFFFFFFFFL) << 32);
+        this.size++;
     }
 
     public void putIfAbsent(int key, int value) {
-        if (size >= threshold) {
-            resize((data.length >> 1) * 2);
+        if (this.size >= this.threshold) {
+            this.resize(this.data.length << 1);
         }
-        int capacity = data.length >> 1;
-        int mask = capacity - 1;
-        int index = hash(key) & mask;
-        while (data[index * 2] != EMPTY_VALUE) {
-            if (data[index * 2] == key) {
-                return;
+        long[] data = this.data;
+        int mask = data.length - 1;
+        int index = this.hash(key) & mask;
+        long entry;
+        while ((entry = data[index]) != EMPTY_VALUE) {
+            if ((int) (entry & 0xFFFFFFFFL) == key) {
+                return; // already present, don't insert
             }
+            // collision, advance
             index = (index + 1) & mask;
         }
-        data[index * 2] = key;
-        data[index * 2 + 1] = value;
-        size++;
+        // insert new entry at empty index
+        data[index] = (key & 0xFFFFFFFFL) | ((value & 0xFFFFFFFFL) << 32);
+        this.size++;
     }
 
     private void resize(int newCapacity) {
-        int[] oldData = data;
-        int oldCapacity = oldData.length >> 1;
+        long[] oldData = this.data;
 
-        threshold = (int) (newCapacity * LOAD_FACTOR);
-        data = new int[newCapacity * 2];
+        // construct new table
+        this.threshold = (int) (newCapacity * LOAD_FACTOR);
+        long[] data = new long[newCapacity];
         Arrays.fill(data, EMPTY_VALUE);
-        size = 0;
+        this.data = data;
 
-        for (int i = 0; i < oldCapacity; i++) {
-            int key = oldData[i * 2];
-            if (key != EMPTY_VALUE) {
-                put(key, oldData[i * 2 + 1]);
+        // put old table back into new table
+        int mask = newCapacity - 1;
+        for (int i = 0, len = oldData.length; i < len; i++) {
+            long entry = oldData[i];
+            int key = (int) (entry & 0xFFFFFFFFL);
+            int index = this.hash(key) & mask;
+            // we can skip checking for matches against this same key as
+            // this is a fresh table being built and there should be no replacements, only collisions
+            while (data[index] != EMPTY_VALUE) {
+                index = (index + 1) & mask;
             }
+            data[index] = entry;
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
@@ -5,24 +5,25 @@ import org.jetbrains.annotations.ApiStatus;
 import java.util.Arrays;
 
 /**
- * A simple open-addressing hash map optimized for int keys and values.
- * It uses linear probing and supports a default return value of -1.
+ * A simple open-addressing hash map optimized for int keys and values.</br>
+ * It uses linear probing and supports a default return value of {@link #EMPTY_VALUE}.<br/>
  * Only to be used with non-negative keys and values.
  */
 @ApiStatus.Internal
-class Int2IntOpenHashMap {
+class Int2IntHashMap {
 
     private static final float LOAD_FACTOR = 0.75f;
+    public static final int EMPTY_VALUE = -1;
 
     private int[] data;
     private int size;
     private int threshold;
 
-    public Int2IntOpenHashMap(int expectedSize) {
+    public Int2IntHashMap(int expectedSize) {
         int capacity = tableSizeFor(expectedSize);
         this.threshold = (int) (capacity * LOAD_FACTOR);
         this.data = new int[capacity * 2];
-        Arrays.fill(this.data, -1);
+        Arrays.fill(this.data, EMPTY_VALUE);
     }
 
     private static int tableSizeFor(int cap) {
@@ -34,13 +35,13 @@ class Int2IntOpenHashMap {
         int capacity = data.length >> 1;
         int mask = capacity - 1;
         int index = hash(key) & mask;
-        while (data[index * 2] != -1) {
+        while (data[index * 2] != EMPTY_VALUE) {
             if (data[index * 2] == key) {
                 return data[index * 2 + 1];
             }
             index = (index + 1) & mask;
         }
-        return -1;
+        return EMPTY_VALUE;
     }
 
     public void put(int key, int value) {
@@ -50,7 +51,7 @@ class Int2IntOpenHashMap {
         int capacity = data.length >> 1;
         int mask = capacity - 1;
         int index = hash(key) & mask;
-        while (data[index * 2] != -1) {
+        while (data[index * 2] != EMPTY_VALUE) {
             if (data[index * 2] == key) {
                 data[index * 2 + 1] = value;
                 return;
@@ -69,7 +70,7 @@ class Int2IntOpenHashMap {
         int capacity = data.length >> 1;
         int mask = capacity - 1;
         int index = hash(key) & mask;
-        while (data[index * 2] != -1) {
+        while (data[index * 2] != EMPTY_VALUE) {
             if (data[index * 2] == key) {
                 return;
             }
@@ -86,12 +87,12 @@ class Int2IntOpenHashMap {
 
         threshold = (int) (newCapacity * LOAD_FACTOR);
         data = new int[newCapacity * 2];
-        Arrays.fill(data, -1);
+        Arrays.fill(data, EMPTY_VALUE);
         size = 0;
 
         for (int i = 0; i < oldCapacity; i++) {
             int key = oldData[i * 2];
-            if (key != -1) {
+            if (key != EMPTY_VALUE) {
                 put(key, oldData[i * 2 + 1]);
             }
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
  * A simple open-addressing hash map optimized for int keys and values.</br>
  * It uses linear probing and supports a default return value of {@link #EMPTY_VALUE}.<br/>
  * Only to be used with non-negative keys and values.
+ * <p>
+ * Greatly inspired by <a href="https://github.com/aeron-io/agrona/blob/5512dda83e1b1a8dc38a6286e440237b1a7e480c/agrona/src/main/java/org/agrona/collections/Int2IntHashMap.java">Int2IntHashMap.java</a>, licensed under the terms of the Apache License 2.0.
  */
 @ApiStatus.Internal
 class Int2IntHashMap {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntHashMap.java
@@ -104,6 +104,9 @@ final class Int2IntHashMap {
         int mask = newCapacity - 1;
         for (int i = 0, len = oldData.length; i < len; i++) {
             long entry = oldData[i];
+            if (entry == EMPTY_VALUE) {
+                continue;
+            }
             int key = (int) (entry & 0xFFFFFFFFL);
             int index = this.hash(key) & mask;
             // we can skip checking for matches against this same key as

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntOpenHashMap.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/Int2IntOpenHashMap.java
@@ -1,0 +1,111 @@
+package com.github.retrooper.packetevents.protocol.world.chunk.palette;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Arrays;
+
+/**
+ * A simple open-addressing hash map optimized for int keys and values.
+ * It uses linear probing and supports a default return value of -1.
+ * Only to be used with non-negative keys and values.
+ */
+@ApiStatus.Internal
+class Int2IntOpenHashMap {
+
+    private static final float LOAD_FACTOR = 0.75f;
+
+    private int[] data;
+    private int size;
+    private int threshold;
+
+    public Int2IntOpenHashMap(int expectedSize) {
+        int capacity = tableSizeFor(expectedSize);
+        this.threshold = (int) (capacity * LOAD_FACTOR);
+        this.data = new int[capacity * 2];
+        Arrays.fill(this.data, -1);
+    }
+
+    private static int tableSizeFor(int cap) {
+        if (cap <= 1) return 1;
+        return 1 << (32 - Integer.numberOfLeadingZeros(cap - 1));
+    }
+
+    public int get(int key) {
+        int capacity = data.length >> 1;
+        int mask = capacity - 1;
+        int index = hash(key) & mask;
+        while (data[index * 2] != -1) {
+            if (data[index * 2] == key) {
+                return data[index * 2 + 1];
+            }
+            index = (index + 1) & mask;
+        }
+        return -1;
+    }
+
+    public void put(int key, int value) {
+        if (size >= threshold) {
+            resize((data.length >> 1) * 2);
+        }
+        int capacity = data.length >> 1;
+        int mask = capacity - 1;
+        int index = hash(key) & mask;
+        while (data[index * 2] != -1) {
+            if (data[index * 2] == key) {
+                data[index * 2 + 1] = value;
+                return;
+            }
+            index = (index + 1) & mask;
+        }
+        data[index * 2] = key;
+        data[index * 2 + 1] = value;
+        size++;
+    }
+
+    public void putIfAbsent(int key, int value) {
+        if (size >= threshold) {
+            resize((data.length >> 1) * 2);
+        }
+        int capacity = data.length >> 1;
+        int mask = capacity - 1;
+        int index = hash(key) & mask;
+        while (data[index * 2] != -1) {
+            if (data[index * 2] == key) {
+                return;
+            }
+            index = (index + 1) & mask;
+        }
+        data[index * 2] = key;
+        data[index * 2 + 1] = value;
+        size++;
+    }
+
+    private void resize(int newCapacity) {
+        int[] oldData = data;
+        int oldCapacity = oldData.length >> 1;
+
+        threshold = (int) (newCapacity * LOAD_FACTOR);
+        data = new int[newCapacity * 2];
+        Arrays.fill(data, -1);
+        size = 0;
+
+        for (int i = 0; i < oldCapacity; i++) {
+            int key = oldData[i * 2];
+            if (key != -1) {
+                put(key, oldData[i * 2 + 1]);
+            }
+        }
+    }
+
+    /**
+     * MurmurHash3 for better distribution.
+     */
+    private int hash(int key) {
+        key ^= key >>> 16;
+        key *= 0x85ebca6b;
+        key ^= key >>> 13;
+        key *= 0xc2b2ae35;
+        key ^= key >>> 16;
+        return key;
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
@@ -27,8 +27,6 @@ package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
-import java.util.Arrays;
-
 /**
  * A palette backed by a map.
  */
@@ -36,13 +34,13 @@ public class MapPalette implements Palette {
 
     private final int bits;
     private final int[] idToState;
-    private final Int2IntMap stateToId;
+    private final Int2IntOpenHashMap stateToId;
     private int nextId = 0;
 
     public MapPalette(int bitsPerEntry) {
         this.bits = bitsPerEntry;
         this.idToState = new int[1 << bitsPerEntry];
-        this.stateToId = new Int2IntMap(1 << bitsPerEntry);
+        this.stateToId = new Int2IntOpenHashMap(1 << bitsPerEntry);
     }
 
     @Deprecated
@@ -98,109 +96,5 @@ public class MapPalette implements Palette {
     @Override
     public int getBits() {
         return this.bits;
-    }
-
-    /**
-     * A simple open-addressing hash map optimized for int keys and values.
-     * It uses linear probing and supports a default return value of -1.
-     */
-    private static class Int2IntMap {
-
-        private static final float LOAD_FACTOR = 0.75f;
-
-        private int[] data;
-        private int size;
-        private int threshold;
-
-        public Int2IntMap(int expectedSize) {
-            int capacity = tableSizeFor(expectedSize);
-            this.threshold = (int) (capacity * LOAD_FACTOR);
-            this.data = new int[capacity * 2];
-            Arrays.fill(this.data, -1);
-        }
-
-        private static int tableSizeFor(int cap) {
-            int highestOneBit = Integer.highestOneBit(cap - 1);
-            return (cap <= 1) ? 1 : (highestOneBit >= 1 << 30) ? 1 << 30 : highestOneBit << 1;
-        }
-
-        public int get(int key) {
-            int capacity = data.length >> 1;
-            int mask = capacity - 1;
-            int index = hash(key) & mask;
-            while (data[index * 2] != -1) {
-                if (data[index * 2] == key) {
-                    return data[index * 2 + 1];
-                }
-                index = (index + 1) & mask;
-            }
-            return -1;
-        }
-
-        public void put(int key, int value) {
-            if (size >= threshold) {
-                resize((data.length >> 1) * 2);
-            }
-            int capacity = data.length >> 1;
-            int mask = capacity - 1;
-            int index = hash(key) & mask;
-            while (data[index * 2] != -1) {
-                if (data[index * 2] == key) {
-                    data[index * 2 + 1] = value;
-                    return;
-                }
-                index = (index + 1) & mask;
-            }
-            data[index * 2] = key;
-            data[index * 2 + 1] = value;
-            size++;
-        }
-
-        public void putIfAbsent(int key, int value) {
-            if (size >= threshold) {
-                resize((data.length >> 1) * 2);
-            }
-            int capacity = data.length >> 1;
-            int mask = capacity - 1;
-            int index = hash(key) & mask;
-            while (data[index * 2] != -1) {
-                if (data[index * 2] == key) {
-                    return;
-                }
-                index = (index + 1) & mask;
-            }
-            data[index * 2] = key;
-            data[index * 2 + 1] = value;
-            size++;
-        }
-
-        private void resize(int newCapacity) {
-            int[] oldData = data;
-            int oldCapacity = oldData.length >> 1;
-
-            threshold = (int) (newCapacity * LOAD_FACTOR);
-            data = new int[newCapacity * 2];
-            Arrays.fill(data, -1);
-            size = 0;
-
-            for (int i = 0; i < oldCapacity; i++) {
-                int key = oldData[i * 2];
-                if (key != -1) {
-                    put(key, oldData[i * 2 + 1]);
-                }
-            }
-        }
-
-        /**
-         * MurmurHash3 for better distribution.
-         */
-        private int hash(int key) {
-            key ^= key >>> 16;
-            key *= 0x85ebca6b;
-            key ^= key >>> 13;
-            key *= 0xc2b2ae35;
-            key ^= key >>> 16;
-            return key;
-        }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
@@ -27,6 +27,8 @@ package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
+import static com.github.retrooper.packetevents.protocol.world.chunk.palette.Int2IntHashMap.EMPTY_VALUE;
+
 /**
  * A palette backed by a map.
  */
@@ -34,13 +36,13 @@ public class MapPalette implements Palette {
 
     private final int bits;
     private final int[] idToState;
-    private final Int2IntOpenHashMap stateToId;
+    private final Int2IntHashMap stateToId;
     private int nextId = 0;
 
     public MapPalette(int bitsPerEntry) {
         this.bits = bitsPerEntry;
         this.idToState = new int[1 << bitsPerEntry];
-        this.stateToId = new Int2IntOpenHashMap(1 << bitsPerEntry);
+        this.stateToId = new Int2IntHashMap(1 << bitsPerEntry);
     }
 
     @Deprecated
@@ -76,7 +78,7 @@ public class MapPalette implements Palette {
     @Override
     public int stateToId(int state) {
         int id = this.stateToId.get(state);
-        if (id == -1 && this.size() < this.idToState.length) {
+        if (id == EMPTY_VALUE && this.size() < this.idToState.length) {
             id = this.nextId++;
             this.idToState[id] = state;
             this.stateToId.put(state, id);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/MapPalette.java
@@ -27,7 +27,7 @@ package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
-import java.util.HashMap;
+import java.util.Arrays;
 
 /**
  * A palette backed by a map.
@@ -36,13 +36,13 @@ public class MapPalette implements Palette {
 
     private final int bits;
     private final int[] idToState;
-    // TODO: Can we use fastutils here?
-    private final HashMap<Object, Integer> stateToId = new HashMap<>();
+    private final Int2IntMap stateToId;
     private int nextId = 0;
 
     public MapPalette(int bitsPerEntry) {
         this.bits = bitsPerEntry;
         this.idToState = new int[1 << bitsPerEntry];
+        this.stateToId = new Int2IntMap(1 << bitsPerEntry);
     }
 
     @Deprecated
@@ -77,18 +77,13 @@ public class MapPalette implements Palette {
 
     @Override
     public int stateToId(int state) {
-        Integer id = this.stateToId.get(state);
-        if (id == null && this.size() < this.idToState.length) {
+        int id = this.stateToId.get(state);
+        if (id == -1 && this.size() < this.idToState.length) {
             id = this.nextId++;
             this.idToState[id] = state;
             this.stateToId.put(state, id);
         }
-
-        if (id != null) {
-            return id;
-        } else {
-            return -1;
-        }
+        return id;
     }
 
     @Override
@@ -103,5 +98,109 @@ public class MapPalette implements Palette {
     @Override
     public int getBits() {
         return this.bits;
+    }
+
+    /**
+     * A simple open-addressing hash map optimized for int keys and values.
+     * It uses linear probing and supports a default return value of -1.
+     */
+    private static class Int2IntMap {
+
+        private static final float LOAD_FACTOR = 0.75f;
+
+        private int[] data;
+        private int size;
+        private int threshold;
+
+        public Int2IntMap(int expectedSize) {
+            int capacity = tableSizeFor(expectedSize);
+            this.threshold = (int) (capacity * LOAD_FACTOR);
+            this.data = new int[capacity * 2];
+            Arrays.fill(this.data, -1);
+        }
+
+        private static int tableSizeFor(int cap) {
+            int highestOneBit = Integer.highestOneBit(cap - 1);
+            return (cap <= 1) ? 1 : (highestOneBit >= 1 << 30) ? 1 << 30 : highestOneBit << 1;
+        }
+
+        public int get(int key) {
+            int capacity = data.length >> 1;
+            int mask = capacity - 1;
+            int index = hash(key) & mask;
+            while (data[index * 2] != -1) {
+                if (data[index * 2] == key) {
+                    return data[index * 2 + 1];
+                }
+                index = (index + 1) & mask;
+            }
+            return -1;
+        }
+
+        public void put(int key, int value) {
+            if (size >= threshold) {
+                resize((data.length >> 1) * 2);
+            }
+            int capacity = data.length >> 1;
+            int mask = capacity - 1;
+            int index = hash(key) & mask;
+            while (data[index * 2] != -1) {
+                if (data[index * 2] == key) {
+                    data[index * 2 + 1] = value;
+                    return;
+                }
+                index = (index + 1) & mask;
+            }
+            data[index * 2] = key;
+            data[index * 2 + 1] = value;
+            size++;
+        }
+
+        public void putIfAbsent(int key, int value) {
+            if (size >= threshold) {
+                resize((data.length >> 1) * 2);
+            }
+            int capacity = data.length >> 1;
+            int mask = capacity - 1;
+            int index = hash(key) & mask;
+            while (data[index * 2] != -1) {
+                if (data[index * 2] == key) {
+                    return;
+                }
+                index = (index + 1) & mask;
+            }
+            data[index * 2] = key;
+            data[index * 2 + 1] = value;
+            size++;
+        }
+
+        private void resize(int newCapacity) {
+            int[] oldData = data;
+            int oldCapacity = oldData.length >> 1;
+
+            threshold = (int) (newCapacity * LOAD_FACTOR);
+            data = new int[newCapacity * 2];
+            Arrays.fill(data, -1);
+            size = 0;
+
+            for (int i = 0; i < oldCapacity; i++) {
+                int key = oldData[i * 2];
+                if (key != -1) {
+                    put(key, oldData[i * 2 + 1]);
+                }
+            }
+        }
+
+        /**
+         * MurmurHash3 for better distribution.
+         */
+        private int hash(int key) {
+            key ^= key >>> 16;
+            key *= 0x85ebca6b;
+            key ^= key >>> 13;
+            key *= 0xc2b2ae35;
+            key ^= key >>> 16;
+            return key;
+        }
     }
 }


### PR DESCRIPTION
Replaces a very unnecessary HashMap<Object, Integer> with a much lighter custom Int2Int map.
Works fine from my tests, might warrant a unit test.

Closes #1412 