### PR TITLE
Fix incorrect sound pitch wrapping for 1.7-1.9

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSoundEffect.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSoundEffect.java
@@ -93,7 +93,7 @@ public class WrapperPlayServerSoundEffect extends PacketWrapper<WrapperPlayServe
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_10)) {
             pitch = readFloat();
         } else {
-            pitch = readUnsignedByte() / 63.5F;
+            pitch = readUnsignedByte() / 63.0F;
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             this.seed = readLong();
@@ -119,7 +119,7 @@ public class WrapperPlayServerSoundEffect extends PacketWrapper<WrapperPlayServe
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_10)) {
             writeFloat(pitch);
         } else {
-            writeByte((int) (pitch * 63.5F));
+            writeByte((int) (pitch * 63.0F));
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_19)) {
             writeLong(seed);


### PR DESCRIPTION
**Justification:**

1.7 Sound Packet:
<img width="242" height="178" alt="image" src="https://github.com/user-attachments/assets/ced54c47-b243-41c3-9249-3f7b4ca89c9c" />

1.8 Sound Packet:
<img width="325" height="55" alt="image" src="https://github.com/user-attachments/assets/6eb7d511-ad5b-427a-800a-73e0933dd9fe" />

1.9 Sound Packet:
<img width="334" height="56" alt="image" src="https://github.com/user-attachments/assets/590146d9-1e9a-4f53-b3b6-45e43c4be8d1" />

packetevents was reading and writing sound pitch multiplier as `63.5F`, but the client and server uses `63.0F`

that 0.5 really bothered me lmao