### PR TITLE
State loading optimizations

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/serializer/NBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/serializer/NBTSerializer.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 @ApiStatus.NonExtendable
@@ -36,9 +37,9 @@ public class NBTSerializer<IN, OUT> implements NBTReader<NBT, IN>, NBTWriter<NBT
     protected final NameReader<IN> nameReader;
     protected final NameWriter<OUT> nameWriter;
     protected final Map<Integer, NBTType<? extends NBT>> idToType = new HashMap<>();
-    protected final Map<NBTType<? extends NBT>, Integer> typeToId = new HashMap<>();
-    protected final Map<NBTType<? extends NBT>, TagReader<IN, ? extends NBT>> typeReaders = new HashMap<>();
-    protected final Map<NBTType<? extends NBT>, TagWriter<OUT, ? extends NBT>> typeWriters = new HashMap<>();
+    protected final Map<NBTType<? extends NBT>, Integer> typeToId = new IdentityHashMap<>();
+    protected final Map<NBTType<? extends NBT>, TagReader<IN, ? extends NBT>> typeReaders = new IdentityHashMap<>();
+    protected final Map<NBTType<? extends NBT>, TagWriter<OUT, ? extends NBT>> typeWriters = new IdentityHashMap<>();
 
     public NBTSerializer(
             IdReader<IN> idReader, IdWriter<OUT> idWriter,

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/serializer/SequentialNBTReader.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/nbt/serializer/SequentialNBTReader.java
@@ -22,6 +22,7 @@ import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
 import com.github.retrooper.packetevents.protocol.nbt.NBTLimiter;
 import com.github.retrooper.packetevents.protocol.nbt.NBTList;
 import com.github.retrooper.packetevents.protocol.nbt.NBTType;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayOutputStream;
@@ -30,7 +31,6 @@ import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -87,6 +87,9 @@ public final class SequentialNBTReader implements NBTReader<NBT, DataInputStream
         private NBT lastRead;
         private boolean hasReadType;
 
+        // allocate only once to reduce memory allocations
+        private final NbtEntry entry = new NbtEntry();
+
         private Compound(DataInputStream stream, NBTLimiter limiter, Runnable onComplete) {
             this.stream = stream;
             this.limiter = limiter;
@@ -139,7 +142,7 @@ public final class SequentialNBTReader implements NBTReader<NBT, DataInputStream
             try {
                 hasReadType = false;
 
-                String name = DefaultNBTSerializer.readString(limiter, stream);
+                this.entry.name = DefaultNBTSerializer.readString(limiter, stream);
 
                 if (nextType == NBTType.COMPOUND) {
                     lastRead = new Compound(stream, limiter, this::runCompleted);
@@ -151,7 +154,8 @@ public final class SequentialNBTReader implements NBTReader<NBT, DataInputStream
                 }
                 limiter.increment(36);
 
-                return new AbstractMap.SimpleEntry<>(name, lastRead);
+                this.entry.tag = this.lastRead;
+                return this.entry;
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -282,6 +286,30 @@ public final class SequentialNBTReader implements NBTReader<NBT, DataInputStream
         @Override
         public void close() throws IOException {
             stream.close();
+        }
+
+        private static final class NbtEntry implements Map.Entry<String, NBT> {
+
+            private @MonotonicNonNull String name;
+            private @MonotonicNonNull NBT tag;
+
+            private NbtEntry() {
+            }
+
+            @Override
+            public String getKey() {
+                return this.name;
+            }
+
+            @Override
+            public NBT getValue() {
+                return this.tag;
+            }
+
+            @Override
+            public NBT setValue(NBT value) {
+                throw new UnsupportedOperationException();
+            }
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -556,6 +556,8 @@ public class WrappedBlockState {
                                 PacketEvents.getAPI().getLogManager().warn("Unknown NBT typeString in modern mapping: " + value.getClass().getSimpleName());
                                 continue;
                             }
+                            // TODO remove toUpperCase, every parser needs to be adjusted; this would
+                            //   eliminate 10% of all allocations if loading all modern state mappings
                             dataMap.put(state, state.getParser().apply(v.toString().toUpperCase(Locale.ROOT)));
                         }
                         stateCache = cache.computeIfAbsent(dataMap, StateCacheValue::new);
@@ -1734,18 +1736,24 @@ public class WrappedBlockState {
 
         public String getString() {
             if (this.string == null) {
-                StringBuilder builder = new StringBuilder();
+                StringBuilder builder = new StringBuilder("[");
                 for (Map.Entry<StateValue, Object> entry : this.map.entrySet()) {
+                    if (builder.length() != 1) {
+                        builder.append(',');
+                    }
                     builder
                             .append(entry.getKey().getName())
                             .append('=')
                             // this is technically incorrect as block property values are case-sensitive, but it
                             // doesn't matter for this use case as we do String#toUpperCase while reading anyway;
                             // the current block state property system is already enough of a mess
-                            .append(String.valueOf(entry.getValue()).toLowerCase(Locale.ROOT))
-                            .append(',');
+                            .append(String.valueOf(entry.getValue()).toLowerCase(Locale.ROOT));
                 }
-                this.string = builder.length() == 0 ? "" : '[' + builder.substring(0, builder.length() - 1) + ']';
+                if (builder.length() != 1) {
+                    this.string = builder.append(']').toString();
+                } else {
+                    this.string = "";
+                }
             }
             return this.string;
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -360,7 +361,7 @@ public class WrappedBlockState {
         Map<WrappedBlockState, Integer> stateToIdMap = new HashMap<>();
         Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
         Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
-        Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new HashMap<>();
+        Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
 
         try (final SequentialNBTReader.Compound compound = MappingHelper.decompress(MAPPINGS_ASSETS_LEGACY)) {
             compound.skipOne(); // Skip version
@@ -450,7 +451,7 @@ public class WrappedBlockState {
             Map<WrappedBlockState, Integer> stateToIdMap = new HashMap<>();
             Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
             Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
-            Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new HashMap<>();
+            Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
 
             int id = 0;
             for (NBT e : list) {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -43,6 +43,7 @@ import com.github.retrooper.packetevents.util.LogManager;
 import com.github.retrooper.packetevents.util.mappings.MappingHelper;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -111,7 +112,7 @@ public class WrappedBlockState {
     private static final WrappedBlockState AIR = new WrappedBlockState(StateTypes.AIR,
             new EnumMap<>(StateValue.class), 0, AIR_MAPPING_INDEX);
     private static final Map<String, WrappedBlockState>[] BY_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
-    private static final Map<Integer, WrappedBlockState>[] BY_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
+    private static final @Nullable WrappedBlockState[][] BY_ID = new WrappedBlockState[HIGHEST_MAPPING_INDEX + 1][];
     private static final Map<WrappedBlockState, String>[] INTO_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<WrappedBlockState, WrappedBlockState>[] INTO_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<StateType, WrappedBlockState>[] DEFAULT_STATES = new Map[HIGHEST_MAPPING_INDEX + 1];
@@ -122,7 +123,7 @@ public class WrappedBlockState {
         STRING_UPDATER.put("grass_path", "dirt_path"); // 1.16 -> 1.17
 
         Arrays.fill(BY_STRING, Collections.emptyMap());
-        Arrays.fill(BY_ID, Collections.emptyMap());
+        Arrays.fill(BY_ID, new WrappedBlockState[0]);
         Arrays.fill(INTO_STRING, Collections.emptyMap());
         Arrays.fill(INTO_ID, Collections.emptyMap());
         Arrays.fill(DEFAULT_STATES, Collections.emptyMap());
@@ -130,7 +131,7 @@ public class WrappedBlockState {
         // because AIR is a constant, preload all data for this into a separate mapping index
         String airName = AIR.getType().getMapped().getName().getKey();
         BY_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(airName, AIR);
-        BY_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getGlobalId(), AIR);
+        BY_ID[AIR_MAPPING_INDEX] = new WrappedBlockState[]{AIR};
         INTO_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, airName);
         INTO_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, AIR);
         DEFAULT_STATES[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getType(), AIR);
@@ -172,14 +173,14 @@ public class WrappedBlockState {
 
     private static byte loadMappings(ClientVersion version) {
         byte mappingsIndex = getMappingsIndex(version);
-        if (!PRELOAD_BLOCK_STATE_MAPPINGS && BY_ID[mappingsIndex].isEmpty()) {
+        if (!PRELOAD_BLOCK_STATE_MAPPINGS && BY_ID[mappingsIndex].length == 0) {
             loadMappings0(getMappingsVersion(version), mappingsIndex); // try to load mappings
         }
         return mappingsIndex;
     }
 
     private static synchronized void loadMappings0(ClientVersion version, byte mappingsIndex) {
-        if (!BY_ID[mappingsIndex].isEmpty()) {
+        if (BY_ID[mappingsIndex].length != 0) {
             return; // already loaded
         }
         PacketEvents.getAPI().getLogManager().info("Loading block mappings for " + version + "/" + mappingsIndex + "...");
@@ -210,11 +211,10 @@ public class WrappedBlockState {
 
         Map<Map<StateValue, Object>, StateCacheValue> cache = new HashMap<>();
         for (byte i = 0; i < HIGHEST_MAPPING_INDEX; i++) {
-            Map<Integer, WrappedBlockState> map = BY_ID[i];
-            if (map == null) {
-                continue; // not loaded yet
-            }
-            for (WrappedBlockState state : map.values()) {
+            for (WrappedBlockState state : BY_ID[i]) {
+                if (state == null) {
+                    continue;
+                }
                 cache.computeIfAbsent(state.data, StateCacheValue::new);
             }
         }
@@ -303,10 +303,16 @@ public class WrappedBlockState {
 
     @NotNull
     public static WrappedBlockState getByGlobalId(ClientVersion version, int globalID, boolean clone) {
-        if (globalID == 0) return AIR; // Hardcode for performance
+        if (globalID <= 0) return AIR; // Hardcode for performance
         byte mappingsIndex = loadMappings(version);
-        final WrappedBlockState state = BY_ID[mappingsIndex].getOrDefault(globalID, AIR);
+        final WrappedBlockState state = getByGlobalId0(mappingsIndex, globalID);
         return clone ? state.clone() : state;
+    }
+
+    private static WrappedBlockState getByGlobalId0(byte mappingsIndex, int globalId) {
+        @Nullable WrappedBlockState[] map = BY_ID[mappingsIndex];
+        final WrappedBlockState state = globalId < map.length ? map[globalId] : null;
+        return state != null ? state : AIR;
     }
 
     @NotNull
@@ -356,12 +362,71 @@ public class WrappedBlockState {
         return MAPPING_VERSIONS[version.ordinal()];
     }
 
+    private static final class StateLoaderBuilder {
+
+        private final byte mappingsIndex;
+
+        private WrappedBlockState[] stateById;
+        private int maximumId = -1;
+
+        private final Map<WrappedBlockState, WrappedBlockState> stateToId = new HashMap<>();
+        private final Map<String, WrappedBlockState> stateByString = new HashMap<>();
+        private final Map<WrappedBlockState, String> stateToString = new HashMap<>();
+        private final Map<StateType, WrappedBlockState> defaultStates = new IdentityHashMap<>();
+
+        public StateLoaderBuilder(byte mappingsIndex) {
+            this.mappingsIndex = mappingsIndex;
+            if (mappingsIndex == LEGACY_MAPPING_INDEX) {
+                // we "guess" how many states there after loading
+                this.stateById = new WrappedBlockState[(256 << 4) - 1];
+            } else {
+                // varies by version, this is an actual guess
+                this.stateById = new WrappedBlockState[1 << 15];
+            }
+        }
+
+        public void add(WrappedBlockState state, String string, boolean def) {
+            int globalId = state.getGlobalId();
+            if (globalId > this.maximumId) {
+                this.maximumId = globalId;
+            }
+            if (this.stateById.length <= globalId) {
+                // resize array, double in length
+                this.stateById = Arrays.copyOf(this.stateById, this.stateById.length << 1);
+            }
+            this.stateById[globalId] = state;
+
+            this.stateToString.put(state, string);
+            this.stateToId.put(state, state);
+
+            // legacy handling bullshit (otherwise we could just do #put):
+            //   We want the first with this ID, to prevent invalid blocks that work with vanilla, but may
+            //   cause other things handling data to have issues, such as air with a byte value of 1
+            //   (this matters as doors read bytes if they are a half without caring what type the other block is)
+            this.stateByString.putIfAbsent(string, state);
+
+            if (def) {
+                // use #putIfAbsent for legacy block states
+                this.defaultStates.putIfAbsent(state.getType(), state);
+            }
+        }
+
+        public void register() {
+            // reduce length if we created a too large array
+            if (this.maximumId + 1 != this.stateById.length) {
+                this.stateById = Arrays.copyOf(this.stateById, this.maximumId + 1);
+            }
+
+            BY_ID[this.mappingsIndex] = this.stateById;
+            INTO_ID[this.mappingsIndex] = this.stateToId;
+            BY_STRING[this.mappingsIndex] = this.stateByString;
+            INTO_STRING[this.mappingsIndex] = this.stateToString;
+            DEFAULT_STATES[this.mappingsIndex] = this.defaultStates;
+        }
+    }
+
     private static void loadLegacy(Map<Map<StateValue, Object>, StateCacheValue> cache) {
-        Map<Integer, WrappedBlockState> stateByIdMap = new HashMap<>();
-        Map<WrappedBlockState, WrappedBlockState> stateToIdMap = new HashMap<>();
-        Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
-        Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
-        Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
+        StateLoaderBuilder builder = new StateLoaderBuilder(LEGACY_MAPPING_INDEX);
 
         try (final SequentialNBTReader.Compound compound = MappingHelper.decompress(MAPPINGS_ASSETS_LEGACY)) {
             compound.skipOne(); // Skip version
@@ -416,25 +481,13 @@ public class WrappedBlockState {
                     String fullString = entry.getKey() + stateCache.getString();
                     WrappedBlockState state = new WrappedBlockState(type, stateCache.map, combinedID, LEGACY_MAPPING_INDEX);
 
-                    stateByIdMap.put(combinedID, state);
-                    stateToStringMap.put(state, fullString);
-                    stateToIdMap.put(state, state);
-
-                    // We want the first with this ID, to prevent invalid blocks that work with vanilla, but may
-                    // cause other things handling data to have issues, such as air with a byte value of 1
-                    // (this matters as doors read bytes if they are a half without caring what type the other block is)
-                    stateByStringMap.putIfAbsent(fullString, state);
-
-                    // This works because the first of a type is always the default block, by chance
-                    stateTypeToBlockStateMap.putIfAbsent(type, state);
+                    // always mark as default, builder will only mark first default state as actual default -
+                    // and this is correct for every legacy state
+                    builder.add(state, fullString, true);
                 }
             }
 
-            BY_ID[LEGACY_MAPPING_INDEX] = stateByIdMap;
-            INTO_ID[LEGACY_MAPPING_INDEX] = stateToIdMap;
-            BY_STRING[LEGACY_MAPPING_INDEX] = stateByStringMap;
-            INTO_STRING[LEGACY_MAPPING_INDEX] = stateToStringMap;
-            DEFAULT_STATES[LEGACY_MAPPING_INDEX] = stateTypeToBlockStateMap;
+            builder.register();
         } catch (IOException e) {
             throw new RuntimeException("Failed to load legacy block mappings", e);
         }
@@ -445,14 +498,9 @@ public class WrappedBlockState {
             compound.skipOne(); // Skip version
 
             byte mappingIndex = getMappingsIndex(version);
+            StateLoaderBuilder builder = new StateLoaderBuilder(mappingIndex);
+
             SequentialNBTReader.List list = (SequentialNBTReader.List) compound.next().getValue();
-
-            Map<Integer, WrappedBlockState> stateByIdMap = new HashMap<>();
-            Map<WrappedBlockState, WrappedBlockState> stateToIdMap = new HashMap<>();
-            Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
-            Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
-            Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
-
             int id = 0;
             for (NBT e : list) {
                 SequentialNBTReader.Compound element = (SequentialNBTReader.Compound) e;
@@ -516,27 +564,12 @@ public class WrappedBlockState {
                     }
 
                     String fullString = typeString + stateCache.getString();
-                    WrappedBlockState state = new WrappedBlockState(type, stateCache.map, id, mappingIndex);
-
-                    if (defaultIdx == index) {
-                        stateTypeToBlockStateMap.put(type, state);
-                    }
-
-                    stateByStringMap.put(fullString, state);
-                    stateByIdMap.put(id, state);
-                    stateToStringMap.put(state, fullString);
-                    stateToIdMap.put(state, state);
-
-                    id++;
-                    index++;
+                    WrappedBlockState state = new WrappedBlockState(type, stateCache.map, id++, mappingIndex);
+                    builder.add(state, fullString, defaultIdx == index++);
                 }
             }
 
-            BY_ID[mappingIndex] = stateByIdMap;
-            INTO_ID[mappingIndex] = stateToIdMap;
-            BY_STRING[mappingIndex] = stateByStringMap;
-            INTO_STRING[mappingIndex] = stateToStringMap;
-            DEFAULT_STATES[mappingIndex] = stateTypeToBlockStateMap;
+            builder.register();
         } catch (IOException e) {
             throw new RuntimeException("Failed to load modern block mappings", e);
         }
@@ -1604,7 +1637,7 @@ public class WrappedBlockState {
         int oldGlobalID = globalID;
         globalID = getGlobalIdNoCache();
         if (globalID == -1) { // -1 maps to no block as negative ID are impossible
-            WrappedBlockState blockState = BY_ID[this.mappingsIndex].getOrDefault(oldGlobalID, AIR).clone();
+            WrappedBlockState blockState = getByGlobalId0(this.mappingsIndex, oldGlobalID).clone();
             this.type = blockState.type;
             this.globalID = blockState.globalID;
             this.data = new HashMap<>(blockState.data);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -592,7 +592,10 @@ public class WrappedBlockState {
     @Override
     public int hashCode() {
         // Don't hash the global ID, it is determined by the other data types
-        return Objects.hash(type, data);
+        int result = 1;
+        result = 31 * result + this.type.hashCode();
+        result = 31 * result + this.data.hashCode();
+        return result;
     }
 
     public StateType getType() {

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -113,7 +113,7 @@ public class WrappedBlockState {
     private static final Map<String, WrappedBlockState>[] BY_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<Integer, WrappedBlockState>[] BY_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<WrappedBlockState, String>[] INTO_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
-    private static final Map<WrappedBlockState, Integer>[] INTO_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
+    private static final Map<WrappedBlockState, WrappedBlockState>[] INTO_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<StateType, WrappedBlockState>[] DEFAULT_STATES = new Map[HIGHEST_MAPPING_INDEX + 1];
 
     private static final Map<String, String> STRING_UPDATER = new HashMap<>();
@@ -132,7 +132,7 @@ public class WrappedBlockState {
         BY_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(airName, AIR);
         BY_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getGlobalId(), AIR);
         INTO_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, airName);
-        INTO_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, AIR.getGlobalId());
+        INTO_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, AIR);
         DEFAULT_STATES[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getType(), AIR);
     }
 
@@ -358,7 +358,7 @@ public class WrappedBlockState {
 
     private static void loadLegacy(Map<Map<StateValue, Object>, StateCacheValue> cache) {
         Map<Integer, WrappedBlockState> stateByIdMap = new HashMap<>();
-        Map<WrappedBlockState, Integer> stateToIdMap = new HashMap<>();
+        Map<WrappedBlockState, WrappedBlockState> stateToIdMap = new HashMap<>();
         Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
         Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
         Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
@@ -418,7 +418,7 @@ public class WrappedBlockState {
 
                     stateByIdMap.put(combinedID, state);
                     stateToStringMap.put(state, fullString);
-                    stateToIdMap.put(state, combinedID);
+                    stateToIdMap.put(state, state);
 
                     // We want the first with this ID, to prevent invalid blocks that work with vanilla, but may
                     // cause other things handling data to have issues, such as air with a byte value of 1
@@ -448,7 +448,7 @@ public class WrappedBlockState {
             SequentialNBTReader.List list = (SequentialNBTReader.List) compound.next().getValue();
 
             Map<Integer, WrappedBlockState> stateByIdMap = new HashMap<>();
-            Map<WrappedBlockState, Integer> stateToIdMap = new HashMap<>();
+            Map<WrappedBlockState, WrappedBlockState> stateToIdMap = new HashMap<>();
             Map<String, WrappedBlockState> stateByStringMap = new HashMap<>();
             Map<WrappedBlockState, String> stateToStringMap = new HashMap<>();
             Map<StateType, WrappedBlockState> stateTypeToBlockStateMap = new IdentityHashMap<>();
@@ -525,7 +525,7 @@ public class WrappedBlockState {
                     stateByStringMap.put(fullString, state);
                     stateByIdMap.put(id, state);
                     stateToStringMap.put(state, fullString);
-                    stateToIdMap.put(state, id);
+                    stateToIdMap.put(state, state);
 
                     id++;
                     index++;
@@ -1655,7 +1655,8 @@ public class WrappedBlockState {
      * Internal method for determining if the block state is still valid
      */
     private int getGlobalIdNoCache() {
-        return INTO_ID[this.mappingsIndex].getOrDefault(this, -1);
+        WrappedBlockState state = INTO_ID[this.mappingsIndex].get(this);
+        return state != null ? state.getGlobalId() : -1;
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/type/StateType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/type/StateType.java
@@ -27,8 +27,6 @@ import com.github.retrooper.packetevents.util.mappings.TypesBuilderData;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
-
 public class StateType {
 
     private final Mapped mapped;
@@ -129,27 +127,6 @@ public class StateType {
     @Override
     public String toString() {
         return getName();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        StateType stateType = (StateType) o;
-        return Float.compare(blastResistance, stateType.blastResistance) == 0
-                && Float.compare(hardness, stateType.hardness) == 0
-                && isSolid == stateType.isSolid
-                && isBlocking == stateType.isBlocking
-                && isAir == stateType.isAir
-                && requiresCorrectTool == stateType.requiresCorrectTool
-                && exceedsCube == stateType.exceedsCube
-                && Objects.equals(getName(), stateType.getName())
-                && materialType == stateType.materialType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getName(), blastResistance, hardness, isSolid, isBlocking, isAir, requiresCorrectTool, exceedsCube, materialType);
     }
 
     public final class Mapped extends AbstractMappedEntity {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/MappingHelper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/MappingHelper.java
@@ -45,7 +45,7 @@ public class MappingHelper {
 
     public static SequentialNBTReader.Compound decompress(final String path) {
         try {
-            final DataInputStream dataInput = new DataInputStream(new GZIPInputStream(new BufferedInputStream(
+            final DataInputStream dataInput = new DataInputStream(new BufferedInputStream(new GZIPInputStream(
                     PacketEvents.getAPI().getSettings().getResourceProvider().apply("assets/" + path + ".nbt"))));
             return (SequentialNBTReader.Compound) SequentialNBTReader.INSTANCE.deserializeTag(NBTLimiter.noop(), dataInput);
         } catch (IOException e) {


### PR DESCRIPTION
See individual commits for more details, but essentially:
- Reduced retained memory after states have been loaded (array instead of map and no longer allocates some ints)
- Reduced allocations during state loading (e.g. sequential nbt reading now only uses one entry object)
- Buffer gzip input stream (buffer was previously placed incorrectly)
- Always compare/hash state types + nbt types by object identity

On my device, all states now load in about 1.3s-1.5s instead of 2.1s-2.3s like before

---

Some async profiler reports:
- alloc: https://files.booky.dev/public/26-06-26_asprof_packetevents_alloc.html
- cpu: https://files.booky.dev/public/26-06-26_asprof_packetevents_cpu.html

If someone sees/finds anything in there which could be further optimized, please let me know!

---

Initially marked as a draft as I still need to test + check if everything is behaving correctly

(thanks to MissingReports on Discord for suggesting to take a look at this!)