### PR TITLE
Add system property to allow longer chat messages on legacy versions

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
@@ -35,6 +35,18 @@ import java.util.Optional;
  * This packet is used to send a chat message to the server.
  */
 public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClientChatMessage> {
+    private static int getLegacyMaxChatLength() {
+        final String value = System.getProperty("packetevents.legacyClientChatMaxLength");
+        if (value != null) {
+            try {
+                return Integer.parseInt(value.trim());
+            } catch (final NumberFormatException e) {
+                // Exception has been handled
+            }
+        }
+        return 100;
+    }
+
     private String message;
     private MessageSignData messageSignData;
     private @Nullable LastSeenMessages.Update lastSeenMessages;
@@ -60,7 +72,7 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
 
     @Override
     public void read() {
-        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : 100;
+        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : getLegacyMaxChatLength();
         this.message = readString(maxMessageLength);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             Instant timestamp = readTimestamp();
@@ -81,7 +93,7 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
 
     @Override
     public void write() {
-        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : 100;
+        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : getLegacyMaxChatLength();
         writeString(this.message, maxMessageLength);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             writeTimestamp(messageSignData.getTimestamp());

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
@@ -24,7 +24,6 @@ import com.github.retrooper.packetevents.protocol.chat.LastSeenMessages;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.util.crypto.MessageSignData;
-import com.github.retrooper.packetevents.util.crypto.SaltSignature;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,17 +34,7 @@ import java.util.Optional;
  * This packet is used to send a chat message to the server.
  */
 public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClientChatMessage> {
-    private static int getLegacyMaxChatLength() {
-        final String value = System.getProperty("packetevents.legacyClientChatMaxLength");
-        if (value != null) {
-            try {
-                return Integer.parseInt(value.trim());
-            } catch (final NumberFormatException e) {
-                // Exception has been handled
-            }
-        }
-        return 100;
-    }
+    private static final int LEGACY_MAX_LENGTH = Integer.getInteger("packetevents.legacy-chat-max-length", 100);
 
     private String message;
     private MessageSignData messageSignData;
@@ -72,7 +61,7 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
 
     @Override
     public void read() {
-        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : getLegacyMaxChatLength();
+        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : LEGACY_MAX_LENGTH;
         this.message = readString(maxMessageLength);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             Instant timestamp = readTimestamp();
@@ -93,7 +82,7 @@ public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClien
 
     @Override
     public void write() {
-        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : getLegacyMaxChatLength();
+        int maxMessageLength = serverVersion.isNewerThanOrEquals(ServerVersion.V_1_11) ? 256 : LEGACY_MAX_LENGTH;
         writeString(this.message, maxMessageLength);
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             writeTimestamp(messageSignData.getTimestamp());

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientChatMessage.java
@@ -34,6 +34,7 @@ import java.util.Optional;
  * This packet is used to send a chat message to the server.
  */
 public class WrapperPlayClientChatMessage extends PacketWrapper<WrapperPlayClientChatMessage> {
+
     private static final int LEGACY_MAX_LENGTH = Integer.getInteger("packetevents.legacy-chat-max-length", 100);
 
     private String message;


### PR DESCRIPTION
Similar to
https://github.com/PaperMC/Velocity/blob/6aff78728c267bbb67b07298b8cf4580fb79fc6f/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatPacket.java#L49

LunarClient Apollo API allows you to override the max chat length message for older mc versions. Without this change plugins that listen for chat packets break.