### PR TITLE
Add comment to indicate the mojang name of the packet the wrapper is handling

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChangeGameState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerChangeGameState.java
@@ -22,6 +22,9 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
+/**
+ * Mojang name: ClientboundGameEventPacket
+ */
 public class WrapperPlayServerChangeGameState extends PacketWrapper<WrapperPlayServerChangeGameState> {
     private Reason reason;
     private float value;


### PR DESCRIPTION
This is some parity comment in regard of ClientboundLevelEventPacket