### PR TITLE
Instantly run task after write operation

### DIFF
--- a/fabric-common/src/main/java/io/github/retrooper/packetevents/handler/PacketDecoder.java
+++ b/fabric-common/src/main/java/io/github/retrooper/packetevents/handler/PacketDecoder.java
@@ -18,6 +18,9 @@
 
 package io.github.retrooper.packetevents.handler;
 
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
+import com.github.retrooper.packetevents.exception.PacketProcessException;
 import com.github.retrooper.packetevents.protocol.PacketSide;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
@@ -48,10 +51,20 @@ public class PacketDecoder extends MessageToMessageDecoder<ByteBuf> {
         if (!msg.isReadable()) {
             return;
         }
-        PacketEventsImplHelper.handlePacket(ctx.channel(), this.user, this.player,
+        ProtocolPacketEvent event = PacketEventsImplHelper.handlePacket(ctx.channel(), this.user, this.player,
                 msg, false, this.side);
         if (msg.isReadable()) {
             out.add(msg.retain());
+        }
+
+        if (event instanceof PacketSendEvent sendEvent && sendEvent.hasTasksAfterSend()) {
+            for (Runnable task : sendEvent.getTasksAfterSend()) {
+                try {
+                    task.run();
+                } catch (Throwable throwable) {
+                    throw new PacketProcessException("Error while handling post-send-task " + task + " for " + event, throwable);
+                }
+            }
         }
     }
 }

--- a/fabric-common/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
+++ b/fabric-common/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
@@ -18,6 +18,9 @@
 
 package io.github.retrooper.packetevents.handler;
 
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.event.ProtocolPacketEvent;
+import com.github.retrooper.packetevents.exception.PacketProcessException;
 import com.github.retrooper.packetevents.protocol.PacketSide;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
@@ -53,10 +56,21 @@ public class PacketEncoder extends ChannelOutboundHandlerAdapter {
             return;
         }
 
-        PacketEventsImplHelper.handlePacket(ctx.channel(),
+        ProtocolPacketEvent event = PacketEventsImplHelper.handlePacket(ctx.channel(),
                 this.user, this.player, in, false, this.side);
         if (in.isReadable()) {
             ctx.write(in, promise);
+        }
+
+        // TODO why do these tasks only exist for the "send" (clientbound) event?
+        if (event instanceof PacketSendEvent sendEvent && sendEvent.hasTasksAfterSend()) {
+            for (Runnable task : sendEvent.getTasksAfterSend()) {
+                try {
+                    task.run();
+                } catch (Throwable throwable) {
+                    throw new PacketProcessException("Error while handling post-send-task " + task + " for " + event, throwable);
+                }
+            }
         }
     }
 }

--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/handlers/PacketEventsEncoder.java
@@ -33,6 +33,7 @@ import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 import io.github.retrooper.packetevents.util.viaversion.CustomPipelineUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -41,7 +42,6 @@ import io.netty.util.ReferenceCountUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayDeque;
@@ -57,7 +57,7 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         // https://howoldisminecraft188.today/
         boolean netty410 = false;
         try {
-            ChannelPromise.class.getDeclaredMethod("unvoid");
+            ChannelFuture.class.getDeclaredMethod("isVoid");
             netty410 = true;
         } catch (NoSuchMethodException ignored) {
         }
@@ -67,7 +67,6 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
     public User user;
     public Player player;
     private boolean handledCompression = COMPRESSION_ENABLED_EVENT != null;
-    private ChannelPromise promise;
 
     private final Queue<QueuedMessage> queuedMessages = new ArrayDeque<>();
     private boolean hold = false;
@@ -80,7 +79,6 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         user = ((PacketEventsEncoder) encoder).user;
         player = ((PacketEventsEncoder) encoder).player;
         handledCompression = ((PacketEventsEncoder) encoder).handledCompression;
-        promise = ((PacketEventsEncoder) encoder).promise;
     }
 
     public void setHold(Channel ch, boolean hold) throws Exception {
@@ -98,18 +96,6 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         }
     }
 
-    private @Nullable PacketSendEvent handleClientBoundPacket(Channel channel, User user, Object player, ByteBuf buffer, ChannelPromise promise) throws Exception {
-        PacketSendEvent packetSendEvent = PacketEventsImplHelper.handleClientBoundPacket(channel, user, player, buffer, true);
-        if (packetSendEvent != null && packetSendEvent.hasTasksAfterSend()) {
-            promise.addListener((p) -> {
-                for (Runnable task : packetSendEvent.getTasksAfterSend()) {
-                    task.run();
-                }
-            });
-        }
-        return packetSendEvent;
-    }
-
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         // if we are told to hold all messages, add them to the queue
@@ -118,20 +104,10 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
             return;
         }
 
-        // We must restore the old promise (in case we are stacking promises such as sending packets on send event)
-        // If the old promise was successful, set it to null to avoid memory leaks.
-        ChannelPromise oldPromise = this.promise != null && !this.promise.isSuccess() ? this.promise : null;
-        if (NETTY_4_1_0) {
-            // "unvoid" will just make sure we can actually add listeners to this promise...
-            // since 1.21.6, mojang will give us void promises when they don't care about the result
-            promise = promise.unvoid();
-        }
-        promise.addListener(p -> this.promise = oldPromise);
-        this.promise = promise;
-
+        PacketSendEvent packetSendEvent = null;
         if (msg instanceof ByteBuf) {
             boolean needsRecompression = !this.handledCompression && this.handleCompression(ctx, (ByteBuf) msg);
-            this.handleClientBoundPacket(ctx.channel(), this.user, this.player, (ByteBuf) msg, this.promise);
+            packetSendEvent = PacketEventsImplHelper.handleClientBoundPacket(ctx.channel(), this.user, this.player, msg, true);
 
             // check if the packet got cancelled
             if (!((ByteBuf) msg).isReadable()) {
@@ -146,6 +122,16 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         }
 
         ctx.write(msg, promise);
+
+        if (packetSendEvent != null && packetSendEvent.hasTasksAfterSend()) {
+            for (Runnable task : packetSendEvent.getTasksAfterSend()) {
+                try {
+                    task.run();
+                } catch (Throwable throwable) {
+                    throw new PacketProcessException("Error while handling post-send-task " + task + " for " + packetSendEvent, throwable);
+                }
+            }
+        }
     }
 
     @Override

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
@@ -23,7 +23,6 @@ import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.exception.CancelPacketException;
 import com.github.retrooper.packetevents.exception.InvalidDisconnectPacketSend;
 import com.github.retrooper.packetevents.exception.PacketProcessException;
-import com.github.retrooper.packetevents.netty.buffer.ByteBufHelper;
 import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.ExceptionUtil;
@@ -66,13 +65,14 @@ public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
         Object player = this.player == null ? null : Sponge.server().player(this.player).orElse(null);
         PacketSendEvent event = PacketEventsImplHelper.handleClientBoundPacket(ctx.channel(), user, player, byteBuf, true);
 
-        if (needsRecompression) {
-            compress(ctx, byteBuf);
+        if (!byteBuf.isReadable()) {
+            byteBuf.release();
+            promise.trySuccess();
+            return;
         }
 
-        // So apparently, this is how ViaVersion hacks around bungeecord not supporting sending empty packets
-        if (!ByteBufHelper.isReadable(byteBuf)) {
-            throw CancelPacketException.INSTANCE;
+        if (needsRecompression) {
+            compress(ctx, byteBuf);
         }
 
         ctx.write(byteBuf, promise);

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/handlers/PacketEventsEncoder.java
@@ -31,24 +31,20 @@ import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
 import io.github.retrooper.packetevents.sponge.injector.connection.ServerConnectionInitializer;
 import io.github.retrooper.packetevents.sponge.util.viaversion.CustomPipelineUtil;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.MessageToMessageEncoder;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.api.Sponge;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import java.util.UUID;
 
-public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
+public class PacketEventsEncoder extends ChannelOutboundHandlerAdapter {
 
     public User user;
     public UUID player;
     private boolean handledCompression;
-    private ChannelPromise promise;
 
     public PacketEventsEncoder(User user) {
         this.user = user;
@@ -58,13 +54,17 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
         user = ((PacketEventsEncoder) encoder).user;
         player = ((PacketEventsEncoder) encoder).player;
         handledCompression = ((PacketEventsEncoder) encoder).handledCompression;
-        promise = ((PacketEventsEncoder) encoder).promise;
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> list) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (!(msg instanceof ByteBuf byteBuf)) {
+            super.write(ctx, msg, promise);
+            return;
+        }
         boolean needsRecompression = !handledCompression && handleCompression(ctx, byteBuf);
-        handleClientBoundPacket(ctx.channel(), user, player, byteBuf, this.promise);
+        Object player = this.player == null ? null : Sponge.server().player(this.player).orElse(null);
+        PacketSendEvent event = PacketEventsImplHelper.handleClientBoundPacket(ctx.channel(), user, player, byteBuf, true);
 
         if (needsRecompression) {
             compress(ctx, byteBuf);
@@ -75,35 +75,18 @@ public class PacketEventsEncoder extends MessageToMessageEncoder<ByteBuf> {
             throw CancelPacketException.INSTANCE;
         }
 
-        list.add(byteBuf.retain());
-    }
+        ctx.write(byteBuf, promise);
 
-    private @Nullable PacketSendEvent handleClientBoundPacket(Channel channel, User user, UUID player, ByteBuf buffer, ChannelPromise promise) throws Exception {
-        PacketSendEvent packetSendEvent = PacketEventsImplHelper.handleClientBoundPacket(channel, user, player == null ? null : Sponge.server().player(player).orElse(null), buffer, true);
-        if (packetSendEvent != null && packetSendEvent.hasTasksAfterSend()) {
-            promise.addListener((p) -> {
-                for (Runnable task : packetSendEvent.getTasksAfterSend()) {
+        if (event != null && event.hasTasksAfterSend()) {
+            for (Runnable task : event.getTasksAfterSend()) {
+                try {
                     task.run();
+                } catch (Throwable throwable) {
+                    throw new PacketProcessException("Error while handling post-send-task " + task + " for " + event, throwable);
                 }
-            });
+            }
         }
-        return packetSendEvent;
     }
-
-    @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        // We must restore the old promise (in case we are stacking promises such as sending packets on send event)
-        // If the old promise was successful, set it to null to avoid memory leaks.
-        ChannelPromise oldPromise = this.promise != null && !this.promise.isSuccess() ? this.promise : null;
-        if (promise.isVoid()) {
-            promise = ctx.newPromise();
-        }
-        promise.addListener(p -> this.promise = oldPromise);
-
-        this.promise = promise;
-        super.write(ctx, msg, promise);
-    }
-
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {


### PR DESCRIPTION
Once again #1460 
> Right now it's possible other packets get written before the promise is completed, If you want to write a packet right after another packet using getTasksAfterSend it's possible another packet gets written inbetween. This solves it for spigot (sponge needs a different type of implementation, probably overwriting the whole write function to execute the tasks).

However this seems to have caused issues

> @Axionize (packetevents discord): 
https://github.com/GrimAnticheat/Grim/issues/2589
https://github.com/GrimAnticheat/Grim/issues/2588
https://github.com/GrimAnticheat/Grim/issues/2587
https://github.com/GrimAnticheat/Grim/issues/2586
https://github.com/GrimAnticheat/Grim/issues/2586
BadpacketsN also starts flagging
amongst many otherthings

Marked as draft until the issues have been fixed 