### PR TITLE
Fix sponge module shading all of adventure

### DIFF
--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.retrooper.excludeAdventure
 import org.spongepowered.gradle.plugin.config.PluginLoaders
 import org.spongepowered.plugin.metadata.model.PluginDependency
 
@@ -89,8 +90,14 @@ dependencies {
     shadow(libs.adventure.nbt) {
         isTransitive = false
     }
-    shadow(project(":api", "shadow"))
-    shadow(project(":netty-common"))
+    shadow(project(":api", "shadow")) {
+        excludeAdventure()
+        exclude(group = "net.kyori", module = "adventure-key")
+    }
+    shadow(project(":netty-common")) {
+        excludeAdventure()
+        exclude(group = "net.kyori", module = "adventure-key")
+    }
     compileShadowOnly(libs.bstats.sponge)
 
     compileOnly(libs.via.version)


### PR DESCRIPTION
Sponge should only shade adventure-nbt due to it being unavailable on Sponge by default. 61818d1b7 caused a regression in this regard.