### PR TITLE
fix: add type check for channel read handler

### DIFF
--- a/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
+++ b/spigot/src/main/java/io/github/retrooper/packetevents/injector/connection/ServerChannelHandler.java
@@ -64,6 +64,8 @@ public class ServerChannelHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof Channel)) return;
+
         Channel channel = (Channel) msg;
         //Resolve netty version only once.
         if (NETTY_VERSION == null && !CHECKED_NETTY_VERSION) {

--- a/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/connection/ServerChannelHandler.java
+++ b/sponge/src/main/java/io/github/retrooper/packetevents/sponge/injector/connection/ServerChannelHandler.java
@@ -27,6 +27,8 @@ public class ServerChannelHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof Channel)) return;
+
         Channel channel = (Channel) msg;
         channel.pipeline().addLast(PacketEvents.SERVER_CHANNEL_HANDLER_NAME, new PreChannelInitializer());
         super.channelRead(ctx, msg);


### PR DESCRIPTION
Fixed `ClassCastException: class io.netty.channel.socket.DatagramPacket cannot be cast to class io.netty.channel.Channel`