### PR TITLE
Fix asBukkitCopy reflection for MC 26.1.1+

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/util/SpigotReflectionUtil.java
@@ -213,7 +213,11 @@ public final class SpigotReflectionUtil {
             }
         }
 
-        CRAFT_ITEM_STACK_AS_BUKKIT_COPY = Reflection.getMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", 0);
+        CRAFT_ITEM_STACK_AS_BUKKIT_COPY = Reflection.getMethodExact(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", null, NMS_ITEM_STACK_CLASS);
+        if (CRAFT_ITEM_STACK_AS_BUKKIT_COPY == null) {
+            // Fallback for older servers where there's only one overload
+            CRAFT_ITEM_STACK_AS_BUKKIT_COPY = Reflection.getMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", 0);
+        }
         CRAFT_ITEM_STACK_AS_NMS_COPY = Reflection.getMethod(CRAFT_ITEM_STACK_CLASS, "asNMSCopy", ItemStack.class);
 
         // Had to hardcode the 1.12 vanilla names because some jar was screwing with it, fall back to normal mappings if not found


### PR DESCRIPTION
MC 26.1.1 introduced a new CraftItemStack.asBukkitCopy(ItemStackTemplate) overload. The index-based method lookup (getMethod with index 0) could resolve to the wrong overload depending on JVM method ordering, causing "argument type mismatch" errors for item-holding disguises.

Use getMethodExact with explicit NMS_ITEM_STACK_CLASS parameter type to always resolve the correct asBukkitCopy(ItemStack) method, with a fallback to the old index-based lookup for older servers.