### PR TITLE
Annotate nullable manager returns

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/manager/player/PlayerManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/player/PlayerManager.java
@@ -26,15 +26,16 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface PlayerManager {
     int getPing(@NotNull Object player);
 
     @NotNull ClientVersion getClientVersion(@NotNull Object player);
 
-    Object getChannel(@NotNull Object player);
+    @Nullable Object getChannel(@NotNull Object player);
 
-    User getUser(@NotNull Object player);
+    @Nullable User getUser(@NotNull Object player);
 
     /**
      * <strong>WARNING</strong>: Usage of this method should be avoided. Please use either

--- a/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/manager/protocol/ProtocolManager.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.PacketTransformationUtil;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -55,7 +56,7 @@ public interface ProtocolManager {
     void writePacketSilently(Object channel, Object byteBuf);
     void receivePacket(Object channel, Object byteBuf);
     void receivePacketSilently(Object channel, Object byteBuf);
-    ClientVersion getClientVersion(Object channel);
+    @Nullable ClientVersion getClientVersion(Object channel);
     //TODO Define method that accepts an array of channels/set/list of channels.
 
     default void sendPackets(Object channel, Object... byteBuf) {
@@ -147,13 +148,13 @@ public interface ProtocolManager {
         receivePacketsSilently(channel, transformed);
     }
 
-    default User getUser(Object channel) {
+    default @Nullable User getUser(Object channel) {
         Object pipeline = ChannelHelper.getPipeline(channel);
         return USERS.get(pipeline);
     }
 
     @ApiStatus.Internal
-    default User removeUser(Object channel) {
+    default @Nullable User removeUser(Object channel) {
         Object pipeline = ChannelHelper.getPipeline(channel);
         return USERS.remove(pipeline);
     }
@@ -167,7 +168,7 @@ public interface ProtocolManager {
         PacketEvents.getAPI().getInjector().updateUser(channel, user);
     }
 
-    default Object getChannel(UUID uuid) {
+    default @Nullable Object getChannel(UUID uuid) {
         return CHANNELS.get(uuid);
     }
 


### PR DESCRIPTION
Fixes #1514.

Adds nullable return annotations for manager lookups that can miss and return null.

Tested:
- .\gradlew.bat :api:test --console=plain