### PR TITLE
Nullable annotation for ProtocolManager.java and PlayerManager.java

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/player/PlayerManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/player/PlayerManager.java
@@ -26,15 +26,22 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface PlayerManager {
     int getPing(@NotNull Object player);
 
     @NotNull ClientVersion getClientVersion(@NotNull Object player);
 
-    Object getChannel(@NotNull Object player);
+    /**
+     * Gets the channel of a platform specific player object. This returns null if no channel for the player has been established.
+     */
+    @Nullable Object getChannel(@NotNull Object player);
 
-    User getUser(@NotNull Object player);
+    /**
+     * Get the user from the platform specific player object. This returns null if the player's channel is null.
+     */
+    @Nullable User getUser(@NotNull Object player);
 
     /**
      * <strong>WARNING</strong>: Usage of this method should be avoided. Please use either

--- a/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.PacketTransformationUtil;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -167,7 +168,7 @@ public interface ProtocolManager {
         PacketEvents.getAPI().getInjector().updateUser(channel, user);
     }
 
-    default Object getChannel(UUID uuid) {
+    default @Nullable Object getChannel(UUID uuid) {
         return CHANNELS.get(uuid);
     }
 

--- a/bungeecord/src/main/java/io/github/retrooper/packetevents/bungee/factory/BungeePacketEventsBuilder.java
+++ b/bungeecord/src/main/java/io/github/retrooper/packetevents/bungee/factory/BungeePacketEventsBuilder.java
@@ -134,12 +134,12 @@ public class BungeePacketEventsBuilder {
                 }
 
                 @Override
-                public Object getChannel(@NotNull Object player) {
+                public @Nullable Object getChannel(@NotNull Object player) {
                     return PacketEvents.getAPI().getProtocolManager().getChannel(((ProxiedPlayer) player).getUniqueId());
                 }
 
                 @Override
-                public User getUser(@NotNull Object player) {
+                public @Nullable User getUser(@NotNull Object player) {
                     ProxiedPlayer p = (ProxiedPlayer) player;
                     Object channel = getChannel(p);
                     User user = PacketEvents.getAPI().getProtocolManager().getUser(channel);

--- a/fabric-intermediary/src/client/java/io/github/retrooper/packetevents/factory/fabric/FabricClientPlayerManager.java
+++ b/fabric-intermediary/src/client/java/io/github/retrooper/packetevents/factory/fabric/FabricClientPlayerManager.java
@@ -21,6 +21,7 @@ package io.github.retrooper.packetevents.factory.fabric;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.player.LocalPlayer;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -42,7 +43,7 @@ public class FabricClientPlayerManager extends FabricPlayerManager {
     }
 
     @Override
-    public Object getChannel(Object player) {
+    public @Nullable Object getChannel(Object player) {
         if (player instanceof LocalPlayer) {
             return ((LocalPlayer) player).connection.getConnection().channel;
         }

--- a/fabric-intermediary/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPlayerManager.java
+++ b/fabric-intermediary/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPlayerManager.java
@@ -20,6 +20,7 @@ package io.github.retrooper.packetevents.factory.fabric;
 
 import io.github.retrooper.packetevents.impl.netty.manager.player.PlayerManagerAbstract;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -34,7 +35,7 @@ public class FabricPlayerManager extends PlayerManagerAbstract {
     }
 
     @Override
-    public Object getChannel(Object player) {
+    public @Nullable Object getChannel(Object player) {
         if (player instanceof ServerPlayer) {
             return ((ServerPlayer) player).connection.connection.channel;
         }

--- a/fabric-official/src/client/java/io/github/retrooper/packetevents/factory/fabric/FabricClientPlayerManager.java
+++ b/fabric-official/src/client/java/io/github/retrooper/packetevents/factory/fabric/FabricClientPlayerManager.java
@@ -21,6 +21,7 @@ package io.github.retrooper.packetevents.factory.fabric;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.player.LocalPlayer;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -42,7 +43,7 @@ public class FabricClientPlayerManager extends FabricPlayerManager {
     }
 
     @Override
-    public Object getChannel(Object player) {
+    public @Nullable Object getChannel(Object player) {
         if (player instanceof LocalPlayer) {
             return ((LocalPlayer) player).connection.getConnection().channel;
         }

--- a/fabric-official/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPlayerManager.java
+++ b/fabric-official/src/main/java/io/github/retrooper/packetevents/factory/fabric/FabricPlayerManager.java
@@ -20,6 +20,7 @@ package io.github.retrooper.packetevents.factory.fabric;
 
 import io.github.retrooper.packetevents.impl.netty.manager.player.PlayerManagerAbstract;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -34,7 +35,7 @@ public class FabricPlayerManager extends PlayerManagerAbstract {
     }
 
     @Override
-    public Object getChannel(Object player) {
+    public @Nullable Object getChannel(Object player) {
         if (player instanceof ServerPlayer) {
             return ((ServerPlayer) player).connection.connection.channel;
         }

--- a/netty-common/src/main/java/io/github/retrooper/packetevents/impl/netty/manager/player/PlayerManagerAbstract.java
+++ b/netty-common/src/main/java/io/github/retrooper/packetevents/impl/netty/manager/player/PlayerManagerAbstract.java
@@ -23,13 +23,14 @@ import com.github.retrooper.packetevents.manager.player.PlayerManager;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.player.User;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class PlayerManagerAbstract implements PlayerManager {
     @Override
     public abstract int getPing(@NotNull Object player);
 
     @Override
-    public abstract Object getChannel(@NotNull Object player);
+    public abstract @Nullable Object getChannel(@NotNull Object player);
 
     @Override
     public @NotNull ClientVersion getClientVersion(@NotNull Object player) {
@@ -37,7 +38,7 @@ public abstract class PlayerManagerAbstract implements PlayerManager {
     }
 
     @Override
-    public User getUser(@NotNull Object player) {
+    public @Nullable User getUser(@NotNull Object player) {
         Object channel = getChannel(player);
         return PacketEvents.getAPI().getProtocolManager().getUser(channel);
     }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/manager/player/PlayerManagerImpl.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/manager/player/PlayerManagerImpl.java
@@ -30,7 +30,7 @@ import io.github.retrooper.packetevents.util.protocolsupport.ProtocolSupportUtil
 import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.NotNull;import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;
@@ -88,7 +88,7 @@ public class PlayerManagerImpl implements PlayerManager {
     }
 
     @Override
-    public Object getChannel(@NotNull Object player) {
+    public @Nullable Object getChannel(@NotNull Object player) {
         UUID uuid = ((Player) player).getUniqueId();
         ProtocolManager protocolManager = PacketEvents.getAPI().getProtocolManager();
         Object channel = protocolManager.getChannel(uuid);
@@ -108,7 +108,7 @@ public class PlayerManagerImpl implements PlayerManager {
     }
 
     @Override
-    public User getUser(@NotNull Object player) {
+    public @Nullable User getUser(@NotNull Object player) {
         Player p = (Player) player;
         Object channel = getChannel(p);
 

--- a/spigot/src/main/java/io/github/retrooper/packetevents/manager/player/PlayerManagerImpl.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/manager/player/PlayerManagerImpl.java
@@ -30,7 +30,8 @@ import io.github.retrooper.packetevents.util.protocolsupport.ProtocolSupportUtil
 import io.github.retrooper.packetevents.util.viaversion.ViaVersionUtil;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/manager/player/PlayerManagerImpl.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/manager/player/PlayerManagerImpl.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import io.github.retrooper.packetevents.sponge.util.SpongeReflectionUtil;
 import io.github.retrooper.packetevents.sponge.util.viaversion.ViaVersionUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.network.ServerConnectionState;
 import org.spongepowered.api.network.ServerSideConnection;
@@ -67,7 +68,7 @@ public class PlayerManagerImpl implements PlayerManager {
     }
 
     @Override
-    public Object getChannel(@NotNull Object player) {
+    public @Nullable Object getChannel(@NotNull Object player) {
         UUID uuid = ((ServerPlayer) player).uniqueId();
         ProtocolManager protocolManager = PacketEvents.getAPI().getProtocolManager();
         Object channel = protocolManager.getChannel(uuid);
@@ -87,7 +88,7 @@ public class PlayerManagerImpl implements PlayerManager {
     }
 
     @Override
-    public User getUser(@NotNull Object player) {
+    public @Nullable User getUser(@NotNull Object player) {
         ServerPlayer p = (ServerPlayer) player;
         Object channel = getChannel(p);
 

--- a/velocity/src/main/java/io/github/retrooper/packetevents/manager/PlayerManagerImpl.java
+++ b/velocity/src/main/java/io/github/retrooper/packetevents/manager/PlayerManagerImpl.java
@@ -26,6 +26,7 @@ import com.velocitypowered.api.proxy.Player;
 import io.github.retrooper.packetevents.impl.netty.manager.player.PlayerManagerAbstract;
 import io.netty.channel.Channel;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class PlayerManagerImpl extends PlayerManagerAbstract {
     private static Class<?> CONNECTED_PLAYER, MINECRAFT_CONNECTION_CLASS;
@@ -35,7 +36,7 @@ public class PlayerManagerImpl extends PlayerManagerAbstract {
     }
 
     @Override
-    public Object getChannel(@NotNull Object player) {
+    public @Nullable Object getChannel(@NotNull Object player) {
         ProtocolManager protocolManager = PacketEvents.getAPI().getProtocolManager();
         Object channel = protocolManager.getChannel(((Player) player).getUniqueId());
         if (channel == null) {


### PR DESCRIPTION
This PR aims to add the `@Nullable` annotation to the `ProtocolManager.java` and `PlayerManager.java`. It is annoying having the IDE say that the value is never null when in reality it is. This could avoid a lot of bugs for users.