### PR TITLE
fix: remove length limit for WrapperPlayClientPluginMessage

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPluginMessage.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientPluginMessage.java
@@ -63,7 +63,6 @@ public class WrapperPlayClientPluginMessage extends PacketWrapper<WrapperPlayCli
             int legacyDataSize = readShort();
         }
 
-        if (ByteBufHelper.readableBytes(buffer) > 32767) throw new RuntimeException("Payload may not be larger than 32767 bytes");
         this.data = readRemainingBytes();
     }
 


### PR DESCRIPTION
Closes #1133

This packet may be larger than 32767 bytes:
>  The vanilla server enforces a length limit of 32767 bytes on this data, but only if the channel type is unrecognized.

https://minecraft.wiki/w/Java_Edition_protocol/Packets#Serverbound_Plugin_Message_(play)