### PR TITLE
Add nettystom (Minestom) platform module

### DIFF
--- a/nettystom/build.gradle.kts
+++ b/nettystom/build.gradle.kts
@@ -1,0 +1,54 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+plugins {
+    packetevents.`shadow-conventions`
+    packetevents.`library-conventions`
+}
+
+repositories {
+    mavenLocal() // resolves your locally published nettystom (net.minestom:minestom)
+    mavenCentral()
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
+}
+
+dependencies {
+    // nettystom is a Netty-based Minestom fork; published locally as net.minestom:minestom.
+    // Replace the coordinates/version below with your own server's coordinates if needed.
+    compileOnly("net.minestom:minestom:dev")
+
+    compileOnly(libs.netty)
+    compileOnly(libs.bundles.adventure)
+    compileOnly(libs.gson)
+    compileOnly(libs.slf4j.api)
+
+    shadow(project(":api", "shadow"))
+    shadow(project(":netty-common"))
+}
+
+// nettystom is compiled with a modern JDK (Java 25 bytecode), so this module must be
+// compiled with a toolchain capable of reading those class files.
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.release = 25
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/NettystomPacketEvents.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/NettystomPacketEvents.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.settings.PacketEventsSettings;
+import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import io.github.retrooper.packetevents.factory.nettystom.NettystomPacketEventsBuilder;
+import io.github.retrooper.packetevents.injector.NettystomConnectionInitializer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Convenience facade for embedding packetevents in a nettystom server.
+ *
+ * <p>Because nettystom handles framing, compression and encryption inside
+ * {@code PlayerSocketConnection} (not as Netty pipeline handlers), the recommended
+ * integration is to call {@link #handleServerBound(Channel, ByteBuf)} /
+ * {@link #handleClientBound(Channel, ByteBuf)} from your server at the points where the
+ * buffer contains a single, plaintext packet. See the module README for details.
+ */
+public final class NettystomPacketEvents {
+
+    private NettystomPacketEvents() {
+    }
+
+    /**
+     * Builds and registers the global {@link PacketEventsAPI} instance for this server.
+     * You still need to call {@code PacketEvents.getAPI().load()} and {@code init()}.
+     */
+    public static PacketEventsAPI<Object> create(String id) {
+        PacketEventsAPI<Object> api = NettystomPacketEventsBuilder.build(id);
+        PacketEvents.setAPI(api);
+        return api;
+    }
+
+    /**
+     * Builds and registers the global {@link PacketEventsAPI} instance for this server.
+     */
+    public static PacketEventsAPI<Object> create(String id, PacketEventsSettings settings) {
+        PacketEventsAPI<Object> api = NettystomPacketEventsBuilder.build(id, settings);
+        PacketEvents.setAPI(api);
+        return api;
+    }
+
+    /**
+     * Registers a new connection with packetevents. Call this once a channel is opened.
+     *
+     * @return the created {@link User}, or {@code null} if the connection was rejected.
+     */
+    public static @Nullable User onConnect(Channel channel, ConnectionState state, ClientVersion clientVersion) {
+        return NettystomConnectionInitializer.initChannel(channel, state, clientVersion);
+    }
+
+    /**
+     * Notifies packetevents that a connection has been closed.
+     */
+    public static void onDisconnect(Channel channel, @Nullable UUID uuid) {
+        PacketEventsImplHelper.handleDisconnection(channel, uuid);
+    }
+
+    /**
+     * Associates a nettystom player with an already-registered connection.
+     */
+    public static void setPlayer(Channel channel, Object player) {
+        PacketEvents.getAPI().getInjector().setPlayer(channel, player);
+    }
+
+    /**
+     * Processes an inbound (server-bound) plaintext packet buffer through packetevents.
+     *
+     * @return the fired {@link PacketReceiveEvent} (check {@link PacketReceiveEvent#isCancelled()}),
+     * or {@code null} if there was no user for the channel or the buffer was empty.
+     */
+    public static @Nullable PacketReceiveEvent handleServerBound(Channel channel, ByteBuf buffer) throws Exception {
+        User user = PacketEvents.getAPI().getProtocolManager().getUser(channel);
+        if (user == null) {
+            return null;
+        }
+        return PacketEventsImplHelper.handleServerBoundPacket(channel, user, null, buffer, false);
+    }
+
+    /**
+     * Processes an outbound (client-bound) plaintext packet buffer through packetevents.
+     *
+     * @return the fired {@link PacketSendEvent} (check {@link PacketSendEvent#isCancelled()}),
+     * or {@code null} if there was no user for the channel or the buffer was empty.
+     */
+    public static @Nullable PacketSendEvent handleClientBound(Channel channel, ByteBuf buffer) throws Exception {
+        User user = PacketEvents.getAPI().getProtocolManager().getUser(channel);
+        if (user == null) {
+            return null;
+        }
+        return PacketEventsImplHelper.handleClientBoundPacket(channel, user, null, buffer, false);
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomChannelInjector.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomChannelInjector.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.injector.ChannelInjector;
+import com.github.retrooper.packetevents.protocol.PacketSide;
+import com.github.retrooper.packetevents.protocol.player.User;
+import io.github.retrooper.packetevents.handler.PacketDecoder;
+import io.github.retrooper.packetevents.handler.PacketEncoder;
+import io.netty.channel.Channel;
+import org.jetbrains.annotations.Nullable;
+
+import static com.github.retrooper.packetevents.PacketEvents.DECODER_NAME;
+import static com.github.retrooper.packetevents.PacketEvents.ENCODER_NAME;
+
+/**
+ * nettystom is a self-hosted server framework whose source you control, so unlike the
+ * Bukkit/Velocity platforms there is nothing to reflectively inject into: connections are
+ * registered explicitly through
+ * {@link io.github.retrooper.packetevents.injector.NettystomConnectionInitializer}.
+ */
+public class NettystomChannelInjector implements ChannelInjector {
+
+    @Override
+    public void inject() {
+        // NO-OP - connections are wired explicitly by the server, see NettystomConnectionInitializer
+    }
+
+    @Override
+    public void uninject() {
+        // NO-OP
+    }
+
+    @Override
+    public boolean isPlayerSet(@Nullable Object ch) {
+        if (ch == null) return false;
+        Channel channel = (Channel) ch;
+        PacketEncoder encoder = (PacketEncoder) channel.pipeline().get(ENCODER_NAME);
+        if (encoder != null && encoder.player != null) return true;
+        PacketDecoder decoder = (PacketDecoder) channel.pipeline().get(DECODER_NAME);
+        return decoder != null && decoder.player != null;
+    }
+
+    @Override
+    public void updateUser(Object channel, User user) {
+        if (!PacketEvents.getAPI().getProtocolManager().hasChannel(channel)) {
+            return; // this channel isn't injected by packetevents
+        }
+        Channel ch = (Channel) channel;
+        PacketDecoder decoder = (PacketDecoder) ch.pipeline().get(DECODER_NAME);
+        if (decoder != null) decoder.user = user;
+        PacketEncoder encoder = (PacketEncoder) ch.pipeline().get(ENCODER_NAME);
+        if (encoder != null) encoder.user = user;
+    }
+
+    @Override
+    public void setPlayer(Object channel, Object player) {
+        if (!PacketEvents.getAPI().getProtocolManager().hasChannel(channel)) {
+            return; // this channel isn't injected by packetevents
+        }
+        Channel ch = (Channel) channel;
+        PacketDecoder decoder = (PacketDecoder) ch.pipeline().get(DECODER_NAME);
+        if (decoder != null) decoder.player = player;
+        PacketEncoder encoder = (PacketEncoder) ch.pipeline().get(ENCODER_NAME);
+        if (encoder != null) encoder.player = player;
+    }
+
+    @Override
+    public boolean isProxy() {
+        return false;
+    }
+
+    @Override
+    public PacketSide getPacketSide() {
+        return PacketSide.SERVER;
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPacketEventsAPI.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPacketEventsAPI.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.injector.ChannelInjector;
+import com.github.retrooper.packetevents.manager.player.PlayerManager;
+import com.github.retrooper.packetevents.manager.protocol.ProtocolManager;
+import com.github.retrooper.packetevents.manager.server.ServerManager;
+import com.github.retrooper.packetevents.netty.NettyManager;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.settings.PacketEventsSettings;
+import io.github.retrooper.packetevents.impl.netty.NettyManagerImpl;
+
+import java.util.Locale;
+
+/**
+ * Standalone {@link PacketEventsAPI} implementation for a nettystom server.
+ *
+ * <p>nettystom does not have a plugin/mod container, so the generic plugin type is simply
+ * an opaque identifier object supplied by the embedding server. The {@code LogManager} is
+ * resolved automatically by the core (SLF4J/Adventure are present on a nettystom server).
+ */
+public class NettystomPacketEventsAPI extends PacketEventsAPI<Object> {
+
+    private final Object plugin;
+    private final String id;
+    private final PacketEventsSettings settings;
+
+    private final ProtocolManager protocolManager = new NettystomProtocolManager();
+    private final ServerManager serverManager;
+    private final PlayerManager playerManager = new NettystomPlayerManager();
+    private final ChannelInjector injector = new NettystomChannelInjector();
+    private final NettyManager nettyManager = new NettyManagerImpl();
+
+    private boolean loaded;
+    private boolean initialized;
+    private boolean terminated;
+
+    public NettystomPacketEventsAPI(Object plugin, String id, PacketEventsSettings settings,
+                                    ServerManager serverManager) {
+        this.plugin = plugin;
+        this.id = id;
+        this.settings = settings;
+        this.serverManager = serverManager;
+    }
+
+    @Override
+    public void load() {
+        if (this.loaded) {
+            return;
+        }
+        String identifier = this.id.toLowerCase(Locale.ROOT);
+        PacketEvents.IDENTIFIER = "pe-" + identifier;
+        PacketEvents.ENCODER_NAME = "pe-encoder-" + identifier;
+        PacketEvents.DECODER_NAME = "pe-decoder-" + identifier;
+        PacketEvents.CONNECTION_HANDLER_NAME = "pe-connection-handler-" + identifier;
+        PacketEvents.SERVER_CHANNEL_HANDLER_NAME = "pe-connection-initializer-" + identifier;
+        PacketEvents.TIMEOUT_HANDLER_NAME = "pe-timeout-handler-" + identifier;
+
+        super.load();
+        this.loaded = true;
+    }
+
+    @Override
+    public boolean isLoaded() {
+        return this.loaded;
+    }
+
+    @Override
+    public void init() {
+        this.load();
+        if (this.initialized) {
+            return;
+        }
+        if (this.settings.shouldCheckForUpdates()) {
+            this.getUpdateChecker().handleUpdateCheck();
+        }
+
+        PacketType.Play.Client.load();
+        PacketType.Play.Server.load();
+        this.initialized = true;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return this.initialized;
+    }
+
+    @Override
+    public void terminate() {
+        if (!this.initialized) {
+            return;
+        }
+        super.terminate();
+        this.initialized = false;
+        this.terminated = true;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return this.terminated;
+    }
+
+    @Override
+    public Object getPlugin() {
+        return this.plugin;
+    }
+
+    @Override
+    public ProtocolManager getProtocolManager() {
+        return this.protocolManager;
+    }
+
+    @Override
+    public ServerManager getServerManager() {
+        return this.serverManager;
+    }
+
+    @Override
+    public PlayerManager getPlayerManager() {
+        return this.playerManager;
+    }
+
+    @Override
+    public ChannelInjector getInjector() {
+        return this.injector;
+    }
+
+    @Override
+    public NettyManager getNettyManager() {
+        return this.nettyManager;
+    }
+
+    @Override
+    public PacketEventsSettings getSettings() {
+        return this.settings;
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPacketEventsBuilder.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPacketEventsBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.manager.server.ServerManager;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.settings.PacketEventsSettings;
+
+/**
+ * Entry point for building a {@link PacketEventsAPI} instance on a nettystom server.
+ *
+ * <pre>{@code
+ * PacketEvents.setAPI(NettystomPacketEventsBuilder.build("my-server"));
+ * PacketEvents.getAPI().load();
+ * // register listeners ...
+ * PacketEvents.getAPI().init();
+ * }</pre>
+ */
+public final class NettystomPacketEventsBuilder {
+
+    private static PacketEventsAPI<Object> INSTANCE;
+
+    private NettystomPacketEventsBuilder() {
+    }
+
+    public static void clearBuildCache() {
+        INSTANCE = null;
+    }
+
+    public static PacketEventsAPI<Object> build(String id) {
+        if (INSTANCE == null) {
+            INSTANCE = buildNoCache(id);
+        }
+        return INSTANCE;
+    }
+
+    public static PacketEventsAPI<Object> build(String id, PacketEventsSettings settings) {
+        if (INSTANCE == null) {
+            INSTANCE = buildNoCache(id, settings);
+        }
+        return INSTANCE;
+    }
+
+    public static PacketEventsAPI<Object> build(String id, ServerVersion version, PacketEventsSettings settings) {
+        if (INSTANCE == null) {
+            INSTANCE = buildNoCache(id, version, settings);
+        }
+        return INSTANCE;
+    }
+
+    public static PacketEventsAPI<Object> buildNoCache(String id) {
+        return buildNoCache(id, new PacketEventsSettings());
+    }
+
+    public static PacketEventsAPI<Object> buildNoCache(String id, PacketEventsSettings settings) {
+        return buildNoCache(id, ServerVersion.V_1_21_11, settings);
+    }
+
+    public static PacketEventsAPI<Object> buildNoCache(String id, ServerVersion version, PacketEventsSettings settings) {
+        ServerManager serverManager = new NettystomServerManager(version);
+        return new NettystomPacketEventsAPI(id, id, settings, serverManager);
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPlayerManager.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomPlayerManager.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import io.github.retrooper.packetevents.impl.netty.manager.player.PlayerManagerAbstract;
+import io.github.retrooper.packetevents.util.NettystomConversionUtil;
+import net.minestom.server.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class NettystomPlayerManager extends PlayerManagerAbstract {
+
+    @Override
+    public int getPing(@NotNull Object player) {
+        if (player instanceof Player p) {
+            return p.getLatency();
+        }
+        throw new UnsupportedOperationException("Unsupported player implementation: " + player);
+    }
+
+    @Override
+    public Object getChannel(@NotNull Object player) {
+        if (player instanceof Player p) {
+            return NettystomConversionUtil.getChannel(p);
+        }
+        throw new UnsupportedOperationException("Unsupported player implementation: " + player);
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomProtocolManager.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomProtocolManager.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import com.github.retrooper.packetevents.protocol.ProtocolVersion;
+import io.github.retrooper.packetevents.impl.netty.manager.protocol.ProtocolManagerAbstract;
+
+public class NettystomProtocolManager extends ProtocolManagerAbstract {
+
+    @Override
+    public ProtocolVersion getPlatformVersion() {
+        return ProtocolVersion.UNKNOWN;
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomServerManager.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/factory/nettystom/NettystomServerManager.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.factory.nettystom;
+
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.mappings.GlobalRegistryHolder;
+import io.github.retrooper.packetevents.impl.netty.manager.server.ServerManagerAbstract;
+
+public class NettystomServerManager extends ServerManagerAbstract {
+
+    private final ServerVersion version;
+
+    public NettystomServerManager() {
+        this(ServerVersion.V_1_21_11);
+    }
+
+    public NettystomServerManager(ServerVersion version) {
+        this.version = version;
+    }
+
+    /**
+     * Resolves a packetevents {@link ServerVersion} from a Minecraft release name
+     * (e.g. {@code "1.21.11"}).
+     */
+    public static ServerVersion resolveVersion(String mcVersion) {
+        for (ServerVersion version : ServerVersion.reversedValues()) {
+            if (mcVersion.contains(version.getReleaseName())) {
+                return version;
+            }
+        }
+        throw new IllegalStateException("PacketEvents doesn't support Minecraft version: " + mcVersion);
+    }
+
+    @Override
+    public ServerVersion getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public Object getRegistryCacheKey(User user, ClientVersion version) {
+        return GlobalRegistryHolder.getGlobalRegistryCacheKey(user, version);
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/handler/PacketDecoder.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/handler/PacketDecoder.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.handler;
+
+import com.github.retrooper.packetevents.protocol.PacketSide;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Inbound (server-bound) packetevents handler.
+ *
+ * <p>This handler must be placed at a point in the pipeline where the {@link ByteBuf}
+ * holds a <b>single, decrypted and decompressed</b> Minecraft packet (i.e. starting with
+ * the packet-id var-int). See the module README for how to wire this into a nettystom
+ * server.
+ */
+@ApiStatus.Internal
+public class PacketDecoder extends MessageToMessageDecoder<ByteBuf> {
+
+    private final PacketSide side;
+    public User user;
+    public @Nullable Object player;
+
+    public PacketDecoder(PacketSide side, User user) {
+        this.side = side.getOpposite();
+        this.user = user;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+        if (!msg.isReadable()) {
+            return;
+        }
+        PacketEventsImplHelper.handlePacket(ctx.channel(), this.user, this.player,
+                msg, false, this.side);
+        if (msg.isReadable()) {
+            out.add(msg.retain());
+        }
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/handler/PacketEncoder.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.handler;
+
+import com.github.retrooper.packetevents.protocol.PacketSide;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Outbound (client-bound) packetevents handler.
+ *
+ * <p>This handler must be placed at a point in the pipeline where the {@link ByteBuf}
+ * being written holds a <b>single, uncompressed and unencrypted</b> Minecraft packet
+ * (i.e. starting with the packet-id var-int). See the module README for how to wire this
+ * into a nettystom server.
+ */
+@ApiStatus.Internal
+public class PacketEncoder extends ChannelOutboundHandlerAdapter {
+
+    private final PacketSide side;
+    public User user;
+    public @Nullable Object player;
+
+    public PacketEncoder(PacketSide side, User user) {
+        this.side = side;
+        this.user = user;
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (!(msg instanceof ByteBuf in)) {
+            ctx.write(msg, promise);
+            return;
+        }
+        if (!in.isReadable()) {
+            in.release();
+            return;
+        }
+
+        PacketEventsImplHelper.handlePacket(ctx.channel(),
+                this.user, this.player, in, false, this.side);
+        if (in.isReadable()) {
+            ctx.write(in, promise);
+        } else {
+            in.release();
+        }
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/injector/NettystomConnectionInitializer.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/injector/NettystomConnectionInitializer.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.injector;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.UserConnectEvent;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import com.github.retrooper.packetevents.protocol.PacketSide;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.protocol.player.UserProfile;
+import com.github.retrooper.packetevents.util.PacketEventsImplHelper;
+import io.github.retrooper.packetevents.handler.PacketDecoder;
+import io.github.retrooper.packetevents.handler.PacketEncoder;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Registers a nettystom connection with packetevents.
+ *
+ * <p>Call {@link #initChannel(Channel, ConnectionState, ClientVersion)} once per
+ * connection (typically right after nettystom adds its own {@code frame-decoder} /
+ * {@code handler}).
+ *
+ * <p><b>Important:</b> nettystom performs compression and encryption inside
+ * {@code PlayerSocketConnection} rather than as Netty pipeline handlers, so the
+ * {@link PacketDecoder}/{@link PacketEncoder} added here must be placed where the buffer
+ * holds plaintext, single packets. See the module README for the recommended wiring.
+ */
+@ApiStatus.Internal
+public final class NettystomConnectionInitializer {
+
+    private NettystomConnectionInitializer() {
+    }
+
+    /**
+     * Registers the connection, fires {@link UserConnectEvent} and adds the packetevents
+     * handlers right after nettystom's {@code frame-decoder}.
+     *
+     * @return the created {@link User}, or {@code null} if the connect event was cancelled.
+     */
+    public static @Nullable User initChannel(Channel channel, ConnectionState state, ClientVersion clientVersion) {
+        return initChannel(channel, state, clientVersion, "frame-decoder", "frame-decoder");
+    }
+
+    /**
+     * Registers the connection and adds the packetevents handlers relative to the given
+     * pipeline anchors.
+     *
+     * @param decoderAfter  name of the handler the inbound decoder is added <i>after</i>
+     * @param encoderBefore name of the handler the outbound encoder is added <i>before</i>
+     */
+    public static @Nullable User initChannel(Channel channel, ConnectionState state, ClientVersion clientVersion,
+                                             String decoderAfter, String encoderBefore) {
+        User user = new User(channel, state, clientVersion, new UserProfile(null, null));
+
+        UserConnectEvent connectEvent = new UserConnectEvent(user);
+        PacketEvents.getAPI().getEventManager().callEvent(connectEvent);
+        if (connectEvent.isCancelled()) {
+            channel.unsafe().closeForcibly();
+            return null;
+        }
+
+        PacketEvents.getAPI().getProtocolManager().setUser(channel, user);
+
+        PacketSide side = PacketEvents.getAPI().getInjector().getPacketSide();
+        channel.pipeline().addAfter(decoderAfter, PacketEvents.DECODER_NAME, new PacketDecoder(side, user));
+        channel.pipeline().addBefore(encoderBefore, PacketEvents.ENCODER_NAME, new PacketEncoder(side, user));
+
+        channel.closeFuture().addListener((ChannelFutureListener) future ->
+                PacketEventsImplHelper.handleDisconnection(user.getChannel(), user.getUUID()));
+        return user;
+    }
+
+    /**
+     * Removes the packetevents handlers from the channel pipeline, if present.
+     */
+    public static void destroyChannel(Channel channel) {
+        if (channel.pipeline().get(PacketEvents.DECODER_NAME) != null) {
+            channel.pipeline().remove(PacketEvents.DECODER_NAME);
+        }
+        if (channel.pipeline().get(PacketEvents.ENCODER_NAME) != null) {
+            channel.pipeline().remove(PacketEvents.ENCODER_NAME);
+        }
+    }
+}

--- a/nettystom/src/main/java/io/github/retrooper/packetevents/util/NettystomConversionUtil.java
+++ b/nettystom/src/main/java/io/github/retrooper/packetevents/util/NettystomConversionUtil.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2024 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.retrooper.packetevents.util;
+
+import com.github.retrooper.packetevents.protocol.ConnectionState;
+import io.netty.channel.Channel;
+import net.minestom.server.entity.Player;
+import net.minestom.server.network.player.PlayerConnection;
+import net.minestom.server.network.player.PlayerSocketConnection;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Conversion helpers between nettystom's networking types and packetevents' own
+ * protocol abstractions.
+ */
+@ApiStatus.Internal
+public final class NettystomConversionUtil {
+
+    private NettystomConversionUtil() {
+    }
+
+    /**
+     * Converts a nettystom {@link net.minestom.server.network.ConnectionState} into the
+     * packetevents {@link ConnectionState}.
+     */
+    public static ConnectionState fromNettystom(net.minestom.server.network.ConnectionState state) {
+        return switch (state) {
+            case HANDSHAKE -> ConnectionState.HANDSHAKING;
+            case STATUS -> ConnectionState.STATUS;
+            case LOGIN -> ConnectionState.LOGIN;
+            case CONFIGURATION -> ConnectionState.CONFIGURATION;
+            case PLAY -> ConnectionState.PLAY;
+        };
+    }
+
+    /**
+     * Returns the underlying Netty {@link Channel} for a nettystom player, or {@code null}
+     * if the player is not backed by a socket connection (e.g. a fake player).
+     */
+    public static @Nullable Channel getChannel(Player player) {
+        return getChannel(player.getPlayerConnection());
+    }
+
+    /**
+     * Returns the underlying Netty {@link Channel} for a nettystom connection, or
+     * {@code null} if the connection is not backed by a socket.
+     */
+    public static @Nullable Channel getChannel(@Nullable PlayerConnection connection) {
+        if (connection instanceof PlayerSocketConnection socket) {
+            return socket.getChannel();
+        }
+        return null;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,8 @@ include("fabric")
 include("fabric-common")
 include("fabric-official")
 include("fabric-intermediary")
+// nettystom platform (Netty-based Minestom fork)
+include("nettystom")
 // Patch modules
 include(":patch:adventure-text-serializer-gson")
 include(":patch:adventure-text-serializer-legacy")


### PR DESCRIPTION
Integrate the nettystom platform from the packetstom fork into packetevents as an additional platform module alongside the existing ones (spigot, bungeecord, velocity, sponge, fabric).

nettystom targets a Netty-based Minestom fork and depends only on the shared :api and :netty-common modules. Registered in settings.gradle.kts without removing or altering any existing platform.