### PR TITLE
flexible listener priorities

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/EventManager.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Level;
 
 /**
@@ -43,12 +42,8 @@ import java.util.logging.Level;
 
 public class EventManager {
 
-    //Using a ConcurrentHashMap is faster and more secure here, compared to Collections.synchronizedMap(new EnumMap<>(PacketListenerPriority.class))
-    //This is mainly due to:
-    //1. On each modification Collections.synchronizedMap synchronizes the whole Map object, while ConcurrentHashMap only it's internal, currently modified Node
-    //2. ConcurrentHashMap won't fail in a multi-thread environment, while Collections.synchronizedMap is said to have a lot of potential problems,
-    //being a generalized method for synchronization
-    private final Map<PacketListenerPriority, Set<PacketListenerCommon>> listenersMap = new ConcurrentHashMap<>();
+
+    private final Set<PacketListenerCommon> listenerSet = ConcurrentHashMap.newKeySet();
     //Since reads greatly outnumber writes, create an array for the best possible iteration time
     //Updated as a whole on writes, no index modifications are allowed
     private volatile PacketListenerCommon[] listeners = new PacketListenerCommon[0];
@@ -150,7 +145,7 @@ public class EventManager {
      * Unregister all dynamic packet event listeners.
      */
     public void unregisterAllListeners() {
-        this.listenersMap.clear();
+        this.listenerSet.clear();
         synchronized (this) {//like booky10 said, the synchronization is necessary here
             this.listeners = new PacketListenerCommon[0];
         }
@@ -160,12 +155,8 @@ public class EventManager {
     //is overridden by its non-up-to-date value, simply because it finished a bit later than the most recent update)
     private void recalculateListeners() {
         synchronized (this) {
-            List<PacketListenerCommon> list = new ArrayList<>();
-            //adds from LOWEST to MONITOR, so in the correct order
-            for (PacketListenerPriority priority : PacketListenerPriority.values()) {
-                Set<PacketListenerCommon> set = this.listenersMap.get(priority);
-                if (set != null) list.addAll(set);
-            }
+            List<PacketListenerCommon> list = new ArrayList<>(this.listenerSet);
+            list.sort(Comparator.comparing(PacketListenerCommon::priority));
             this.listeners = list.toArray(new PacketListenerCommon[0]);
         }
     }
@@ -173,13 +164,11 @@ public class EventManager {
     //Internal registration methods, specifically separated for lesser overhead when registering an array of Listeners
 
     private void registerListenerNoRecalculation(PacketListenerCommon listener) {
-        Set<PacketListenerCommon> listenerSet = this.listenersMap.computeIfAbsent(listener.getPriority(), p -> new CopyOnWriteArraySet<>());
-        listenerSet.add(listener);
+        this.listenerSet.add(listener);
     }
 
     //Returns true if the listener was removed, so a modification occurred
     private boolean unregisterListenerNoRecalculation(PacketListenerCommon listener) {
-        Set<PacketListenerCommon> listenerSet = this.listenersMap.get(listener.getPriority());
-        return listenerSet != null && listenerSet.remove(listener);
+        return this.listenerSet.remove(listener);
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
@@ -1,19 +1,39 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2026 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.github.retrooper.packetevents.event;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 /**
- *  Class for defining listener priorities.
- *  The priority of packet listeners affect the order they will be invoked in.
- *  The lowest priority listeners are invoked first, the highest are invoked last.
- *  The highest priority listener has the final decider on an event being cancelled.
- *  <p>
- *  Users can define custom priorities by using the {@link #custom(int)} method.
- *  <p>
- *  Predefined priorities are: {@link #LOWEST}, {@link #LOW}, {@link #NORMAL}, {@link #HIGH}, {@link #HIGHEST} and {@link #MONITOR}.
- *  @author ieatglu3
+ * Class for defining listener priorities.
+ * The priority of packet listeners affect the order they will be invoked in.
+ * The lowest priority listeners are invoked first, the highest are invoked last.
+ * The highest priority listener has the final decider on an event being cancelled.
+ * <p>
+ * Users can define custom priorities by using the {@link #custom(int)} method.
+ * <p>
+ * Predefined priorities are: {@link #LOWEST}, {@link #LOW}, {@link #NORMAL}, {@link #HIGH}, {@link #HIGHEST} and {@link #MONITOR}.
+ *
+ * @author ieatglu3
  */
+@NullMarked
 public final class ListenerPriority implements Comparable<ListenerPriority> {
 
     private final int ordinal;
@@ -82,6 +102,7 @@ public final class ListenerPriority implements Comparable<ListenerPriority> {
      * Create a custom listener priority with the specified ordinal. The higher the ordinal, the higher the priority.
      * <p>
      * The predefined priorities have ordinals from 0 to 5. Custom priorities can be negative.
+     *
      * @param ordinal the ordinal of this priority
      * @return a new {@link ListenerPriority} with the specified ordinal
      */
@@ -96,28 +117,41 @@ public final class ListenerPriority implements Comparable<ListenerPriority> {
         return VALUES.clone();
     }
 
-    @ApiStatus.Internal
+    @Deprecated
     public static ListenerPriority fromLegacy(PacketListenerPriority priority) {
         switch (priority) {
-            case LOWEST: return LOWEST;
-            case LOW: return LOW;
-            case NORMAL: return NORMAL;
-            case HIGH: return HIGH;
-            case HIGHEST: return HIGHEST;
-            case MONITOR: return MONITOR;
-            default: throw new IllegalArgumentException("unknown legacy priority: " + priority);
+            case LOWEST:
+                return LOWEST;
+            case LOW:
+                return LOW;
+            case NORMAL:
+                return NORMAL;
+            case HIGH:
+                return HIGH;
+            case HIGHEST:
+                return HIGHEST;
+            case MONITOR:
+                return MONITOR;
+            default:
+                throw new IllegalArgumentException("unknown legacy priority: " + priority);
         }
     }
 
-    @ApiStatus.Internal
+    @Deprecated
     public PacketListenerPriority legacyType() {
         switch (this.ordinal) {
-            case 0: return PacketListenerPriority.LOWEST;
-            case 1: return PacketListenerPriority.LOW;
-            case 2: return PacketListenerPriority.NORMAL;
-            case 3: return PacketListenerPriority.HIGH;
-            case 4: return PacketListenerPriority.HIGHEST;
-            default: return PacketListenerPriority.MONITOR;
+            case 0:
+                return PacketListenerPriority.LOWEST;
+            case 1:
+                return PacketListenerPriority.LOW;
+            case 2:
+                return PacketListenerPriority.NORMAL;
+            case 3:
+                return PacketListenerPriority.HIGH;
+            case 4:
+                return PacketListenerPriority.HIGHEST;
+            default:
+                return PacketListenerPriority.MONITOR;
         }
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
@@ -1,0 +1,123 @@
+package com.github.retrooper.packetevents.event;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ *  Class for defining listener priorities.
+ *  The priority of packet listeners affect the order they will be invoked in.
+ *  The lowest priority listeners are invoked first, the highest are invoked last.
+ *  The highest priority listener has the final decider on an event being cancelled.
+ *  <p>
+ *  Users can define custom priorities by using the {@link #custom(int)} method.
+ *  <p>
+ *  Predefined priorities are: {@link #LOWEST}, {@link #LOW}, {@link #NORMAL}, {@link #HIGH}, {@link #HIGHEST} and {@link #MONITOR}.
+ *  @author ieatglu3
+ */
+public final class ListenerPriority implements Comparable<ListenerPriority> {
+
+    private final int ordinal;
+
+    private ListenerPriority(int ordinal) {
+        this.ordinal = ordinal;
+    }
+
+    /**
+     * This listener will be run first and has little say in the outcome of events.
+     */
+    public static final ListenerPriority LOWEST = new ListenerPriority(0);
+
+    /**
+     * Listener is of low importance.
+     */
+    public static final ListenerPriority LOW = new ListenerPriority(1);
+
+    /**
+     * The normal listener priority.
+     */
+    public static final ListenerPriority NORMAL = new ListenerPriority(2);
+
+    /**
+     * Listener is of high importance.
+     */
+    public static final ListenerPriority HIGH = new ListenerPriority(3);
+
+    /**
+     * Listener is of critical importance. Use this to decide the final state of packets.
+     */
+    public static final ListenerPriority HIGHEST = new ListenerPriority(4);
+
+    /**
+     * Highest priority. Use this to perform logic based on the outcome of an event.
+     */
+    public static final ListenerPriority MONITOR = new ListenerPriority(5);
+
+    private static final ListenerPriority[] VALUES = {LOWEST, LOW, NORMAL, HIGH, HIGHEST, MONITOR};
+
+    /**
+     * @return the ordinal of this priority. The higher the ordinal, the higher the priority.
+     */
+    public int getOrdinal() {
+        return this.ordinal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || o.getClass() != ListenerPriority.class) return false;
+        return this.ordinal == ((ListenerPriority) o).ordinal;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.ordinal;
+    }
+
+    @Override
+    public int compareTo(@NotNull ListenerPriority o) {
+        return Integer.compare(this.ordinal, o.ordinal);
+    }
+
+    /**
+     * Create a custom listener priority with the specified ordinal. The higher the ordinal, the higher the priority.
+     * <p>
+     * The predefined priorities have ordinals from 0 to 5. Custom priorities can be negative.
+     * @param ordinal the ordinal of this priority
+     * @return a new {@link ListenerPriority} with the specified ordinal
+     */
+    public static ListenerPriority custom(int ordinal) {
+        return new ListenerPriority(ordinal);
+    }
+
+    /**
+     * @return a copy of all the predefined priorities in order of their ordinals.
+     */
+    public static ListenerPriority[] predefined() {
+        return VALUES.clone();
+    }
+
+    @ApiStatus.Internal
+    public static ListenerPriority fromLegacy(PacketListenerPriority priority) {
+        switch (priority) {
+            case LOWEST: return LOWEST;
+            case LOW: return LOW;
+            case NORMAL: return NORMAL;
+            case HIGH: return HIGH;
+            case HIGHEST: return HIGHEST;
+            case MONITOR: return MONITOR;
+            default: throw new IllegalArgumentException("unknown legacy priority: " + priority);
+        }
+    }
+
+    @ApiStatus.Internal
+    public PacketListenerPriority legacyType() {
+        switch (this.ordinal) {
+            case 0: return PacketListenerPriority.LOWEST;
+            case 1: return PacketListenerPriority.LOW;
+            case 2: return PacketListenerPriority.NORMAL;
+            case 3: return PacketListenerPriority.HIGH;
+            case 4: return PacketListenerPriority.HIGHEST;
+            default: return PacketListenerPriority.MONITOR;
+        }
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
@@ -133,6 +133,9 @@ public final class ListenerPriority implements Comparable<ListenerPriority> {
         return Integer.compare(this.priority, o.priority);
     }
 
+    /**
+     * @return the ordinal of this priority. The higher the ordinal, the higher the priority.
+     */
     public int getPriority() {
         return this.priority;
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/ListenerPriority.java
@@ -18,84 +18,62 @@
 
 package com.github.retrooper.packetevents.event;
 
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
- * Class for defining listener priorities.
  * The priority of packet listeners affect the order they will be invoked in.
  * The lowest priority listeners are invoked first, the highest are invoked last.
- * The highest priority listener has the final decider on an event being cancelled.
- * <p>
- * Users can define custom priorities by using the {@link #custom(int)} method.
+ * The highest priority listener has the final decider on an event being canceled.
  * <p>
  * Predefined priorities are: {@link #LOWEST}, {@link #LOW}, {@link #NORMAL}, {@link #HIGH}, {@link #HIGHEST} and {@link #MONITOR}.
- *
- * @author ieatglu3
+ * <p>
+ * Custom integer priorities can be defined using {@link #custom(int)}.
  */
 @NullMarked
 public final class ListenerPriority implements Comparable<ListenerPriority> {
 
-    private final int ordinal;
-
-    private ListenerPriority(int ordinal) {
-        this.ordinal = ordinal;
-    }
+    private static final int LOWEST_PRIORITY = -5000;
+    private static final int LOW_PRIORITY = -2500;
+    private static final int NORMAL_PRIORITY = 0;
+    private static final int HIGH_PRIORITY = 2500;
+    private static final int HIGHEST_PRIORITY = 5000;
+    private static final int MONITOR_PRIORITY = Integer.MAX_VALUE;
 
     /**
      * This listener will be run first and has little say in the outcome of events.
      */
-    public static final ListenerPriority LOWEST = new ListenerPriority(0);
+    public static final ListenerPriority LOWEST = new ListenerPriority(LOWEST_PRIORITY);
 
     /**
      * Listener is of low importance.
      */
-    public static final ListenerPriority LOW = new ListenerPriority(1);
+    public static final ListenerPriority LOW = new ListenerPriority(LOW_PRIORITY);
 
     /**
      * The normal listener priority.
      */
-    public static final ListenerPriority NORMAL = new ListenerPriority(2);
+    public static final ListenerPriority NORMAL = new ListenerPriority(NORMAL_PRIORITY);
 
     /**
      * Listener is of high importance.
      */
-    public static final ListenerPriority HIGH = new ListenerPriority(3);
+    public static final ListenerPriority HIGH = new ListenerPriority(HIGH_PRIORITY);
 
     /**
      * Listener is of critical importance. Use this to decide the final state of packets.
      */
-    public static final ListenerPriority HIGHEST = new ListenerPriority(4);
+    public static final ListenerPriority HIGHEST = new ListenerPriority(HIGHEST_PRIORITY);
 
     /**
      * Highest priority. Use this to perform logic based on the outcome of an event.
      */
-    public static final ListenerPriority MONITOR = new ListenerPriority(5);
+    public static final ListenerPriority MONITOR = new ListenerPriority(MONITOR_PRIORITY);
 
-    private static final ListenerPriority[] VALUES = {LOWEST, LOW, NORMAL, HIGH, HIGHEST, MONITOR};
+    private final int priority;
 
-    /**
-     * @return the ordinal of this priority. The higher the ordinal, the higher the priority.
-     */
-    public int getOrdinal() {
-        return this.ordinal;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || o.getClass() != ListenerPriority.class) return false;
-        return this.ordinal == ((ListenerPriority) o).ordinal;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.ordinal;
-    }
-
-    @Override
-    public int compareTo(@NotNull ListenerPriority o) {
-        return Integer.compare(this.ordinal, o.ordinal);
+    private ListenerPriority(int priority) {
+        this.priority = priority;
     }
 
     /**
@@ -108,13 +86,6 @@ public final class ListenerPriority implements Comparable<ListenerPriority> {
      */
     public static ListenerPriority custom(int ordinal) {
         return new ListenerPriority(ordinal);
-    }
-
-    /**
-     * @return a copy of all the predefined priorities in order of their ordinals.
-     */
-    public static ListenerPriority[] predefined() {
-        return VALUES.clone();
     }
 
     @Deprecated
@@ -133,25 +104,48 @@ public final class ListenerPriority implements Comparable<ListenerPriority> {
             case MONITOR:
                 return MONITOR;
             default:
-                throw new IllegalArgumentException("unknown legacy priority: " + priority);
+                throw new AssertionError();
         }
     }
 
     @Deprecated
     public PacketListenerPriority legacyType() {
-        switch (this.ordinal) {
-            case 0:
+        switch (this.priority) {
+            case LOWEST_PRIORITY:
                 return PacketListenerPriority.LOWEST;
-            case 1:
+            case LOW_PRIORITY:
                 return PacketListenerPriority.LOW;
-            case 2:
+            case NORMAL_PRIORITY:
                 return PacketListenerPriority.NORMAL;
-            case 3:
+            case HIGH_PRIORITY:
                 return PacketListenerPriority.HIGH;
-            case 4:
+            case HIGHEST_PRIORITY:
                 return PacketListenerPriority.HIGHEST;
-            default:
+            case MONITOR_PRIORITY:
                 return PacketListenerPriority.MONITOR;
+            default:
+                throw new IllegalStateException("Can't convert " + this + " to legacy listener priority");
         }
+    }
+
+    @Override
+    public int compareTo(ListenerPriority o) {
+        return Integer.compare(this.priority, o.priority);
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || o.getClass() != ListenerPriority.class) return false;
+        return this.priority == ((ListenerPriority) o).priority;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.priority;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
@@ -18,10 +18,6 @@
 
 package com.github.retrooper.packetevents.event;
 
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Abstract packet listener.
  *
@@ -29,18 +25,44 @@ import java.util.Map;
  * @since 1.8
  */
 public abstract class PacketListenerCommon {
-    private final PacketListenerPriority priority;
+    private final ListenerPriority priority;
 
-    public PacketListenerCommon(PacketListenerPriority priority) {
+    /**
+     * @param priority the priority of this packet listener.
+     */
+    public PacketListenerCommon(ListenerPriority priority) {
         this.priority = priority;
     }
 
+    /**
+     * Default priority is {@link ListenerPriority#NORMAL}.
+     */
     public PacketListenerCommon() {
-        this.priority = PacketListenerPriority.NORMAL;
+        this(ListenerPriority.NORMAL);
     }
 
+    /**
+     * @deprecated Legacy priority type. Use constructor {@link PacketListenerCommon(ListenerPriority)} instead.
+     */
+    @Deprecated
+    public PacketListenerCommon(PacketListenerPriority priority) {
+        this(ListenerPriority.fromLegacy(priority));
+    }
+
+    /**
+     * @deprecated Legacy priority type, returns {@link PacketListenerPriority#MONITOR} for custom priorities. Use {@link #priority()} instead.
+     * @return the priority of this packet listener.
+     */
+    @Deprecated
     public PacketListenerPriority getPriority() {
-        return priority;
+        return priority.legacyType();
+    }
+
+    /**
+     * @return the priority of this packet listener.
+     */
+    public ListenerPriority priority() {
+        return this.priority;
     }
 
     public void onUserConnect(UserConnectEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
@@ -62,8 +62,9 @@ public abstract class PacketListenerCommon {
      * @return the priority of this packet listener.
      */
     public ListenerPriority priority() {
-        // backwards compat, developers may have overrides
-        return ListenerPriority.fromLegacy(this.getPriority());
+        // no point in providing a backwards compat if method returns the modern type
+        // + the new type has to be exposed in one way or another (the event manager needs it), cant get around this one :(
+        return this.priority;
     }
 
     public void onUserConnect(UserConnectEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerCommon.java
@@ -42,7 +42,7 @@ public abstract class PacketListenerCommon {
     }
 
     /**
-     * @deprecated Legacy priority type. Use constructor {@link PacketListenerCommon(ListenerPriority)} instead.
+     * @deprecated use {@link PacketListenerCommon(ListenerPriority)} instead
      */
     @Deprecated
     public PacketListenerCommon(PacketListenerPriority priority) {
@@ -50,19 +50,20 @@ public abstract class PacketListenerCommon {
     }
 
     /**
-     * @deprecated Legacy priority type, returns {@link PacketListenerPriority#MONITOR} for custom priorities. Use {@link #priority()} instead.
      * @return the priority of this packet listener.
+     * @deprecated use {@link #priority()} instead
      */
     @Deprecated
     public PacketListenerPriority getPriority() {
-        return priority.legacyType();
+        return this.priority.legacyType();
     }
 
     /**
      * @return the priority of this packet listener.
      */
     public ListenerPriority priority() {
-        return this.priority;
+        // backwards compat, developers may have overrides
+        return ListenerPriority.fromLegacy(this.getPriority());
     }
 
     public void onUserConnect(UserConnectEvent event) {

--- a/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerPriority.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/event/PacketListenerPriority.java
@@ -27,7 +27,10 @@ package com.github.retrooper.packetevents.event;
  *
  * @author retrooper
  * @since 1.8
+ *
+ * @deprecated Legacy priority type. Use {@link ListenerPriority} instead.
  */
+@Deprecated
 public enum PacketListenerPriority {
     /**
      * This listener will be run first and has little say in the outcome of events.
@@ -64,10 +67,18 @@ public enum PacketListenerPriority {
      */
     MONITOR;
 
+    /**
+     * @deprecated Legacy priority type. Use {@link ListenerPriority} instead.
+     */
+    @Deprecated
     public static PacketListenerPriority getById(byte id) {
         return values()[id];
     }
 
+    /**
+     * @deprecated Legacy priority type. Use {@link ListenerPriority} instead.
+     */
+    @Deprecated
     public byte getId() {
         return (byte) ordinal();
     }


### PR DESCRIPTION
This rewrites the listener priority system in a way that is more robust, including supporting custom integer priorities.

For maximum backwards compatibility, this does not remove the legacy `PacketListenerPriority`, nor its usages, instead just deprecates it without sacrificing existing functionality.

The modern listener priority class is now `ListenerPriority`, with the same default/predefined priority values as its legacy counterpart. 

User's can continue to use existing priorities, or create their own using the new system.