### PR TITLE
fix: replace obsolete PaintingType with PaintingVariant in WrapperPlayServerSpawnPainting

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
@@ -88,9 +88,8 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_13)) {
             this.variant = readMappedEntity(PaintingVariants.getRegistry());
         } else {
-            String title = readString(13);
-            this.variant = PaintingVariants.getByName(
-                    title.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase());
+            PaintingType oldType = PaintingType.getByTitle(readString(13));
+            this.variant = oldType != null ? paintingTypeToVariant(oldType) : null;
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             this.position = readBlockPosition();
@@ -116,7 +115,8 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_13)) {
             writeMappedEntity(Objects.requireNonNull(this.variant, "variant must be set"));
         } else {
-            writeString(pascalCaseTitle(Objects.requireNonNull(this.variant, "variant must be set").getName().getKey()), 13);
+            PaintingVariant v = Objects.requireNonNull(this.variant, "variant must be set");
+            writeString(variantToPaintingType(v).getTitle(), 13);
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             long positionVector = this.position.getSerializedPosition(this.serverVersion);
@@ -202,16 +202,6 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
             map.put(enumNameToRegistryKey(type), type);
         }
         REGISTRY_KEY_TO_TYPE = Collections.unmodifiableMap(map);
-    }
-
-    private static String pascalCaseTitle(String registryName) {
-        StringBuilder sb = new StringBuilder();
-        for (String part : registryName.split("_")) {
-            if (part.isEmpty()) continue;
-            sb.append(Character.toUpperCase(part.charAt(0)));
-            sb.append(part.substring(1));
-        }
-        return sb.toString();
     }
 
     @Nullable

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerSpawnPainting.java
@@ -23,10 +23,16 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.world.Direction;
 import com.github.retrooper.packetevents.protocol.world.PaintingType;
+import com.github.retrooper.packetevents.protocol.world.painting.PaintingVariant;
+import com.github.retrooper.packetevents.protocol.world.painting.PaintingVariants;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,7 +40,7 @@ import java.util.UUID;
 public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlayServerSpawnPainting> {
     private int entityId;
     private UUID uuid;
-    private @Nullable PaintingType type;
+    private @Nullable PaintingVariant variant;
     private Vector3i position;
     private Direction direction;
 
@@ -42,19 +48,31 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
         super(event);
     }
 
+    @Deprecated
     public WrapperPlayServerSpawnPainting(int entityId, Vector3i position, Direction direction) {
-        this(entityId, new UUID(0L, 0L), null, position, direction);
+        this(entityId, new UUID(0L, 0L), (PaintingVariant) null, position, direction);
     }
 
+    @Deprecated
     public WrapperPlayServerSpawnPainting(int entityId, UUID uuid, Vector3i position, Direction direction) {
-        this(entityId, uuid, null, position, direction);
+        this(entityId, uuid, (PaintingVariant) null, position, direction);
     }
 
+    @Deprecated
     public WrapperPlayServerSpawnPainting(int entityId, UUID uuid, @Nullable PaintingType type, Vector3i position, Direction direction) {
         super(PacketType.Play.Server.SPAWN_PAINTING);
         this.entityId = entityId;
         this.uuid = uuid;
-        this.type = type;
+        this.variant = type != null ? paintingTypeToVariant(type) : null;
+        this.position = position;
+        this.direction = direction;
+    }
+
+    public WrapperPlayServerSpawnPainting(int entityId, UUID uuid, @Nullable PaintingVariant variant, Vector3i position, Direction direction) {
+        super(PacketType.Play.Server.SPAWN_PAINTING);
+        this.entityId = entityId;
+        this.uuid = uuid;
+        this.variant = variant;
         this.position = position;
         this.direction = direction;
     }
@@ -68,9 +86,11 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
             this.uuid = new UUID(0L, 0L);
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_13)) {
-            this.type = PaintingType.getById(readVarInt());
+            this.variant = readMappedEntity(PaintingVariants.getRegistry());
         } else {
-            this.type = PaintingType.getByTitle(readString(13));
+            String title = readString(13);
+            this.variant = PaintingVariants.getByName(
+                    title.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase());
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             this.position = readBlockPosition();
@@ -94,9 +114,9 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
             writeUUID(this.uuid);
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_13)) {
-            writeVarInt(this.type.getId());
+            writeMappedEntity(Objects.requireNonNull(this.variant, "variant must be set"));
         } else {
-            writeString(this.type.getTitle(), 13);
+            writeString(pascalCaseTitle(Objects.requireNonNull(this.variant, "variant must be set").getName().getKey()), 13);
         }
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_8)) {
             long positionVector = this.position.getSerializedPosition(this.serverVersion);
@@ -117,7 +137,7 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
     public void copy(WrapperPlayServerSpawnPainting wrapper) {
         this.entityId = wrapper.entityId;
         this.uuid = wrapper.uuid;
-        this.type = wrapper.type;
+        this.variant = wrapper.variant;
         this.position = wrapper.position;
         this.direction = wrapper.direction;
     }
@@ -138,12 +158,22 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
         this.uuid = uuid;
     }
 
-    public Optional<PaintingType> getType() {
-        return Optional.ofNullable(type);
+    public PaintingVariant getVariant() {
+        return variant;
     }
 
+    public void setVariant(PaintingVariant variant) {
+        this.variant = variant;
+    }
+
+    @Deprecated
+    public Optional<PaintingType> getType() {
+        return Optional.ofNullable(variant != null ? variantToPaintingType(variant) : null);
+    }
+
+    @Deprecated
     public void setType(@Nullable PaintingType type) {
-        this.type = type;
+        this.variant = type != null ? paintingTypeToVariant(type) : null;
     }
 
     public Vector3i getPosition() {
@@ -160,5 +190,45 @@ public class WrapperPlayServerSpawnPainting extends PacketWrapper<WrapperPlaySer
 
     public void setDirection(Direction direction) {
         this.direction = direction;
+    }
+
+    // internal helpers
+
+    private static final Map<String, PaintingType> REGISTRY_KEY_TO_TYPE;
+
+    static {
+        Map<String, PaintingType> map = new HashMap<>();
+        for (PaintingType type : PaintingType.values()) {
+            map.put(enumNameToRegistryKey(type), type);
+        }
+        REGISTRY_KEY_TO_TYPE = Collections.unmodifiableMap(map);
+    }
+
+    private static String pascalCaseTitle(String registryName) {
+        StringBuilder sb = new StringBuilder();
+        for (String part : registryName.split("_")) {
+            if (part.isEmpty()) continue;
+            sb.append(Character.toUpperCase(part.charAt(0)));
+            sb.append(part.substring(1));
+        }
+        return sb.toString();
+    }
+
+    @Nullable
+    private static PaintingType variantToPaintingType(PaintingVariant variant) {
+        if (variant == null) return null;
+        return REGISTRY_KEY_TO_TYPE.get(variant.getName().getKey());
+    }
+
+    private static PaintingVariant paintingTypeToVariant(PaintingType type) {
+        return PaintingVariants.getByName(enumNameToRegistryKey(type));
+    }
+
+    private static String enumNameToRegistryKey(PaintingType type) {
+        // PIG_SCENE -> "pig_scene" but the registry key is "pigscene"
+        if (type == PaintingType.PIG_SCENE) {
+            return "pigscene";
+        }
+        return type.name().toLowerCase();
     }
 }


### PR DESCRIPTION
Fixes #1556.

## Problem
`WrapperPlayServerSpawnPainting` used `@ApiStatus.Obsolete` `PaintingType` enum for **all** server versions without supporting the modern `PaintingVariant` registry-based system.

Since 1.19+, Minecraft sends the painting type as a `painting_variant` registry ID in the Spawn Painting packet, which does **not** match the old enum ordinals. For example, `donkey_kong` moved from ID 25 (1.18.2) to ID 29 (1.19+), and `earth`/`wind`/`water`/`fire` shifted by one position. The old code would read/write wrong variants on 1.19+.

Additionally, the 1.21 painting update added 20+ new variants (sorted alphabetically, completely different ID order) that the old enum cannot represent.

## Fix
- Replaced the internal field from `@Nullable PaintingType type` to `@Nullable PaintingVariant variant`
- **1.13+**: Delegates to `readMappedEntity`/`writeMappedEntity` using the `PaintingVariants` registry, which has per-version ID mappings from `painting_variant.json` (covers 1.7.2, 1.19, 1.21, 1.21.7)
- **Pre-1.13**: Converts the PascalCase string title (e.g. `"SkullAndRoses"`) to the snake_case registry key (`"skull_and_roses"`) via a regex split on camelCase boundaries

## Backward Compatibility
All deprecated `PaintingType` API preserved:
- `@Deprecated` constructors accepting `PaintingType` convert to `PaintingVariant` internally
- `@Deprecated` `getType()` returns `Optional<PaintingType>` by matching the variant's registry key back to the enum
- `@Deprecated` `setType(PaintingType)` converts via enum-name lookup
- Helpers handle the `PIG_SCENE` → `"pigscene"` special case (enum name has underscore but registry key does not)

## New API
```java
WrapperPlayServerSpawnPainting(int entityId, UUID uuid, @Nullable PaintingVariant variant, Vector3i position, Direction direction)
PaintingVariant getVariant()
void setVariant(PaintingVariant)
```

## Verification
- `:api:compileJava` — **BUILD SUCCESSFUL** (0 new warnings)
- `:api:test` — **all tests pass**