### PR TITLE
Optimize 1.18+ chunk palette reading

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/stream/NetStreamInputWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/stream/NetStreamInputWrapper.java
@@ -33,6 +33,59 @@ public class NetStreamInputWrapper extends NetStreamInput {
     }
 
     @Override
+    public byte readByte() {
+        return this.wrapper.readByte();
+    }
+
+    @Override
+    public int readUnsignedByte() {
+        return this.wrapper.readUnsignedByte();
+    }
+
+    @Override
+    public short readShort() {
+        return this.wrapper.readShort();
+    }
+
+    @Override
+    public int readUnsignedShort() {
+        return this.wrapper.readUnsignedShort();
+    }
+
+    @Override
+    public int readVarInt() {
+        return this.wrapper.readVarInt();
+    }
+
+    @Override
+    public long readLong() {
+        return this.wrapper.readLong();
+    }
+
+    @Override
+    public long[] readLongs(int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("Array cannot have length less than 0.");
+        }
+        long[] values = new long[length];
+        readLongs(values);
+        return values;
+    }
+
+    @Override
+    public int readLongs(long[] values) {
+        return this.readLongs(values, 0, values.length);
+    }
+
+    @Override
+    public int readLongs(long[] values, int offset, int length) {
+        for (int index = offset; index < offset + length; index++) {
+            values[index] = this.wrapper.readLong();
+        }
+        return length;
+    }
+
+    @Override
     public int read() {
         return this.wrapper.readUnsignedByte();
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
@@ -100,14 +100,10 @@ public class Chunk_v1_18 implements BaseChunk {
 
     public static Chunk_v1_18 read(PacketWrapper<?> wrapper) {
         ClientVersion version = wrapper.getServerVersion().toClientVersion();
-        boolean paletteLengthPrefix = version.isOlderThan(ClientVersion.V_1_21_5);
-        boolean hasFluidCount = version.isNewerThanOrEquals(ClientVersion.V_26_1);
         int blockCount = wrapper.readShort();
-        int fluidCount = hasFluidCount ? wrapper.readShort() : 0;
-        DataPalette chunkPalette = DataPalette.read(wrapper, PaletteType.CHUNK,
-                true, paletteLengthPrefix);
-        DataPalette biomePalette = DataPalette.read(wrapper, PaletteType.BIOME,
-                true, paletteLengthPrefix);
+        int fluidCount = version.isNewerThanOrEquals(ClientVersion.V_26_1) ? wrapper.readShort() : 0;
+        DataPalette chunkPalette = DataPalette.read(wrapper, PaletteType.CHUNK);
+        DataPalette biomePalette = DataPalette.read(wrapper, PaletteType.BIOME);
         return new Chunk_v1_18(version, blockCount, fluidCount, chunkPalette, biomePalette);
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/impl/v_1_18/Chunk_v1_18.java
@@ -22,7 +22,6 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
-import com.github.retrooper.packetevents.protocol.stream.NetStreamInputWrapper;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamOutput;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamOutputWrapper;
 import com.github.retrooper.packetevents.protocol.world.chunk.BaseChunk;
@@ -103,7 +102,13 @@ public class Chunk_v1_18 implements BaseChunk {
         ClientVersion version = wrapper.getServerVersion().toClientVersion();
         boolean paletteLengthPrefix = version.isOlderThan(ClientVersion.V_1_21_5);
         boolean hasFluidCount = version.isNewerThanOrEquals(ClientVersion.V_26_1);
-        return read(version, new NetStreamInputWrapper(wrapper), paletteLengthPrefix, hasFluidCount);
+        int blockCount = wrapper.readShort();
+        int fluidCount = hasFluidCount ? wrapper.readShort() : 0;
+        DataPalette chunkPalette = DataPalette.read(wrapper, PaletteType.CHUNK,
+                true, paletteLengthPrefix);
+        DataPalette biomePalette = DataPalette.read(wrapper, PaletteType.BIOME,
+                true, paletteLengthPrefix);
+        return new Chunk_v1_18(version, blockCount, fluidCount, chunkPalette, biomePalette);
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
@@ -18,12 +18,13 @@
 
 package com.github.retrooper.packetevents.protocol.world.chunk.palette;
 
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamInput;
 import com.github.retrooper.packetevents.protocol.stream.NetStreamOutput;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.BaseStorage;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.BitStorage;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.LegacyFlexibleStorage;
-import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class DataPalette {
@@ -78,24 +79,21 @@ public class DataPalette {
         return read(in, paletteType, allowSingletonPalette, true);
     }
 
-    public static DataPalette read(
-            PacketWrapper<?> wrapper, PaletteType paletteType,
-            boolean allowSingletonPalette, boolean lengthPrefix
-    ) {
+    public static DataPalette read(PacketWrapper<?> wrapper, PaletteType paletteType) {
         int bitsPerEntry = wrapper.readByte();
-        Palette palette = readPalette(paletteType, bitsPerEntry, wrapper, allowSingletonPalette);
+        Palette palette = readPalette(paletteType, bitsPerEntry, wrapper);
         BitStorage storage;
         if (!(palette instanceof SingletonPalette)) {
-            if (lengthPrefix) {
-                long[] data = readLongs(wrapper, wrapper.readVarInt());
+            if (wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_21_5)) {
+                long[] data = wrapper.readLongArray();
                 storage = new BitStorage(bitsPerEntry, paletteType.getStorageSize(), data);
             } else {
                 storage = new BitStorage(bitsPerEntry, paletteType.getStorageSize());
-                readLongsInto(wrapper, storage.getData());
+                wrapper.readLongArray(storage.getData());
             }
         } else {
-            if (lengthPrefix) {
-                skipLongs(wrapper, wrapper.readVarInt());
+            if (wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_21_5)) {
+                ByteBufHelper.skipBytes(wrapper.buffer, wrapper.readVarInt() * Long.BYTES);
             }
             storage = null;
         }
@@ -240,13 +238,8 @@ public class DataPalette {
         }
     }
 
-    private static Palette readPalette(
-            PaletteType paletteType,
-            int bitsPerEntry,
-            PacketWrapper<?> wrapper,
-            boolean allowSingletonPalette
-    ) {
-        if (bitsPerEntry == 0 && allowSingletonPalette) {
+    private static Palette readPalette(PaletteType paletteType, int bitsPerEntry, PacketWrapper<?> wrapper) {
+        if (bitsPerEntry == 0 && wrapper.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_18)) {
             return new SingletonPalette(wrapper);
         } else if (bitsPerEntry <= paletteType.getMaxBitsPerEntryForList()) {
             // vanilla forces a blockstate-list-palette to always be the maximum size
@@ -256,33 +249,6 @@ public class DataPalette {
             return new MapPalette(bitsPerEntry, wrapper);
         } else {
             return GlobalPalette.INSTANCE;
-        }
-    }
-
-    private static long[] readLongs(PacketWrapper<?> wrapper, int length) {
-        validateLongArrayLength(length);
-        long[] values = new long[length];
-        readLongsInto(wrapper, values);
-        return values;
-    }
-
-    private static void readLongsInto(PacketWrapper<?> wrapper, long[] target) {
-        for (int i = 0; i < target.length; i++) {
-            target[i] = wrapper.readLong();
-        }
-    }
-
-    private static void skipLongs(PacketWrapper<?> wrapper, int length) {
-        validateLongArrayLength(length);
-        ByteBufHelper.skipBytes(wrapper.buffer, length * Long.BYTES);
-    }
-
-    private static void validateLongArrayLength(int length) {
-        if (length < 0) {
-            throw new IllegalArgumentException("Array cannot have length less than 0.");
-        }
-        if (length > Integer.MAX_VALUE / Long.BYTES) {
-            throw new IllegalArgumentException("Long array byte length is too large: " + length);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/DataPalette.java
@@ -23,6 +23,7 @@ import com.github.retrooper.packetevents.protocol.stream.NetStreamOutput;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.BaseStorage;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.BitStorage;
 import com.github.retrooper.packetevents.protocol.world.chunk.storage.LegacyFlexibleStorage;
+import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
 public class DataPalette {
@@ -75,6 +76,31 @@ public class DataPalette {
     @Deprecated
     public static DataPalette read(NetStreamInput in, PaletteType paletteType, boolean allowSingletonPalette) {
         return read(in, paletteType, allowSingletonPalette, true);
+    }
+
+    public static DataPalette read(
+            PacketWrapper<?> wrapper, PaletteType paletteType,
+            boolean allowSingletonPalette, boolean lengthPrefix
+    ) {
+        int bitsPerEntry = wrapper.readByte();
+        Palette palette = readPalette(paletteType, bitsPerEntry, wrapper, allowSingletonPalette);
+        BitStorage storage;
+        if (!(palette instanceof SingletonPalette)) {
+            if (lengthPrefix) {
+                long[] data = readLongs(wrapper, wrapper.readVarInt());
+                storage = new BitStorage(bitsPerEntry, paletteType.getStorageSize(), data);
+            } else {
+                storage = new BitStorage(bitsPerEntry, paletteType.getStorageSize());
+                readLongsInto(wrapper, storage.getData());
+            }
+        } else {
+            if (lengthPrefix) {
+                skipLongs(wrapper, wrapper.readVarInt());
+            }
+            storage = null;
+        }
+
+        return new DataPalette(palette, storage, paletteType);
     }
 
     /**
@@ -211,6 +237,52 @@ public class DataPalette {
             return new MapPalette(bitsPerEntry, in);
         } else {
             return GlobalPalette.INSTANCE;
+        }
+    }
+
+    private static Palette readPalette(
+            PaletteType paletteType,
+            int bitsPerEntry,
+            PacketWrapper<?> wrapper,
+            boolean allowSingletonPalette
+    ) {
+        if (bitsPerEntry == 0 && allowSingletonPalette) {
+            return new SingletonPalette(wrapper);
+        } else if (bitsPerEntry <= paletteType.getMaxBitsPerEntryForList()) {
+            // vanilla forces a blockstate-list-palette to always be the maximum size
+            int bits = paletteType.isForceMaxListPaletteSize() ? paletteType.getMaxBitsPerEntryForList() : bitsPerEntry;
+            return new ListPalette(bits, wrapper);
+        } else if (bitsPerEntry <= paletteType.getMaxBitsPerEntryForMap()) {
+            return new MapPalette(bitsPerEntry, wrapper);
+        } else {
+            return GlobalPalette.INSTANCE;
+        }
+    }
+
+    private static long[] readLongs(PacketWrapper<?> wrapper, int length) {
+        validateLongArrayLength(length);
+        long[] values = new long[length];
+        readLongsInto(wrapper, values);
+        return values;
+    }
+
+    private static void readLongsInto(PacketWrapper<?> wrapper, long[] target) {
+        for (int i = 0; i < target.length; i++) {
+            target[i] = wrapper.readLong();
+        }
+    }
+
+    private static void skipLongs(PacketWrapper<?> wrapper, int length) {
+        validateLongArrayLength(length);
+        ByteBufHelper.skipBytes(wrapper.buffer, length * Long.BYTES);
+    }
+
+    private static void validateLongArrayLength(int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("Array cannot have length less than 0.");
+        }
+        if (length > Integer.MAX_VALUE / Long.BYTES) {
+            throw new IllegalArgumentException("Long array byte length is too large: " + length);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/PaletteType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/PaletteType.java
@@ -81,7 +81,7 @@ public enum PaletteType {
         }
         boolean allowSingletonPalette = wrapper.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_18);
         boolean lengthPrefix = wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_21_5);
-        return DataPalette.read(new NetStreamInputWrapper(wrapper), this, allowSingletonPalette, lengthPrefix);
+        return DataPalette.read(wrapper, this, allowSingletonPalette, lengthPrefix);
     }
 
     public DataPalette create() {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/PaletteType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/chunk/palette/PaletteType.java
@@ -79,9 +79,7 @@ public enum PaletteType {
         if (wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_16)) {
             return DataPalette.readLegacy(new NetStreamInputWrapper(wrapper));
         }
-        boolean allowSingletonPalette = wrapper.getServerVersion().isNewerThanOrEquals(ServerVersion.V_1_18);
-        boolean lengthPrefix = wrapper.getServerVersion().isOlderThan(ServerVersion.V_1_21_5);
-        return DataPalette.read(wrapper, this, allowSingletonPalette, lengthPrefix);
+        return DataPalette.read(wrapper, this);
     }
 
     public DataPalette create() {

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/PacketWrapper.java
@@ -832,8 +832,10 @@ public class PacketWrapper<T extends PacketWrapper<T>> {
         if (size > readableBytes) {
             throw new IllegalStateException("LongArray with size " + size + " is bigger than allowed " + readableBytes);
         }
-        long[] array = new long[size];
+        return this.readLongArray(new long[size]);
+    }
 
+    public long[] readLongArray(long[] array) {
         for (int i = 0; i < array.length; i++) {
             array[i] = readLong();
         }


### PR DESCRIPTION
Improves chunk decode performance by replacing the slow NetStreamInput.readLong() palette path with direct PacketWrapper primitive reads. This avoids per-long byte-array allocation and removes the readBytes / copyMemory hotspot shown in Spark during chunk packet processing.

Testing phase in progress. Will report back when done.