### PR TITLE
perf: drop per-call allocations in AdventureNBTSerializer style (de)serialization

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -90,14 +90,7 @@ import java.util.function.Function;
 
 public class AdventureNBTSerializer implements ComponentSerializer<Component, Component, NBT> {
 
-    private static final TextDecoration[] DECORATION_VALUES = TextDecoration.values();
-    private static final String[] DECORATION_KEYS = new String[DECORATION_VALUES.length];
-
-    static {
-        for (int i = 0; i < DECORATION_VALUES.length; i++) {
-            DECORATION_KEYS[i] = DECORATION_VALUES[i].toString();
-        }
-    }
+    private static final Map<String, TextDecoration> DECORATION_MAP = new HashMap<>(TextDecoration.NAMES.keyToValue());
 
     private final ClientVersion version;
     private final boolean downsampleColor;
@@ -491,9 +484,9 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             if (shadowColor != null) style.shadowColor(ShadowColor.shadowColor(shadowColor.intValue()));
         }
 
-        for (int i = 0; i < DECORATION_KEYS.length; i++) {
-            Number value = reader.getNumber(DECORATION_KEYS[i]);
-            if (value != null) style.decoration(DECORATION_VALUES[i], TextDecoration.State.byBoolean(value.byteValue() != 0));
+        for (Map.Entry<String, TextDecoration> entry : DECORATION_MAP.entrySet()) {
+            Number value = reader.getNumber(entry.getKey());
+            if (value != null) style.decoration(entry.getValue(), TextDecoration.State.byBoolean(value.byteValue() != 0));
         }
 
         String insertion = reader.getUTF("insertion");
@@ -617,10 +610,10 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             if (shadowColor != null) writer.writeInt("shadow_color", shadowColor.value());
         }
 
-        for (TextDecoration decoration : DECORATION_VALUES) {
-            TextDecoration.State state = style.decoration(decoration);
+        for (Map.Entry<String, TextDecoration> entry : DECORATION_MAP.entrySet()) {
+            TextDecoration.State state = style.decoration(entry.getValue());
             if (state != TextDecoration.State.NOT_SET) {
-                writer.writeBoolean(decoration.toString(), state == TextDecoration.State.TRUE);
+                writer.writeBoolean(entry.getKey(), state == TextDecoration.State.TRUE);
             }
         }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -88,9 +88,16 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.github.retrooper.packetevents.util.adventure.AdventureIndexUtil.indexValueOrThrow;
-
 public class AdventureNBTSerializer implements ComponentSerializer<Component, Component, NBT> {
+
+    private static final TextDecoration[] DECORATION_VALUES = TextDecoration.values();
+    private static final String[] DECORATION_KEYS = new String[DECORATION_VALUES.length];
+
+    static {
+        for (int i = 0; i < DECORATION_VALUES.length; i++) {
+            DECORATION_KEYS[i] = DECORATION_VALUES[i].toString();
+        }
+    }
 
     private final ClientVersion version;
     private final boolean downsampleColor;
@@ -470,22 +477,27 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
         Style.Builder style = Style.style();
         NBTReader reader = new NBTReader(wrapper, input);
 
-        reader.useUTF("font", value -> style.font(Key.key(value)));
-        reader.useUTF("color", value -> {
-            TextColor color = this.deserializeColor(value);
+        String font = reader.getUTF("font");
+        if (font != null) style.font(Key.key(font));
+
+        String colorName = reader.getUTF("color");
+        if (colorName != null) {
+            TextColor color = this.deserializeColor(colorName);
             if (color != null) style.color(color);
-        });
-        if (BackwardCompatUtil.IS_4_18_0_OR_NEWER) {
-            reader.useNumber("shadow_color", num ->
-                    style.shadowColor(ShadowColor.shadowColor(num.intValue())));
         }
 
-        for (String decorationKey : TextDecoration.NAMES.keys()) {
-            reader.useBoolean(decorationKey, value -> style.decoration(
-                    indexValueOrThrow(TextDecoration.NAMES, decorationKey),
-                    TextDecoration.State.byBoolean(value)));
+        if (BackwardCompatUtil.IS_4_18_0_OR_NEWER) {
+            Number shadowColor = reader.getNumber("shadow_color");
+            if (shadowColor != null) style.shadowColor(ShadowColor.shadowColor(shadowColor.intValue()));
         }
-        reader.useUTF("insertion", style::insertion);
+
+        for (int i = 0; i < DECORATION_KEYS.length; i++) {
+            Number value = reader.getNumber(DECORATION_KEYS[i]);
+            if (value != null) style.decoration(DECORATION_VALUES[i], TextDecoration.State.byBoolean(value.byteValue() != 0));
+        }
+
+        String insertion = reader.getUTF("insertion");
+        if (insertion != null) style.insertion(insertion);
 
         boolean modernEvents = this.version.isNewerThanOrEquals(ClientVersion.V_1_21_5);
         NBTReader clickEvent = reader.child(modernEvents ? "click_event" : "clickEvent");
@@ -605,7 +617,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             if (shadowColor != null) writer.writeInt("shadow_color", shadowColor.value());
         }
 
-        for (TextDecoration decoration : TextDecoration.NAMES.values()) {
+        for (TextDecoration decoration : DECORATION_VALUES) {
             TextDecoration.State state = style.decoration(decoration);
             if (state != TextDecoration.State.NOT_SET) {
                 writer.writeBoolean(decoration.toString(), state == TextDecoration.State.TRUE);
@@ -866,6 +878,18 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
 
         public <R> R readUTF(String key, Function<String, R> function) {
             return withTag(key, tag -> function.apply(requireType(tag, NBTType.STRING).getValue()));
+        }
+
+        public String getUTF(String key) {
+            NBT tag = compound.getTagOrNull(key);
+            return tag == null ? null : requireType(tag, NBTType.STRING).getValue();
+        }
+
+        public Number getNumber(String key) {
+            NBT tag = compound.getTagOrNull(key);
+            if (tag == null) return null;
+            if (tag instanceof NBTNumber) return ((NBTNumber) tag).getAsNumber();
+            throw new IllegalArgumentException("Expected number but got " + tag.getType());
         }
 
         public void useByteArray(String key, Consumer<byte[]> consumer) {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -873,7 +873,7 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             return withTag(key, tag -> function.apply(requireType(tag, NBTType.STRING).getValue()));
         }
 
-        public String getUTF(String key) {
+        public @Nullable String getUTF(String key) {
             NBT tag = compound.getTagOrNull(key);
             return tag == null ? null : requireType(tag, NBTType.STRING).getValue();
         }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/adventure/AdventureNBTSerializer.java
@@ -85,12 +85,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class AdventureNBTSerializer implements ComponentSerializer<Component, Component, NBT> {
 
-    private static final Map<String, TextDecoration> DECORATION_MAP = new HashMap<>(TextDecoration.NAMES.keyToValue());
+    private static final Set<TextDecoration> DECORATIONS = TextDecoration.NAMES.values();
 
     private final ClientVersion version;
     private final boolean downsampleColor;
@@ -484,9 +485,9 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             if (shadowColor != null) style.shadowColor(ShadowColor.shadowColor(shadowColor.intValue()));
         }
 
-        for (Map.Entry<String, TextDecoration> entry : DECORATION_MAP.entrySet()) {
-            Number value = reader.getNumber(entry.getKey());
-            if (value != null) style.decoration(entry.getValue(), TextDecoration.State.byBoolean(value.byteValue() != 0));
+        for (TextDecoration decoration : DECORATIONS) {
+            Boolean value = reader.getBoolean(decoration.toString());
+            if (value != null) style.decoration(decoration, TextDecoration.State.byBoolean(value));
         }
 
         String insertion = reader.getUTF("insertion");
@@ -610,10 +611,10 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             if (shadowColor != null) writer.writeInt("shadow_color", shadowColor.value());
         }
 
-        for (Map.Entry<String, TextDecoration> entry : DECORATION_MAP.entrySet()) {
-            TextDecoration.State state = style.decoration(entry.getValue());
+        for (TextDecoration decoration : DECORATIONS) {
+            TextDecoration.State state = style.decoration(decoration);
             if (state != TextDecoration.State.NOT_SET) {
-                writer.writeBoolean(entry.getKey(), state == TextDecoration.State.TRUE);
+                writer.writeBoolean(decoration.toString(), state == TextDecoration.State.TRUE);
             }
         }
 
@@ -878,11 +879,16 @@ public class AdventureNBTSerializer implements ComponentSerializer<Component, Co
             return tag == null ? null : requireType(tag, NBTType.STRING).getValue();
         }
 
-        public Number getNumber(String key) {
+        public @Nullable Number getNumber(String key) {
             NBT tag = compound.getTagOrNull(key);
             if (tag == null) return null;
             if (tag instanceof NBTNumber) return ((NBTNumber) tag).getAsNumber();
             throw new IllegalArgumentException("Expected number but got " + tag.getType());
+        }
+
+        public @Nullable Boolean getBoolean(String key) {
+            Number number = getNumber(key);
+            return number == null ? null : number.byteValue() != 0;
         }
 
         public void useByteArray(String key, Consumer<byte[]> consumer) {


### PR DESCRIPTION
Process + allocation spark (all corresponding "negligible" performance issues have been sufficiently resolved since this PR):
- Allocation: https://spark.lucko.me/vFIsYkEE5S
- Process: https://spark.lucko.me/LZlH1hqafl

`deserializeStyle` runs for every component and recurses through children, so it's on the hot path whenever text-heavy packets go through. A couple of things made it allocate more than it needs to:
- It iterated `TextDecoration.NAMES.keys()`, and Adventure's `Index#keys()` hands back a fresh `Set.copyOf(...)` on every call (same with `NAMES.values()` on the serialize side).
- Every style field was read via a `Consumer`/`Function` (`reader.useUTF(...)`, `useBoolean(...)`, ...), so each call spun up a pile of short-lived capturing lambdas; around 20 per component once you count the internal `useX -> useNumber -> useTag` delegates (x5 for the decorations); plus the invokedynamic linkage that comes with them.

This caches the decoration names/values in static arrays and adds small, lambda-free `getUTF`/`getNumber` readers, allowing the style attributes to be read directly instead of through a consumer. `serializeStyle` receives the same cached-decoration treatment. No behavior change; same NBT in/out.

The frames only showed up as ~0.02–0.05% in a profile, but they're hit recursively per nested component, so it compounds under component-heavy traffic (e.g., tab + scoreboards).