### PR TITLE
return immutable static constant when calling #zero in Vector3i and Vector3f 

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3f.java
@@ -32,6 +32,9 @@ import java.util.Objects;
  * @since 1.8
  */
 public class Vector3f {
+
+    private static final Vector3f ZERO = new Vector3f(0.0f, 0.0f, 0.0f);
+
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -232,7 +235,7 @@ public class Vector3f {
     }
 
     public static Vector3f zero() {
-        return new Vector3f();
+        return ZERO;
     }
 }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/Vector3i.java
@@ -35,6 +35,9 @@ import java.util.Objects;
  * @since 1.7
  */
 public class Vector3i {
+
+    private static final Vector3i ZERO = new Vector3i(0, 0, 0);
+
     /**
      * X (coordinate/angle/whatever you wish)
      */
@@ -281,6 +284,6 @@ public class Vector3i {
     }
 
     public static Vector3i zero() {
-        return new Vector3i();
+        return ZERO;
     }
 }


### PR DESCRIPTION
`Vector3f` and `Vector3i` both returned a **new** vector object when calling the `zero()` method; this is unnecessary as `Vector3f` and `Vector3i` components are immutable. I considered it may have been intentional, although I see in the `Vector3d` class, that this isn't the case, and its `zero()` method does indeed return a static constant https://github.com/retrooper/packetevents/blob/bbeec896384e22844a51ab28b9bc4c91f8f1daf0/api/src/main/java/com/github/retrooper/packetevents/util/Vector3d.java#L289 So it may have just been forgotten to be implemented in its float and integer counterparts.