### PR TITLE
implement specialized listener map for EventManager

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -23,8 +23,9 @@ import com.github.retrooper.packetevents.exception.InvalidHandshakeException;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 /**
@@ -43,12 +44,43 @@ import java.util.logging.Level;
 
 public class EventManager {
 
-    //Using a ConcurrentHashMap is faster and more secure here, compared to Collections.synchronizedMap(new EnumMap<>(PacketListenerPriority.class))
-    //This is mainly due to:
-    //1. On each modification Collections.synchronizedMap synchronizes the whole Map object, while ConcurrentHashMap only it's internal, currently modified Node
-    //2. ConcurrentHashMap won't fail in a multi-thread environment, while Collections.synchronizedMap is said to have a lot of potential problems,
-    //being a generalized method for synchronization
-    private final Map<PacketListenerPriority, Set<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
+    // specifically optimized for the use case of storing listeners by their priority concurrently
+    // we can use a small array since priorities are very limited and known ahead of time
+    // uses cas operations to uphold a safe lock free architecture
+    private static class ConcurrentListenerMap {
+
+        private final AtomicReferenceArray<Set<PacketListenerCommon>> array = new AtomicReferenceArray(PacketListenerPriority.values().length);
+
+        public void clear() {
+            for (int i = 0; i < this.array.length(); i++) {
+                do {
+                    Set<PacketListenerCommon> current = this.array.get(i);
+                    if (current == null || this.array.compareAndSet(i, current, null))
+                        break;
+                } while (true);
+            }
+        }
+
+        public Set<PacketListenerCommon> get(PacketListenerPriority priority) {
+            return this.array.get(priority.ordinal());
+        }
+
+        public Set<PacketListenerCommon> computeIfAbsent(PacketListenerPriority priority, Function<PacketListenerPriority, Set<PacketListenerCommon>> supplier) {
+            int index = priority.ordinal();
+            Set<PacketListenerCommon> supplied = null;
+            do {
+                Set<PacketListenerCommon> current = this.array.get(index);
+                if (current != null)
+                    return current;
+                if (supplied == null)
+                    supplied = supplier.apply(priority);
+                if (this.array.compareAndSet(index, null, supplied))
+                    return supplied;
+            } while (true);
+        }
+    }
+
+    private final ConcurrentListenerMap listenersMap = new ConcurrentListenerMap();
     //Since reads greatly outnumber writes, create an array for the best possible iteration time
     //Updated as a whole on writes, no index modifications are allowed
     private volatile PacketListenerCommon[] listeners = new PacketListenerCommon[0];


### PR DESCRIPTION
This changes the listenerMap field inside `EventManager` https://github.com/retrooper/packetevents/blob/95afd3fce8bfbf7087233a3bd31e0705cd1e4df5/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java#L51 to a specialized implementation (`ConcurrentListenerMap`). 

This implementation is a drop in replacement for the old `ConcurrentHashMap` that was being used with an enum key type (`PacketListenerPriority`). 

The `PacketListenerPriority` enum is a very limited enum, with only 6 usable entries, and will most likely never amount to anything considered "large". `PacketEvents` already makes use of its embedded `ordinal` and `values` field, so It was used for this implementation aswell.

The specialized implementation uses a single `AtomicReferenceArray` allocated with a size of `PacketListenerPriority#values().length`, using `PacketListenerPriority#ordinal` as the "hash" function of the map. Then CAS operations are used on the array to achieve concurrency.

This implementation does not implement `Map` or `ConcurrentMap`, because it is simply a specialized drop-in replacement for what was being used previously.

This implementation provides a few benefits; it is a lock-free architecture, is thread-safe, and is more efficient than any _JDK concurrent map implementation for its ***(!!!) use case (!!!)*** in the `EventManager`_, as there is minimal indirection with only a single backing array.