### PR TITLE
Remove username length limit

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/server/WrapperLoginServerLoginSuccess.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/login/server/WrapperLoginServerLoginSuccess.java
@@ -63,7 +63,7 @@ public class WrapperLoginServerLoginSuccess extends PacketWrapper<WrapperLoginSe
         } else {
             uuid = UUID.fromString(readString(36));
         }
-        String username = readString(16);
+        String username = readString();
         this.userProfile = new UserProfile(uuid, username);
 
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
@@ -90,7 +90,7 @@ public class WrapperLoginServerLoginSuccess extends PacketWrapper<WrapperLoginSe
         } else {
             writeString(userProfile.getUUID().toString(), 36);
         }
-        writeString(userProfile.getName(), 16);
+        writeString(userProfile.getName());
 
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             writeVarInt(userProfile.getTextureProperties().size());


### PR DESCRIPTION
Remove this limit for offline-mode servers, which actually accept 16+ length usernames.