### PR TITLE
feat(api): split EntityTypes hierarchy into EntityClass + EntityHierarchy

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityClass.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityClass.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2026 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.protocol.entity.type;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A node in the Minecraft entity class hierarchy. Mirrors the Java inheritance
+ * structure of Minecraft's entity classes (Entity → LivingEntity → Mob → ...).
+ * <p>
+ * Unlike {@link EntityType}, this is NOT a registry entry. It carries no
+ * protocol
+ * IDs, no versioned mappings, and is not stored in any registry. It exists
+ * purely
+ * for type-checking via {@link EntityType#isInstanceOf(EntityClass)}.
+ * <p>
+ * Design inspired by ViaVersion's entity type system.
+ *
+ * @see EntityHierarchy All predefined hierarchy nodes
+ */
+public final class EntityClass {
+
+	private final String name;
+	private final @Nullable EntityClass parent;
+
+	EntityClass(String name, @Nullable EntityClass parent) {
+		this.name = name;
+		this.parent = parent;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public @Nullable EntityClass getParent() {
+		return this.parent;
+	}
+
+	/**
+	 * Returns true if {@code possibleChild} is this class or a descendant.
+	 * Walks the parent chain and compares by reference equality.
+	 *
+	 * @throws NullPointerException if possibleChild is null
+	 * @see Class#isAssignableFrom(Class)
+	 */
+	public boolean isAssignableFrom(EntityClass possibleChild) {
+		Objects.requireNonNull(possibleChild, "possibleChild");
+		EntityClass current = possibleChild;
+		while (current != null) {
+			if (current == this)
+				return true;
+			current = current.parent;
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "EntityClass{" + name + "}";
+	}
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityHierarchy.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityHierarchy.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2026 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.protocol.entity.type;
+
+/**
+ * Predefined {@link EntityClass} hierarchy nodes mirroring Minecraft's
+ * entity class inheritance tree. These are NOT registry entries — they
+ * are pure type-markers for use with
+ * {@link EntityType#isInstanceOf(EntityClass)}.
+ * <p>
+ * Hierarchy modelled after Minecraft's class tree:
+ * {@code Entity → LivingEntity → Mob → PathfinderMob → ...}
+ * <p>
+ * Credit to ViaVersion for the original category structure.
+ */
+public final class EntityHierarchy {
+
+	private EntityHierarchy() {
+	}
+
+	// ───── Root ─────
+	/** Root of all entity types. */
+	public static final EntityClass ENTITY = new EntityClass("entity", null);
+
+	// ───── Living entities ─────
+	/** Base for all living entities (has health, can take damage). */
+	public static final EntityClass LIVING_ENTITY = new EntityClass("living_entity", ENTITY);
+	/** Living entities without AI pathfinding (slime, bee, ender dragon). */
+	public static final EntityClass ABSTRACT_INSENTIENT = new EntityClass("abstract_insentient", LIVING_ENTITY);
+	/** Living entities that can move and perceive. */
+	public static final EntityClass ABSTRACT_CREATURE = new EntityClass("abstract_creature", ABSTRACT_INSENTIENT);
+	/** Creature that can age (baby/adult). */
+	public static final EntityClass ABSTRACT_AGEABLE = new EntityClass("abstract_ageable", ABSTRACT_CREATURE);
+	/** Non-monster animal. */
+	public static final EntityClass ABSTRACT_ANIMAL = new EntityClass("abstract_animal", ABSTRACT_AGEABLE);
+	/** Animal that can be tamed. */
+	public static final EntityClass ABSTRACT_TAMEABLE_ANIMAL = new EntityClass("abstract_tameable_animal",
+			ABSTRACT_ANIMAL);
+	/** Shoulder-riding tameable (parrot). */
+	public static final EntityClass ABSTRACT_PARROT = new EntityClass("abstract_parrot", ABSTRACT_TAMEABLE_ANIMAL);
+	/** Horse family. */
+	public static final EntityClass ABSTRACT_HORSE = new EntityClass("abstract_horse", ABSTRACT_ANIMAL);
+	/** Horses with inventory chest slot. */
+	public static final EntityClass CHESTED_HORSE = new EntityClass("chested_horse", ABSTRACT_HORSE);
+	/** Nautilus family (1.21.11+). */
+	public static final EntityClass ABSTRACT_NAUTILUS = new EntityClass("abstract_nautilus", ABSTRACT_TAMEABLE_ANIMAL);
+	/** Golem family. */
+	public static final EntityClass ABSTRACT_GOLEM = new EntityClass("abstract_golem", ABSTRACT_CREATURE);
+	/** Fish family (swim, require water). */
+	public static final EntityClass ABSTRACT_FISHES = new EntityClass("abstract_fishes", ABSTRACT_CREATURE);
+	/** Hostile monster. */
+	public static final EntityClass ABSTRACT_MONSTER = new EntityClass("abstract_monster", ABSTRACT_CREATURE);
+	/** Piglin family. */
+	public static final EntityClass ABSTRACT_PIGLIN = new EntityClass("abstract_piglin", ABSTRACT_MONSTER);
+	/** Illager base (pillager, vindicator). */
+	public static final EntityClass ABSTRACT_ILLAGER = new EntityClass("abstract_illager_base", ABSTRACT_MONSTER);
+	/** Evoker / illusioner. */
+	public static final EntityClass ABSTRACT_EVO_ILLU_ILLAGER = new EntityClass("abstract_evo_illu_illager",
+			ABSTRACT_ILLAGER);
+	/** Skeleton family. */
+	public static final EntityClass ABSTRACT_SKELETON = new EntityClass("abstract_skeleton", ABSTRACT_MONSTER);
+	/** Flying mob (ghast, phantom). */
+	public static final EntityClass ABSTRACT_FLYING = new EntityClass("abstract_flying", ABSTRACT_INSENTIENT);
+	/** Ambient mob (bat). */
+	public static final EntityClass ABSTRACT_AMBIENT = new EntityClass("abstract_ambient", ABSTRACT_INSENTIENT);
+	/** Water-dwelling creature (squid, dolphin). */
+	public static final EntityClass ABSTRACT_WATERMOB = new EntityClass("abstract_watermob", ABSTRACT_INSENTIENT);
+	/** Player and mannequin (1.21.9+). */
+	public static final EntityClass AVATAR = new EntityClass("avatar", LIVING_ENTITY);
+
+	// ───── Non-living entities ─────
+	/** Hanging entities (item frame, painting, leash knot). */
+	public static final EntityClass ABSTRACT_HANGING = new EntityClass("abstract_hanging", ENTITY);
+	/** Lightning bolt. */
+	public static final EntityClass ABSTRACT_LIGHTNING = new EntityClass("abstract_lightning", ENTITY);
+	/** Arrows and tridents. */
+	public static final EntityClass ABSTRACT_ARROW = new EntityClass("abstract_arrow", ENTITY);
+	/** Fireball entities. */
+	public static final EntityClass ABSTRACT_FIREBALL = new EntityClass("abstract_fireball", ENTITY);
+	/** Throwable projectiles (snowball, egg, potion, ender pearl). */
+	public static final EntityClass ABSTRACT_PROJECTILE = new EntityClass("abstract_projectile", ENTITY);
+	/** Wind charge projectiles (1.20.3+). */
+	public static final EntityClass ABSTRACT_WIND_CHARGE = new EntityClass("abstract_wind_charge", ABSTRACT_PROJECTILE);
+	/** Minecart family. */
+	public static final EntityClass ABSTRACT_MINECART = new EntityClass("abstract_minecart", ENTITY);
+	/** Minecart with chest-like inventory. */
+	public static final EntityClass ABSTRACT_CHESTED_MINECART = new EntityClass("abstract_chested_minecart",
+			ABSTRACT_MINECART);
+	/** Boat family (pre-1.21.2 generic, post-1.21.2 as parent). */
+	public static final EntityClass ABSTRACT_BOAT = new EntityClass("abstract_boat", ENTITY);
+	/** Boat with chest. */
+	public static final EntityClass ABSTRACT_CHEST_BOAT = new EntityClass("abstract_chest_boat", ABSTRACT_BOAT);
+	/** Display entity (1.19.4+). */
+	public static final EntityClass DISPLAY = new EntityClass("display", ENTITY);
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityType.java
@@ -18,14 +18,41 @@
 
 package com.github.retrooper.packetevents.protocol.entity.type;
 
+import java.util.Optional;
+
 import com.github.retrooper.packetevents.protocol.mapper.LegacyMappedEntity;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 
-import java.util.Optional;
-
 public interface EntityType extends MappedEntity, LegacyMappedEntity {
 
-    boolean isInstanceOf(EntityType parent);
+	/**
+	 * Returns the hierarchy class this entity type belongs to.
+	 * For example, {@code ZOMBIE → ABSTRACT_MONSTER}.
+	 */
+	EntityClass getEntityClass();
 
-    Optional<EntityType> getParent();
+	/**
+	 * Checks if this entity type is an instance of the given hierarchy class
+	 * (or one of its ancestors). Uses the {@link EntityClass} tree.
+	 * <p>
+	 * This is the replacement for the deprecated {@link #isInstanceOf(EntityType)}.
+	 */
+	default boolean isInstanceOf(EntityClass clazz) {
+		EntityClass self = getEntityClass();
+		return clazz != null && self != null && clazz.isAssignableFrom(self);
+	}
+
+	/**
+	 * @deprecated Use {@link #isInstanceOf(EntityClass)} with constants from
+	 *             {@link EntityHierarchy}.
+	 */
+	@Deprecated
+	boolean isInstanceOf(EntityType parent);
+
+	/**
+	 * @deprecated Use {@link #getEntityClass()} and
+	 *             {@link EntityClass#getParent()}.
+	 */
+	@Deprecated
+	Optional<EntityType> getParent();
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
@@ -71,8 +71,13 @@ public final class EntityTypes {
 
     // Credit to ViaVersion for these categories
     public static final EntityType ENTITY = define("entity", null);
-    public static final EntityType LIVINGENTITY = define("livingentity", ENTITY);
-    public static final EntityType ABSTRACT_INSENTIENT = define("abstract_insentient", LIVINGENTITY);
+    public static final EntityType LIVING_ENTITY = define("livingentity", ENTITY);
+    /**
+     * @deprecated Use {@link #LIVING_ENTITY}
+     */
+    @Deprecated
+    public static final EntityType LIVINGENTITY = LIVING_ENTITY;
+    public static final EntityType ABSTRACT_INSENTIENT = define("abstract_insentient", LIVING_ENTITY);
     public static final EntityType ABSTRACT_CREATURE = define("abstract_creature", ABSTRACT_INSENTIENT);
     public static final EntityType ABSTRACT_AGEABLE = define("abstract_ageable", ABSTRACT_CREATURE);
     public static final EntityType ABSTRACT_ANIMAL = define("abstract_animal", ABSTRACT_AGEABLE);
@@ -94,17 +99,40 @@ public final class EntityTypes {
     public static final EntityType ABSTRACT_LIGHTNING = define("abstract_lightning", ENTITY);
     public static final EntityType ABSTRACT_ARROW = define("abstract_arrow", ENTITY);
     public static final EntityType ABSTRACT_FIREBALL = define("abstract_fireball", ENTITY);
-    public static final EntityType PROJECTILE_ABSTRACT = define("projectile_abstract", ENTITY);
-    public static final EntityType MINECART_ABSTRACT = define("minecart_abstract", ENTITY);
-    public static final EntityType CHESTED_MINECART_ABSTRACT = define("chested_minecart_abstract", MINECART_ABSTRACT);
+    public static final EntityType ABSTRACT_PROJECTILE = define("projectile_abstract", ENTITY);
+    /**
+     * @deprecated Use {@link #ABSTRACT_PROJECTILE}
+     */
+    @Deprecated
+    public static final EntityType PROJECTILE_ABSTRACT = ABSTRACT_PROJECTILE;
+    public static final EntityType ABSTRACT_MINECART = define("minecart_abstract", ENTITY);
+    /**
+     * @deprecated Use {@link #ABSTRACT_MINECART}
+     */
+    @Deprecated
+    public static final EntityType MINECART_ABSTRACT = ABSTRACT_MINECART;
+    public static final EntityType ABSTRACT_CHESTED_MINECART = define("chested_minecart_abstract", ABSTRACT_MINECART);
+    /**
+     * @deprecated Use {@link #ABSTRACT_CHESTED_MINECART}
+     */
+    @Deprecated
+    public static final EntityType CHESTED_MINECART_ABSTRACT = ABSTRACT_CHESTED_MINECART;
+    /**
+     * Virtual parent type for all boat entities.
+     */
+    public static final EntityType ABSTRACT_BOAT = define("abstract_boat", ENTITY);
+    /**
+     * Virtual parent type for all chest boat entities.
+     */
+    public static final EntityType ABSTRACT_CHEST_BOAT = define("abstract_chest_boat", ABSTRACT_BOAT);
     /**
      * Not spawnable
      *
      * @versions 1.21.9+
      */
-    public static final EntityType AVATAR = define("avatar", LIVINGENTITY);
+    public static final EntityType AVATAR = define("avatar", LIVING_ENTITY);
     public static final EntityType AREA_EFFECT_CLOUD = define("area_effect_cloud", ENTITY);
-    public static final EntityType ARMOR_STAND = define("armor_stand", LIVINGENTITY);
+    public static final EntityType ARMOR_STAND = define("armor_stand", LIVING_ENTITY);
     public static final EntityType ALLAY = define("allay", ABSTRACT_CREATURE);
     public static final EntityType ARROW = define("arrow", ABSTRACT_ARROW);
     public static final EntityType AXOLOTL = define("axolotl", ABSTRACT_ANIMAL);
@@ -114,11 +142,11 @@ public final class EntityTypes {
     /**
      * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
      */
-    public static final EntityType BOAT = define("boat", ENTITY);
+    public static final EntityType BOAT = define("boat", ABSTRACT_BOAT);
     /**
      * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
      */
-    public static final EntityType CHEST_BOAT = define("chest_boat", BOAT);
+    public static final EntityType CHEST_BOAT = define("chest_boat", ABSTRACT_CHEST_BOAT);
     public static final EntityType CAT = define("cat", ABSTRACT_TAMEABLE_ANIMAL);
     public static final EntityType CAMEL = define("camel", ABSTRACT_HORSE);
     public static final EntityType SPIDER = define("spider", ABSTRACT_MONSTER);
@@ -167,13 +195,13 @@ public final class EntityTypes {
     public static final EntityType SLIME = define("slime", ABSTRACT_INSENTIENT);
     public static final EntityType MAGMA_CUBE = define("magma_cube", SLIME);
     public static final EntityType MARKER = define("marker", ENTITY);
-    public static final EntityType MINECART = define("minecart", MINECART_ABSTRACT);
-    public static final EntityType CHEST_MINECART = define("chest_minecart", CHESTED_MINECART_ABSTRACT);
-    public static final EntityType COMMAND_BLOCK_MINECART = define("command_block_minecart", MINECART_ABSTRACT);
-    public static final EntityType FURNACE_MINECART = define("furnace_minecart", MINECART_ABSTRACT);
-    public static final EntityType HOPPER_MINECART = define("hopper_minecart", CHESTED_MINECART_ABSTRACT);
-    public static final EntityType SPAWNER_MINECART = define("spawner_minecart", MINECART_ABSTRACT);
-    public static final EntityType TNT_MINECART = define("tnt_minecart", MINECART_ABSTRACT);
+    public static final EntityType MINECART = define("minecart", ABSTRACT_MINECART);
+    public static final EntityType CHEST_MINECART = define("chest_minecart", ABSTRACT_CHESTED_MINECART);
+    public static final EntityType COMMAND_BLOCK_MINECART = define("command_block_minecart", ABSTRACT_MINECART);
+    public static final EntityType FURNACE_MINECART = define("furnace_minecart", ABSTRACT_MINECART);
+    public static final EntityType HOPPER_MINECART = define("hopper_minecart", ABSTRACT_CHESTED_MINECART);
+    public static final EntityType SPAWNER_MINECART = define("spawner_minecart", ABSTRACT_MINECART);
+    public static final EntityType TNT_MINECART = define("tnt_minecart", ABSTRACT_MINECART);
     public static final EntityType MULE = define("mule", CHESTED_HORSE);
     public static final EntityType MOOSHROOM = define("mooshroom", COW);
     public static final EntityType OCELOT = define("ocelot", ABSTRACT_TAMEABLE_ANIMAL);
@@ -199,18 +227,18 @@ public final class EntityTypes {
     public static final EntityType SKELETON_HORSE = define("skeleton_horse", ABSTRACT_HORSE);
     public static final EntityType SMALL_FIREBALL = define("small_fireball", ABSTRACT_FIREBALL);
     public static final EntityType SNOW_GOLEM = define("snow_golem", ABSTRACT_GOLEM);
-    public static final EntityType SNOWBALL = define("snowball", PROJECTILE_ABSTRACT);
+    public static final EntityType SNOWBALL = define("snowball", ABSTRACT_PROJECTILE);
     public static final EntityType SPECTRAL_ARROW = define("spectral_arrow", ABSTRACT_ARROW);
     public static final EntityType STRAY = define("stray", ABSTRACT_SKELETON);
     public static final EntityType STRIDER = define("strider", ABSTRACT_ANIMAL);
-    public static final EntityType EGG = define("egg", PROJECTILE_ABSTRACT);
-    public static final EntityType ENDER_PEARL = define("ender_pearl", PROJECTILE_ABSTRACT);
-    public static final EntityType EXPERIENCE_BOTTLE = define("experience_bottle", PROJECTILE_ABSTRACT);
+    public static final EntityType EGG = define("egg", ABSTRACT_PROJECTILE);
+    public static final EntityType ENDER_PEARL = define("ender_pearl", ABSTRACT_PROJECTILE);
+    public static final EntityType EXPERIENCE_BOTTLE = define("experience_bottle", ABSTRACT_PROJECTILE);
     /**
      * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.5, this has
      * been split into {@link #SPLASH_POTION} and {@link #LINGERING_POTION}
      */
-    public static final EntityType POTION = define("potion", PROJECTILE_ABSTRACT);
+    public static final EntityType POTION = define("potion", ABSTRACT_PROJECTILE);
     public static final EntityType TADPOLE = define("tadpole", ABSTRACT_FISHES);
     @Deprecated // Exists only in 1.9 and 1.10
     public static final EntityType TIPPED_ARROW = define("tipped_arrow", ARROW);
@@ -235,16 +263,16 @@ public final class EntityTypes {
     public static final EntityType PLAYER = define("player", AVATAR);
     public static final EntityType FISHING_BOBBER = define("fishing_bobber", ENTITY);
     public static final EntityType ENDER_SIGNAL = define("ender_signal", ENTITY);
-    public static final EntityType THROWN_EXP_BOTTLE = define("thrown_exp_bottle", PROJECTILE_ABSTRACT);
+    public static final EntityType THROWN_EXP_BOTTLE = define("thrown_exp_bottle", ABSTRACT_PROJECTILE);
     public static final EntityType PRIMED_TNT = define("primed_tnt", ENTITY);
     public static final EntityType FIREWORK = define("firework", ENTITY);
-    public static final EntityType MINECART_COMMAND = define("minecart_command", MINECART_ABSTRACT);
-    public static final EntityType MINECART_RIDEABLE = define("minecart_rideable", MINECART_ABSTRACT);
-    public static final EntityType MINECART_CHEST = define("minecart_chest", MINECART_ABSTRACT);
-    public static final EntityType MINECART_FURNACE = define("minecart_furnace", MINECART_ABSTRACT);
-    public static final EntityType MINECART_TNT = define("minecart_tnt", MINECART_ABSTRACT);
-    public static final EntityType MINECART_HOPPER = define("minecart_hopper", MINECART_ABSTRACT);
-    public static final EntityType MINECART_MOB_SPAWNER = define("minecart_mob_spawner", MINECART_ABSTRACT);
+    public static final EntityType MINECART_COMMAND = define("minecart_command", ABSTRACT_MINECART);
+    public static final EntityType MINECART_RIDEABLE = define("minecart_rideable", ABSTRACT_MINECART);
+    public static final EntityType MINECART_CHEST = define("minecart_chest", ABSTRACT_MINECART);
+    public static final EntityType MINECART_FURNACE = define("minecart_furnace", ABSTRACT_MINECART);
+    public static final EntityType MINECART_TNT = define("minecart_tnt", ABSTRACT_MINECART);
+    public static final EntityType MINECART_HOPPER = define("minecart_hopper", ABSTRACT_MINECART);
+    public static final EntityType MINECART_MOB_SPAWNER = define("minecart_mob_spawner", ABSTRACT_MINECART);
     /**
      * @versions 1.19.4+
      */
@@ -276,7 +304,7 @@ public final class EntityTypes {
     /**
      * @versions 1.20.3+
      */
-    public static final EntityType ABSTRACT_WIND_CHARGE = define("abstract_wind_charge", PROJECTILE_ABSTRACT);
+    public static final EntityType ABSTRACT_WIND_CHARGE = define("abstract_wind_charge", ABSTRACT_PROJECTILE);
     /**
      * @versions 1.20.3+
      */

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/EntityTypes.java
@@ -18,458 +18,617 @@
 
 package com.github.retrooper.packetevents.protocol.entity.type;
 
-import com.github.retrooper.packetevents.protocol.player.ClientVersion;
-import com.github.retrooper.packetevents.util.mappings.VersionedRegistry;
+import java.util.Collection;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.util.mappings.VersionedRegistry;
+
+// bejiihiu loves node.js
 
 public final class EntityTypes {
 
-    private static final VersionedRegistry<EntityType> REGISTRY = new VersionedRegistry<>("entity_type");
-    private static final VersionedRegistry<EntityType> LEGACY_SPAWN_REGISTRY = new VersionedRegistry<>("legacy_spawn_entity_type");
+	private static final VersionedRegistry<EntityType> REGISTRY = new VersionedRegistry<>("entity_type");
+	private static final VersionedRegistry<EntityType> LEGACY_SPAWN_REGISTRY = new VersionedRegistry<>(
+			"legacy_spawn_entity_type");
 
-    private EntityTypes() {
-    }
+	private EntityTypes() {
+	}
 
-    public static VersionedRegistry<EntityType> getRegistry() {
-        return REGISTRY;
-    }
+	public static VersionedRegistry<EntityType> getRegistry() {
+		return REGISTRY;
+	}
 
-    @ApiStatus.Obsolete
-    public static VersionedRegistry<EntityType> getLegacySpawnRegistry() {
-        return LEGACY_SPAWN_REGISTRY;
-    }
+	@ApiStatus.Obsolete
+	public static VersionedRegistry<EntityType> getLegacySpawnRegistry() {
+		return LEGACY_SPAWN_REGISTRY;
+	}
 
-    @ApiStatus.Internal
-    public static EntityType define(String name, @Nullable EntityType parent) {
-        StaticEntityType type = REGISTRY.define(name, data ->
-                new StaticEntityType(data, parent));
-        return LEGACY_SPAWN_REGISTRY.define(name, type::setLegacyData);
-    }
+	@ApiStatus.Internal
+	public static EntityType define(String name, EntityClass clazz) {
+		return define(name, clazz, null);
+	}
 
-    public static boolean isTypeInstanceOf(EntityType type, EntityType parent) {
-        return type != null && type.isInstanceOf(parent);
-    }
+	@ApiStatus.Internal
+	public static EntityType define(String name, EntityClass clazz, @Nullable EntityType concreteParent) {
+		StaticEntityType type = REGISTRY.define(name, data -> new StaticEntityType(data, clazz, concreteParent));
+		return LEGACY_SPAWN_REGISTRY.define(name, type::setLegacyData);
+	}
 
-    public static EntityType getByName(String name) {
-        return REGISTRY.getByName(name);
-    }
+	@Deprecated
+	private static EntityType bridge(EntityClass clazz) {
+		return new StaticEntityType(null, clazz);
+	}
 
-    public static EntityType getById(ClientVersion version, int id) {
-        return REGISTRY.getById(version, id);
-    }
+	@SuppressWarnings("deprecation")
+	public static boolean isTypeInstanceOf(EntityType type, EntityType parent) {
+		return type != null && type.isInstanceOf(parent);
+	}
 
-    @ApiStatus.Obsolete
-    public static EntityType getByLegacyId(ClientVersion version, int id) {
-        if (version.isNewerThanOrEquals(ClientVersion.V_1_14)) {
-            return null;
-        }
-        return LEGACY_SPAWN_REGISTRY.getById(version, id);
-    }
+	public static EntityType getByName(String name) {
+		return REGISTRY.getByName(name);
+	}
 
-    // Credit to ViaVersion for these categories
-    public static final EntityType ENTITY = define("entity", null);
-    public static final EntityType LIVING_ENTITY = define("livingentity", ENTITY);
-    /**
-     * @deprecated Use {@link #LIVING_ENTITY}
-     */
-    @Deprecated
-    public static final EntityType LIVINGENTITY = LIVING_ENTITY;
-    public static final EntityType ABSTRACT_INSENTIENT = define("abstract_insentient", LIVING_ENTITY);
-    public static final EntityType ABSTRACT_CREATURE = define("abstract_creature", ABSTRACT_INSENTIENT);
-    public static final EntityType ABSTRACT_AGEABLE = define("abstract_ageable", ABSTRACT_CREATURE);
-    public static final EntityType ABSTRACT_ANIMAL = define("abstract_animal", ABSTRACT_AGEABLE);
-    public static final EntityType ABSTRACT_TAMEABLE_ANIMAL = define("abstract_tameable_animal", ABSTRACT_ANIMAL);
-    public static final EntityType ABSTRACT_PARROT = define("abstract_parrot", ABSTRACT_TAMEABLE_ANIMAL);
-    public static final EntityType ABSTRACT_HORSE = define("abstract_horse", ABSTRACT_ANIMAL);
-    public static final EntityType CHESTED_HORSE = define("chested_horse", ABSTRACT_HORSE);
-    public static final EntityType ABSTRACT_GOLEM = define("abstract_golem", ABSTRACT_CREATURE);
-    public static final EntityType ABSTRACT_FISHES = define("abstract_fishes", ABSTRACT_CREATURE);
-    public static final EntityType ABSTRACT_MONSTER = define("abstract_monster", ABSTRACT_CREATURE);
-    public static final EntityType ABSTRACT_PIGLIN = define("abstract_piglin", ABSTRACT_MONSTER);
-    public static final EntityType ABSTRACT_ILLAGER_BASE = define("abstract_illager_base", ABSTRACT_MONSTER);
-    public static final EntityType ABSTRACT_EVO_ILLU_ILLAGER = define("abstract_evo_illu_illager", ABSTRACT_ILLAGER_BASE);
-    public static final EntityType ABSTRACT_SKELETON = define("abstract_skeleton", ABSTRACT_MONSTER);
-    public static final EntityType ABSTRACT_FLYING = define("abstract_flying", ABSTRACT_INSENTIENT);
-    public static final EntityType ABSTRACT_AMBIENT = define("abstract_ambient", ABSTRACT_INSENTIENT);
-    public static final EntityType ABSTRACT_WATERMOB = define("abstract_watermob", ABSTRACT_INSENTIENT);
-    public static final EntityType ABSTRACT_HANGING = define("abstract_hanging", ENTITY);
-    public static final EntityType ABSTRACT_LIGHTNING = define("abstract_lightning", ENTITY);
-    public static final EntityType ABSTRACT_ARROW = define("abstract_arrow", ENTITY);
-    public static final EntityType ABSTRACT_FIREBALL = define("abstract_fireball", ENTITY);
-    public static final EntityType ABSTRACT_PROJECTILE = define("projectile_abstract", ENTITY);
-    /**
-     * @deprecated Use {@link #ABSTRACT_PROJECTILE}
-     */
-    @Deprecated
-    public static final EntityType PROJECTILE_ABSTRACT = ABSTRACT_PROJECTILE;
-    public static final EntityType ABSTRACT_MINECART = define("minecart_abstract", ENTITY);
-    /**
-     * @deprecated Use {@link #ABSTRACT_MINECART}
-     */
-    @Deprecated
-    public static final EntityType MINECART_ABSTRACT = ABSTRACT_MINECART;
-    public static final EntityType ABSTRACT_CHESTED_MINECART = define("chested_minecart_abstract", ABSTRACT_MINECART);
-    /**
-     * @deprecated Use {@link #ABSTRACT_CHESTED_MINECART}
-     */
-    @Deprecated
-    public static final EntityType CHESTED_MINECART_ABSTRACT = ABSTRACT_CHESTED_MINECART;
-    /**
-     * Virtual parent type for all boat entities.
-     */
-    public static final EntityType ABSTRACT_BOAT = define("abstract_boat", ENTITY);
-    /**
-     * Virtual parent type for all chest boat entities.
-     */
-    public static final EntityType ABSTRACT_CHEST_BOAT = define("abstract_chest_boat", ABSTRACT_BOAT);
-    /**
-     * Not spawnable
-     *
-     * @versions 1.21.9+
-     */
-    public static final EntityType AVATAR = define("avatar", LIVING_ENTITY);
-    public static final EntityType AREA_EFFECT_CLOUD = define("area_effect_cloud", ENTITY);
-    public static final EntityType ARMOR_STAND = define("armor_stand", LIVING_ENTITY);
-    public static final EntityType ALLAY = define("allay", ABSTRACT_CREATURE);
-    public static final EntityType ARROW = define("arrow", ABSTRACT_ARROW);
-    public static final EntityType AXOLOTL = define("axolotl", ABSTRACT_ANIMAL);
-    public static final EntityType BAT = define("bat", ABSTRACT_AMBIENT);
-    public static final EntityType BEE = define("bee", ABSTRACT_INSENTIENT);
-    public static final EntityType BLAZE = define("blaze", ABSTRACT_MONSTER);
-    /**
-     * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
-     */
-    public static final EntityType BOAT = define("boat", ABSTRACT_BOAT);
-    /**
-     * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
-     */
-    public static final EntityType CHEST_BOAT = define("chest_boat", ABSTRACT_CHEST_BOAT);
-    public static final EntityType CAT = define("cat", ABSTRACT_TAMEABLE_ANIMAL);
-    public static final EntityType CAMEL = define("camel", ABSTRACT_HORSE);
-    public static final EntityType SPIDER = define("spider", ABSTRACT_MONSTER);
-    public static final EntityType CAVE_SPIDER = define("cave_spider", SPIDER);
-    public static final EntityType CHICKEN = define("chicken", ABSTRACT_ANIMAL);
-    public static final EntityType COD = define("cod", ABSTRACT_FISHES);
-    public static final EntityType COW = define("cow", ABSTRACT_ANIMAL);
-    public static final EntityType CREEPER = define("creeper", ABSTRACT_MONSTER);
-    public static final EntityType DOLPHIN = define("dolphin", ABSTRACT_INSENTIENT);
-    public static final EntityType DONKEY = define("donkey", CHESTED_HORSE);
-    public static final EntityType DRAGON_FIREBALL = define("dragon_fireball", ABSTRACT_FIREBALL);
-    public static final EntityType ZOMBIE = define("zombie", ABSTRACT_MONSTER);
-    public static final EntityType DROWNED = define("drowned", ZOMBIE);
-    public static final EntityType GUARDIAN = define("guardian", ABSTRACT_MONSTER);
-    public static final EntityType ELDER_GUARDIAN = define("elder_guardian", GUARDIAN);
-    public static final EntityType END_CRYSTAL = define("end_crystal", ENTITY);
-    public static final EntityType ENDER_DRAGON = define("ender_dragon", ABSTRACT_INSENTIENT);
-    public static final EntityType ENDERMAN = define("enderman", ABSTRACT_MONSTER);
-    public static final EntityType ENDERMITE = define("endermite", ABSTRACT_MONSTER);
-    public static final EntityType EVOKER = define("evoker", ABSTRACT_EVO_ILLU_ILLAGER);
-    public static final EntityType EVOKER_FANGS = define("evoker_fangs", ENTITY);
-    public static final EntityType EXPERIENCE_ORB = define("experience_orb", ENTITY);
-    public static final EntityType EYE_OF_ENDER = define("eye_of_ender", ENTITY);
-    public static final EntityType FALLING_BLOCK = define("falling_block", ENTITY);
-    public static final EntityType FIREWORK_ROCKET = define("firework_rocket", ENTITY);
-    public static final EntityType FOX = define("fox", ABSTRACT_ANIMAL);
-    public static final EntityType FROG = define("frog", ABSTRACT_ANIMAL);
-    public static final EntityType GHAST = define("ghast", ABSTRACT_FLYING);
-    public static final EntityType GIANT = define("giant", ABSTRACT_MONSTER);
-    public static final EntityType ITEM_FRAME = define("item_frame", ABSTRACT_HANGING);
-    public static final EntityType GLOW_ITEM_FRAME = define("glow_item_frame", ITEM_FRAME);
-    public static final EntityType SQUID = define("squid", ABSTRACT_WATERMOB);
-    public static final EntityType GLOW_SQUID = define("glow_squid", SQUID);
-    public static final EntityType GOAT = define("goat", ABSTRACT_ANIMAL);
-    public static final EntityType HOGLIN = define("hoglin", ABSTRACT_ANIMAL);
-    public static final EntityType HORSE = define("horse", ABSTRACT_HORSE);
-    public static final EntityType HUSK = define("husk", ZOMBIE);
-    public static final EntityType ILLUSIONER = define("illusioner", ABSTRACT_EVO_ILLU_ILLAGER);
-    public static final EntityType IRON_GOLEM = define("iron_golem", ABSTRACT_GOLEM);
-    public static final EntityType ITEM = define("item", ENTITY);
-    public static final EntityType FIREBALL = define("fireball", ABSTRACT_FIREBALL);
-    public static final EntityType LEASH_KNOT = define("leash_knot", ABSTRACT_HANGING);
-    public static final EntityType LIGHTNING_BOLT = define("lightning_bolt", ABSTRACT_LIGHTNING);
-    public static final EntityType LLAMA = define("llama", CHESTED_HORSE);
-    public static final EntityType LLAMA_SPIT = define("llama_spit", ENTITY);
-    public static final EntityType SLIME = define("slime", ABSTRACT_INSENTIENT);
-    public static final EntityType MAGMA_CUBE = define("magma_cube", SLIME);
-    public static final EntityType MARKER = define("marker", ENTITY);
-    public static final EntityType MINECART = define("minecart", ABSTRACT_MINECART);
-    public static final EntityType CHEST_MINECART = define("chest_minecart", ABSTRACT_CHESTED_MINECART);
-    public static final EntityType COMMAND_BLOCK_MINECART = define("command_block_minecart", ABSTRACT_MINECART);
-    public static final EntityType FURNACE_MINECART = define("furnace_minecart", ABSTRACT_MINECART);
-    public static final EntityType HOPPER_MINECART = define("hopper_minecart", ABSTRACT_CHESTED_MINECART);
-    public static final EntityType SPAWNER_MINECART = define("spawner_minecart", ABSTRACT_MINECART);
-    public static final EntityType TNT_MINECART = define("tnt_minecart", ABSTRACT_MINECART);
-    public static final EntityType MULE = define("mule", CHESTED_HORSE);
-    public static final EntityType MOOSHROOM = define("mooshroom", COW);
-    public static final EntityType OCELOT = define("ocelot", ABSTRACT_TAMEABLE_ANIMAL);
-    public static final EntityType PAINTING = define("painting", ABSTRACT_HANGING);
-    public static final EntityType PANDA = define("panda", ABSTRACT_INSENTIENT);
-    public static final EntityType PARROT = define("parrot", ABSTRACT_PARROT);
-    public static final EntityType PHANTOM = define("phantom", ABSTRACT_FLYING);
-    public static final EntityType PIG = define("pig", ABSTRACT_ANIMAL);
-    public static final EntityType PIGLIN = define("piglin", ABSTRACT_PIGLIN);
-    public static final EntityType PIGLIN_BRUTE = define("piglin_brute", ABSTRACT_PIGLIN);
-    public static final EntityType PILLAGER = define("pillager", ABSTRACT_ILLAGER_BASE);
-    public static final EntityType POLAR_BEAR = define("polar_bear", ABSTRACT_ANIMAL);
-    public static final EntityType TNT = define("tnt", ENTITY);
-    public static final EntityType PUFFERFISH = define("pufferfish", ABSTRACT_FISHES);
-    public static final EntityType RABBIT = define("rabbit", ABSTRACT_ANIMAL);
-    public static final EntityType RAVAGER = define("ravager", ABSTRACT_MONSTER);
-    public static final EntityType SALMON = define("salmon", ABSTRACT_FISHES);
-    public static final EntityType SHEEP = define("sheep", ABSTRACT_ANIMAL);
-    public static final EntityType SHULKER = define("shulker", ABSTRACT_GOLEM); // yes this is correct
-    public static final EntityType SHULKER_BULLET = define("shulker_bullet", ENTITY);
-    public static final EntityType SILVERFISH = define("silverfish", ABSTRACT_MONSTER);
-    public static final EntityType SKELETON = define("skeleton", ABSTRACT_SKELETON);
-    public static final EntityType SKELETON_HORSE = define("skeleton_horse", ABSTRACT_HORSE);
-    public static final EntityType SMALL_FIREBALL = define("small_fireball", ABSTRACT_FIREBALL);
-    public static final EntityType SNOW_GOLEM = define("snow_golem", ABSTRACT_GOLEM);
-    public static final EntityType SNOWBALL = define("snowball", ABSTRACT_PROJECTILE);
-    public static final EntityType SPECTRAL_ARROW = define("spectral_arrow", ABSTRACT_ARROW);
-    public static final EntityType STRAY = define("stray", ABSTRACT_SKELETON);
-    public static final EntityType STRIDER = define("strider", ABSTRACT_ANIMAL);
-    public static final EntityType EGG = define("egg", ABSTRACT_PROJECTILE);
-    public static final EntityType ENDER_PEARL = define("ender_pearl", ABSTRACT_PROJECTILE);
-    public static final EntityType EXPERIENCE_BOTTLE = define("experience_bottle", ABSTRACT_PROJECTILE);
-    /**
-     * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.5, this has
-     * been split into {@link #SPLASH_POTION} and {@link #LINGERING_POTION}
-     */
-    public static final EntityType POTION = define("potion", ABSTRACT_PROJECTILE);
-    public static final EntityType TADPOLE = define("tadpole", ABSTRACT_FISHES);
-    @Deprecated // Exists only in 1.9 and 1.10
-    public static final EntityType TIPPED_ARROW = define("tipped_arrow", ARROW);
-    public static final EntityType TRIDENT = define("trident", ABSTRACT_ARROW);
-    public static final EntityType TRADER_LLAMA = define("trader_llama", CHESTED_HORSE);
-    public static final EntityType TROPICAL_FISH = define("tropical_fish", ABSTRACT_FISHES);
-    public static final EntityType TURTLE = define("turtle", ABSTRACT_ANIMAL);
-    public static final EntityType VEX = define("vex", ABSTRACT_MONSTER);
-    public static final EntityType VILLAGER = define("villager", ABSTRACT_AGEABLE);
-    public static final EntityType VINDICATOR = define("vindicator", ABSTRACT_ILLAGER_BASE);
-    public static final EntityType WANDERING_TRADER = define("wandering_trader", ABSTRACT_AGEABLE);
-    public static final EntityType WARDEN = define("warden", ABSTRACT_MONSTER);
-    public static final EntityType WITCH = define("witch", ABSTRACT_MONSTER);
-    public static final EntityType WITHER = define("wither", ABSTRACT_MONSTER);
-    public static final EntityType WITHER_SKELETON = define("wither_skeleton", ABSTRACT_SKELETON);
-    public static final EntityType WITHER_SKULL = define("wither_skull", ABSTRACT_FIREBALL);
-    public static final EntityType WOLF = define("wolf", ABSTRACT_TAMEABLE_ANIMAL);
-    public static final EntityType ZOGLIN = define("zoglin", ABSTRACT_MONSTER);
-    public static final EntityType ZOMBIE_HORSE = define("zombie_horse", ABSTRACT_HORSE);
-    public static final EntityType ZOMBIE_VILLAGER = define("zombie_villager", ZOMBIE);
-    public static final EntityType ZOMBIFIED_PIGLIN = define("zombified_piglin", ZOMBIE);
-    public static final EntityType PLAYER = define("player", AVATAR);
-    public static final EntityType FISHING_BOBBER = define("fishing_bobber", ENTITY);
-    public static final EntityType ENDER_SIGNAL = define("ender_signal", ENTITY);
-    public static final EntityType THROWN_EXP_BOTTLE = define("thrown_exp_bottle", ABSTRACT_PROJECTILE);
-    public static final EntityType PRIMED_TNT = define("primed_tnt", ENTITY);
-    public static final EntityType FIREWORK = define("firework", ENTITY);
-    public static final EntityType MINECART_COMMAND = define("minecart_command", ABSTRACT_MINECART);
-    public static final EntityType MINECART_RIDEABLE = define("minecart_rideable", ABSTRACT_MINECART);
-    public static final EntityType MINECART_CHEST = define("minecart_chest", ABSTRACT_MINECART);
-    public static final EntityType MINECART_FURNACE = define("minecart_furnace", ABSTRACT_MINECART);
-    public static final EntityType MINECART_TNT = define("minecart_tnt", ABSTRACT_MINECART);
-    public static final EntityType MINECART_HOPPER = define("minecart_hopper", ABSTRACT_MINECART);
-    public static final EntityType MINECART_MOB_SPAWNER = define("minecart_mob_spawner", ABSTRACT_MINECART);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType DISPLAY = define("display", ENTITY);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType BLOCK_DISPLAY = define("block_display", DISPLAY);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType ITEM_DISPLAY = define("item_display", DISPLAY);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType TEXT_DISPLAY = define("text_display", DISPLAY);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType INTERACTION = define("interaction", DISPLAY);
-    /**
-     * @versions 1.19.4+
-     */
-    public static final EntityType SNIFFER = define("sniffer", ABSTRACT_ANIMAL);
-    /**
-     * @versions 1.20.3+
-     */
-    public static final EntityType BREEZE = define("breeze", ABSTRACT_MONSTER);
-    /**
-     * @versions 1.20.3+
-     */
-    public static final EntityType ABSTRACT_WIND_CHARGE = define("abstract_wind_charge", ABSTRACT_PROJECTILE);
-    /**
-     * @versions 1.20.3+
-     */
-    public static final EntityType WIND_CHARGE = define("wind_charge", ABSTRACT_WIND_CHARGE);
-    /**
-     * @versions 1.20.5+
-     */
-    public static final EntityType ARMADILLO = define("armadillo", ABSTRACT_ANIMAL);
-    /**
-     * @versions 1.20.5+
-     */
-    public static final EntityType BOGGED = define("bogged", ABSTRACT_SKELETON);
-    /**
-     * @versions 1.20.5+
-     */
-    public static final EntityType BREEZE_WIND_CHARGE = define("breeze_wind_charge", ABSTRACT_WIND_CHARGE);
-    /**
-     * @versions 1.20.5+
-     */
-    public static final EntityType OMINOUS_ITEM_SPAWNER = define("ominous_item_spawner", ENTITY);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType ACACIA_BOAT = define("acacia_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType ACACIA_CHEST_BOAT = define("acacia_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType BAMBOO_CHEST_RAFT = define("bamboo_chest_raft", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType BAMBOO_RAFT = define("bamboo_raft", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType BIRCH_BOAT = define("birch_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType BIRCH_CHEST_BOAT = define("birch_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType CHERRY_BOAT = define("cherry_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType CHERRY_CHEST_BOAT = define("cherry_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType CREAKING = define("creaking", ABSTRACT_MONSTER);
-    /**
-     * @versions 1.21.2-1.21.3
-     */
-    @ApiStatus.Obsolete
-    public static final EntityType CREAKING_TRANSIENT = define("creaking_transient", CREAKING);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType DARK_OAK_BOAT = define("dark_oak_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType DARK_OAK_CHEST_BOAT = define("dark_oak_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType JUNGLE_BOAT = define("jungle_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType JUNGLE_CHEST_BOAT = define("jungle_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType MANGROVE_BOAT = define("mangrove_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType MANGROVE_CHEST_BOAT = define("mangrove_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType OAK_BOAT = define("oak_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType OAK_CHEST_BOAT = define("oak_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType PALE_OAK_BOAT = define("pale_oak_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType PALE_OAK_CHEST_BOAT = define("pale_oak_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType SPRUCE_BOAT = define("spruce_boat", BOAT);
-    /**
-     * @versions 1.21.2+
-     */
-    public static final EntityType SPRUCE_CHEST_BOAT = define("spruce_chest_boat", CHEST_BOAT);
-    /**
-     * @versions 1.21.5+
-     */
-    public static final EntityType SPLASH_POTION = define("splash_potion", POTION);
-    /**
-     * @versions 1.21.5+
-     */
-    public static final EntityType LINGERING_POTION = define("lingering_potion", POTION);
-    /**
-     * @versions 1.21.6+
-     */
-    public static final EntityType HAPPY_GHAST = define("happy_ghast", ABSTRACT_ANIMAL);
-    /**
-     * @versions 1.21.9+
-     */
-    public static final EntityType COPPER_GOLEM = define("copper_golem", ABSTRACT_GOLEM);
-    /**
-     * @versions 1.21.9+
-     */
-    public static final EntityType MANNEQUIN = define("mannequin", AVATAR);
-    /**
-     * @versions 1.21.11+
-     */
-    public static final EntityType CAMEL_HUSK = define("camel_husk", CAMEL);
-    /**
-     * @versions 1.21.11+
-     */
-    public static final EntityType ABSTRACT_NAUTILUS = define("abstract_nautilus", ABSTRACT_TAMEABLE_ANIMAL);
-    /**
-     * @versions 1.21.11+
-     */
-    public static final EntityType NAUTILUS = define("nautilus", ABSTRACT_NAUTILUS);
-    /**
-     * @versions 1.21.11+
-     */
-    public static final EntityType PARCHED = define("parched", ABSTRACT_SKELETON);
-    /**
-     * @versions 1.21.11+
-     */
-    public static final EntityType ZOMBIE_NAUTILUS = define("zombie_nautilus", ABSTRACT_NAUTILUS);
-    /**
-     * @versions 26.2+
-     */
-    public static final EntityType SULFUR_CUBE = define("sulfur_cube", ABSTRACT_AGEABLE);
+	public static EntityType getById(ClientVersion version, int id) {
+		return REGISTRY.getById(version, id);
+	}
 
-    /**
-     * Returns an immutable view of the entity types.
-     *
-     * @return Entity Types
-     */
-    public static Collection<EntityType> values() {
-        return REGISTRY.getEntries();
-    }
+	@ApiStatus.Obsolete
+	public static EntityType getByLegacyId(ClientVersion version, int id) {
+		if (version.isNewerThanOrEquals(ClientVersion.V_1_14)) {
+			return null;
+		}
+		return LEGACY_SPAWN_REGISTRY.getById(version, id);
+	}
 
-    static {
-        REGISTRY.unloadMappings();
-        LEGACY_SPAWN_REGISTRY.unloadMappings();
-    }
+	// ═══════════════════════════════════════════════
+	// DEPRECATED HIERARCHY BRIDGES
+	// These constants exist only for backward compat.
+	// Use EntityHierarchy.XYZ instead.
+	// ═══════════════════════════════════════════════
+
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ENTITY}
+	 */
+	@Deprecated
+	public static final EntityType ENTITY = bridge(EntityHierarchy.ENTITY);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#LIVING_ENTITY}
+	 */
+	@Deprecated
+	public static final EntityType LIVING_ENTITY = bridge(EntityHierarchy.LIVING_ENTITY);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#LIVING_ENTITY}
+	 */
+	@Deprecated
+	public static final EntityType LIVINGENTITY = LIVING_ENTITY;
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_INSENTIENT}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_INSENTIENT = bridge(EntityHierarchy.ABSTRACT_INSENTIENT);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_CREATURE}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_CREATURE = bridge(EntityHierarchy.ABSTRACT_CREATURE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_AGEABLE}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_AGEABLE = bridge(EntityHierarchy.ABSTRACT_AGEABLE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_ANIMAL}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_ANIMAL = bridge(EntityHierarchy.ABSTRACT_ANIMAL);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_TAMEABLE_ANIMAL}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_TAMEABLE_ANIMAL = bridge(EntityHierarchy.ABSTRACT_TAMEABLE_ANIMAL);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_PARROT}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_PARROT = bridge(EntityHierarchy.ABSTRACT_PARROT);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_HORSE}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_HORSE = bridge(EntityHierarchy.ABSTRACT_HORSE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#CHESTED_HORSE}
+	 */
+	@Deprecated
+	public static final EntityType CHESTED_HORSE = bridge(EntityHierarchy.CHESTED_HORSE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_GOLEM}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_GOLEM = bridge(EntityHierarchy.ABSTRACT_GOLEM);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_FISHES}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_FISHES = bridge(EntityHierarchy.ABSTRACT_FISHES);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_MONSTER}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_MONSTER = bridge(EntityHierarchy.ABSTRACT_MONSTER);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_PIGLIN}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_PIGLIN = bridge(EntityHierarchy.ABSTRACT_PIGLIN);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_ILLAGER}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_ILLAGER_BASE = bridge(EntityHierarchy.ABSTRACT_ILLAGER);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_EVO_ILLU_ILLAGER}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_EVO_ILLU_ILLAGER = bridge(EntityHierarchy.ABSTRACT_EVO_ILLU_ILLAGER);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_SKELETON}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_SKELETON = bridge(EntityHierarchy.ABSTRACT_SKELETON);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_FLYING}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_FLYING = bridge(EntityHierarchy.ABSTRACT_FLYING);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_AMBIENT}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_AMBIENT = bridge(EntityHierarchy.ABSTRACT_AMBIENT);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_WATERMOB}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_WATERMOB = bridge(EntityHierarchy.ABSTRACT_WATERMOB);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_HANGING}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_HANGING = bridge(EntityHierarchy.ABSTRACT_HANGING);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_LIGHTNING}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_LIGHTNING = bridge(EntityHierarchy.ABSTRACT_LIGHTNING);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_ARROW}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_ARROW = bridge(EntityHierarchy.ABSTRACT_ARROW);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_FIREBALL}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_FIREBALL = bridge(EntityHierarchy.ABSTRACT_FIREBALL);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_PROJECTILE}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_PROJECTILE = bridge(EntityHierarchy.ABSTRACT_PROJECTILE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_PROJECTILE}
+	 */
+	@Deprecated
+	public static final EntityType PROJECTILE_ABSTRACT = ABSTRACT_PROJECTILE;
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_MINECART}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_MINECART = bridge(EntityHierarchy.ABSTRACT_MINECART);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_MINECART}
+	 */
+	@Deprecated
+	public static final EntityType MINECART_ABSTRACT = ABSTRACT_MINECART;
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_CHESTED_MINECART}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_CHESTED_MINECART = bridge(EntityHierarchy.ABSTRACT_CHESTED_MINECART);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_CHESTED_MINECART}
+	 */
+	@Deprecated
+	public static final EntityType CHESTED_MINECART_ABSTRACT = ABSTRACT_CHESTED_MINECART;
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_BOAT}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_BOAT = bridge(EntityHierarchy.ABSTRACT_BOAT);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_CHEST_BOAT}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_CHEST_BOAT = bridge(EntityHierarchy.ABSTRACT_CHEST_BOAT);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_WIND_CHARGE}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_WIND_CHARGE = bridge(EntityHierarchy.ABSTRACT_WIND_CHARGE);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#ABSTRACT_NAUTILUS}
+	 */
+	@Deprecated
+	public static final EntityType ABSTRACT_NAUTILUS = bridge(EntityHierarchy.ABSTRACT_NAUTILUS);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#AVATAR}
+	 */
+	@Deprecated
+	public static final EntityType AVATAR = bridge(EntityHierarchy.AVATAR);
+	/**
+	 * @deprecated Use {@link EntityHierarchy#DISPLAY}
+	 */
+	@Deprecated
+	public static final EntityType DISPLAY = bridge(EntityHierarchy.DISPLAY);
+
+	// ═══════════════════════════════════════════════
+	// CONCRETE TYPES (from minecraft:entity_type)
+	// Every entry here is a real registry entry.
+	// ═══════════════════════════════════════════════
+
+	public static final EntityType AREA_EFFECT_CLOUD = define("area_effect_cloud", EntityHierarchy.ENTITY);
+	public static final EntityType ARMOR_STAND = define("armor_stand", EntityHierarchy.LIVING_ENTITY);
+	public static final EntityType ALLAY = define("allay", EntityHierarchy.ABSTRACT_CREATURE);
+	public static final EntityType ARROW = define("arrow", EntityHierarchy.ABSTRACT_ARROW);
+	public static final EntityType AXOLOTL = define("axolotl", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType BAT = define("bat", EntityHierarchy.ABSTRACT_AMBIENT);
+	public static final EntityType BEE = define("bee", EntityHierarchy.ABSTRACT_INSENTIENT);
+	public static final EntityType BLAZE = define("blaze", EntityHierarchy.ABSTRACT_MONSTER);
+	/**
+	 * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
+	 */
+	public static final EntityType BOAT = define("boat", EntityHierarchy.ABSTRACT_BOAT);
+	/**
+	 * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.2
+	 */
+	public static final EntityType CHEST_BOAT = define("chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT);
+	public static final EntityType CAT = define("cat", EntityHierarchy.ABSTRACT_TAMEABLE_ANIMAL);
+	public static final EntityType CAMEL = define("camel", EntityHierarchy.ABSTRACT_HORSE);
+	public static final EntityType SPIDER = define("spider", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType CAVE_SPIDER = define("cave_spider", EntityHierarchy.ABSTRACT_MONSTER, SPIDER);
+	public static final EntityType CHICKEN = define("chicken", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType COD = define("cod", EntityHierarchy.ABSTRACT_FISHES);
+	public static final EntityType COW = define("cow", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType CREEPER = define("creeper", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType DOLPHIN = define("dolphin", EntityHierarchy.ABSTRACT_INSENTIENT);
+	public static final EntityType DONKEY = define("donkey", EntityHierarchy.CHESTED_HORSE);
+	public static final EntityType DRAGON_FIREBALL = define("dragon_fireball", EntityHierarchy.ABSTRACT_FIREBALL);
+	public static final EntityType ZOMBIE = define("zombie", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType DROWNED = define("drowned", EntityHierarchy.ABSTRACT_MONSTER, ZOMBIE);
+	public static final EntityType GUARDIAN = define("guardian", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType ELDER_GUARDIAN = define("elder_guardian", EntityHierarchy.ABSTRACT_MONSTER,
+			GUARDIAN);
+	public static final EntityType END_CRYSTAL = define("end_crystal", EntityHierarchy.ENTITY);
+	public static final EntityType ENDER_DRAGON = define("ender_dragon", EntityHierarchy.ABSTRACT_INSENTIENT);
+	public static final EntityType ENDERMAN = define("enderman", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType ENDERMITE = define("endermite", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType EVOKER = define("evoker", EntityHierarchy.ABSTRACT_EVO_ILLU_ILLAGER);
+	public static final EntityType EVOKER_FANGS = define("evoker_fangs", EntityHierarchy.ENTITY);
+	public static final EntityType EXPERIENCE_ORB = define("experience_orb", EntityHierarchy.ENTITY);
+	public static final EntityType EYE_OF_ENDER = define("eye_of_ender", EntityHierarchy.ENTITY);
+	public static final EntityType FALLING_BLOCK = define("falling_block", EntityHierarchy.ENTITY);
+	public static final EntityType FIREWORK_ROCKET = define("firework_rocket", EntityHierarchy.ENTITY);
+	public static final EntityType FOX = define("fox", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType FROG = define("frog", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType GHAST = define("ghast", EntityHierarchy.ABSTRACT_FLYING);
+	public static final EntityType GIANT = define("giant", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType ITEM_FRAME = define("item_frame", EntityHierarchy.ABSTRACT_HANGING);
+	public static final EntityType GLOW_ITEM_FRAME = define("glow_item_frame", EntityHierarchy.ABSTRACT_HANGING,
+			ITEM_FRAME);
+	public static final EntityType SQUID = define("squid", EntityHierarchy.ABSTRACT_WATERMOB);
+	public static final EntityType GLOW_SQUID = define("glow_squid", EntityHierarchy.ABSTRACT_WATERMOB, SQUID);
+	public static final EntityType GOAT = define("goat", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType HOGLIN = define("hoglin", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType HORSE = define("horse", EntityHierarchy.ABSTRACT_HORSE);
+	public static final EntityType HUSK = define("husk", EntityHierarchy.ABSTRACT_MONSTER, ZOMBIE);
+	public static final EntityType ILLUSIONER = define("illusioner", EntityHierarchy.ABSTRACT_EVO_ILLU_ILLAGER);
+	public static final EntityType IRON_GOLEM = define("iron_golem", EntityHierarchy.ABSTRACT_GOLEM);
+	public static final EntityType ITEM = define("item", EntityHierarchy.ENTITY);
+	public static final EntityType FIREBALL = define("fireball", EntityHierarchy.ABSTRACT_FIREBALL);
+	public static final EntityType LEASH_KNOT = define("leash_knot", EntityHierarchy.ABSTRACT_HANGING);
+	public static final EntityType LIGHTNING_BOLT = define("lightning_bolt", EntityHierarchy.ABSTRACT_LIGHTNING);
+	public static final EntityType LLAMA = define("llama", EntityHierarchy.CHESTED_HORSE);
+	public static final EntityType LLAMA_SPIT = define("llama_spit", EntityHierarchy.ENTITY);
+	public static final EntityType SLIME = define("slime", EntityHierarchy.ABSTRACT_INSENTIENT);
+	public static final EntityType MAGMA_CUBE = define("magma_cube", EntityHierarchy.ABSTRACT_INSENTIENT, SLIME);
+	public static final EntityType MARKER = define("marker", EntityHierarchy.ENTITY);
+	public static final EntityType MINECART = define("minecart", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType CHEST_MINECART = define("chest_minecart", EntityHierarchy.ABSTRACT_CHESTED_MINECART);
+	public static final EntityType COMMAND_BLOCK_MINECART = define("command_block_minecart",
+			EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType FURNACE_MINECART = define("furnace_minecart", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType HOPPER_MINECART = define("hopper_minecart",
+			EntityHierarchy.ABSTRACT_CHESTED_MINECART);
+	public static final EntityType SPAWNER_MINECART = define("spawner_minecart", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType TNT_MINECART = define("tnt_minecart", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MULE = define("mule", EntityHierarchy.CHESTED_HORSE);
+	public static final EntityType MOOSHROOM = define("mooshroom", EntityHierarchy.ABSTRACT_ANIMAL, COW);
+	public static final EntityType OCELOT = define("ocelot", EntityHierarchy.ABSTRACT_TAMEABLE_ANIMAL);
+	public static final EntityType PAINTING = define("painting", EntityHierarchy.ABSTRACT_HANGING);
+	public static final EntityType PANDA = define("panda", EntityHierarchy.ABSTRACT_INSENTIENT);
+	public static final EntityType PARROT = define("parrot", EntityHierarchy.ABSTRACT_PARROT);
+	public static final EntityType PHANTOM = define("phantom", EntityHierarchy.ABSTRACT_FLYING);
+	public static final EntityType PIG = define("pig", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType PIGLIN = define("piglin", EntityHierarchy.ABSTRACT_PIGLIN);
+	public static final EntityType PIGLIN_BRUTE = define("piglin_brute", EntityHierarchy.ABSTRACT_PIGLIN);
+	public static final EntityType PILLAGER = define("pillager", EntityHierarchy.ABSTRACT_ILLAGER);
+	public static final EntityType POLAR_BEAR = define("polar_bear", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType TNT = define("tnt", EntityHierarchy.ENTITY);
+	public static final EntityType PUFFERFISH = define("pufferfish", EntityHierarchy.ABSTRACT_FISHES);
+	public static final EntityType RABBIT = define("rabbit", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType RAVAGER = define("ravager", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType SALMON = define("salmon", EntityHierarchy.ABSTRACT_FISHES);
+	public static final EntityType SHEEP = define("sheep", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType SHULKER = define("shulker", EntityHierarchy.ABSTRACT_GOLEM); // yes this is correct
+	public static final EntityType SHULKER_BULLET = define("shulker_bullet", EntityHierarchy.ENTITY);
+	public static final EntityType SILVERFISH = define("silverfish", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType SKELETON = define("skeleton", EntityHierarchy.ABSTRACT_SKELETON);
+	public static final EntityType SKELETON_HORSE = define("skeleton_horse", EntityHierarchy.ABSTRACT_HORSE);
+	public static final EntityType SMALL_FIREBALL = define("small_fireball", EntityHierarchy.ABSTRACT_FIREBALL);
+	public static final EntityType SNOW_GOLEM = define("snow_golem", EntityHierarchy.ABSTRACT_GOLEM);
+	public static final EntityType SNOWBALL = define("snowball", EntityHierarchy.ABSTRACT_PROJECTILE);
+	public static final EntityType SPECTRAL_ARROW = define("spectral_arrow", EntityHierarchy.ABSTRACT_ARROW);
+	public static final EntityType STRAY = define("stray", EntityHierarchy.ABSTRACT_SKELETON);
+	public static final EntityType STRIDER = define("strider", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType EGG = define("egg", EntityHierarchy.ABSTRACT_PROJECTILE);
+	public static final EntityType ENDER_PEARL = define("ender_pearl", EntityHierarchy.ABSTRACT_PROJECTILE);
+	public static final EntityType EXPERIENCE_BOTTLE = define("experience_bottle", EntityHierarchy.ABSTRACT_PROJECTILE);
+	/**
+	 * <strong>WARNING:</strong> Does not exist itself anymore since 1.21.5, this
+	 * has
+	 * been split into {@link #SPLASH_POTION} and {@link #LINGERING_POTION}
+	 */
+	public static final EntityType POTION = define("potion", EntityHierarchy.ABSTRACT_PROJECTILE);
+	public static final EntityType TADPOLE = define("tadpole", EntityHierarchy.ABSTRACT_FISHES);
+	@Deprecated // Exists only in 1.9 and 1.10
+	public static final EntityType TIPPED_ARROW = define("tipped_arrow", EntityHierarchy.ABSTRACT_ARROW, ARROW);
+	public static final EntityType TRIDENT = define("trident", EntityHierarchy.ABSTRACT_ARROW);
+	public static final EntityType TRADER_LLAMA = define("trader_llama", EntityHierarchy.CHESTED_HORSE, LLAMA);
+	public static final EntityType TROPICAL_FISH = define("tropical_fish", EntityHierarchy.ABSTRACT_FISHES);
+	public static final EntityType TURTLE = define("turtle", EntityHierarchy.ABSTRACT_ANIMAL);
+	public static final EntityType VEX = define("vex", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType VILLAGER = define("villager", EntityHierarchy.ABSTRACT_AGEABLE);
+	public static final EntityType VINDICATOR = define("vindicator", EntityHierarchy.ABSTRACT_ILLAGER);
+	public static final EntityType WANDERING_TRADER = define("wandering_trader", EntityHierarchy.ABSTRACT_AGEABLE);
+	public static final EntityType WARDEN = define("warden", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType WITCH = define("witch", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType WITHER = define("wither", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType WITHER_SKELETON = define("wither_skeleton", EntityHierarchy.ABSTRACT_SKELETON);
+	public static final EntityType WITHER_SKULL = define("wither_skull", EntityHierarchy.ABSTRACT_FIREBALL);
+	public static final EntityType WOLF = define("wolf", EntityHierarchy.ABSTRACT_TAMEABLE_ANIMAL);
+	public static final EntityType ZOGLIN = define("zoglin", EntityHierarchy.ABSTRACT_MONSTER);
+	public static final EntityType ZOMBIE_HORSE = define("zombie_horse", EntityHierarchy.ABSTRACT_HORSE);
+	public static final EntityType ZOMBIE_VILLAGER = define("zombie_villager", EntityHierarchy.ABSTRACT_MONSTER,
+			ZOMBIE);
+	public static final EntityType ZOMBIFIED_PIGLIN = define("zombified_piglin", EntityHierarchy.ABSTRACT_MONSTER,
+			ZOMBIE);
+	public static final EntityType PLAYER = define("player", EntityHierarchy.AVATAR);
+	public static final EntityType FISHING_BOBBER = define("fishing_bobber", EntityHierarchy.ENTITY);
+	public static final EntityType ENDER_SIGNAL = define("ender_signal", EntityHierarchy.ENTITY);
+	public static final EntityType THROWN_EXP_BOTTLE = define("thrown_exp_bottle", EntityHierarchy.ABSTRACT_PROJECTILE);
+	public static final EntityType PRIMED_TNT = define("primed_tnt", EntityHierarchy.ENTITY);
+	public static final EntityType FIREWORK = define("firework", EntityHierarchy.ENTITY);
+	public static final EntityType MINECART_COMMAND = define("minecart_command", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_RIDEABLE = define("minecart_rideable", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_CHEST = define("minecart_chest", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_FURNACE = define("minecart_furnace", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_TNT = define("minecart_tnt", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_HOPPER = define("minecart_hopper", EntityHierarchy.ABSTRACT_MINECART);
+	public static final EntityType MINECART_MOB_SPAWNER = define("minecart_mob_spawner",
+			EntityHierarchy.ABSTRACT_MINECART);
+	/**
+	 * @versions 1.19.4+
+	 */
+	public static final EntityType BLOCK_DISPLAY = define("block_display", EntityHierarchy.DISPLAY);
+	/**
+	 * @versions 1.19.4+
+	 */
+	public static final EntityType ITEM_DISPLAY = define("item_display", EntityHierarchy.DISPLAY);
+	/**
+	 * @versions 1.19.4+
+	 */
+	public static final EntityType TEXT_DISPLAY = define("text_display", EntityHierarchy.DISPLAY);
+	/**
+	 * @versions 1.19.4+
+	 */
+	public static final EntityType INTERACTION = define("interaction", EntityHierarchy.ENTITY);
+	/**
+	 * @versions 1.19.4+
+	 */
+	public static final EntityType SNIFFER = define("sniffer", EntityHierarchy.ABSTRACT_ANIMAL);
+	/**
+	 * @versions 1.20.3+
+	 */
+	public static final EntityType BREEZE = define("breeze", EntityHierarchy.ABSTRACT_MONSTER);
+	/**
+	 * @versions 1.20.3+
+	 */
+	public static final EntityType WIND_CHARGE = define("wind_charge", EntityHierarchy.ABSTRACT_WIND_CHARGE);
+	/**
+	 * @versions 1.20.5+
+	 */
+	public static final EntityType ARMADILLO = define("armadillo", EntityHierarchy.ABSTRACT_ANIMAL);
+	/**
+	 * @versions 1.20.5+
+	 */
+	public static final EntityType BOGGED = define("bogged", EntityHierarchy.ABSTRACT_SKELETON);
+	/**
+	 * @versions 1.20.5+
+	 */
+	public static final EntityType BREEZE_WIND_CHARGE = define("breeze_wind_charge",
+			EntityHierarchy.ABSTRACT_WIND_CHARGE);
+	/**
+	 * @versions 1.20.5+
+	 */
+	public static final EntityType OMINOUS_ITEM_SPAWNER = define("ominous_item_spawner", EntityHierarchy.ENTITY);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType ACACIA_BOAT = define("acacia_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType ACACIA_CHEST_BOAT = define("acacia_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType BAMBOO_CHEST_RAFT = define("bamboo_chest_raft", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType BAMBOO_RAFT = define("bamboo_raft", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType BIRCH_BOAT = define("birch_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType BIRCH_CHEST_BOAT = define("birch_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType CHERRY_BOAT = define("cherry_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType CHERRY_CHEST_BOAT = define("cherry_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType CREAKING = define("creaking", EntityHierarchy.ABSTRACT_MONSTER);
+	/**
+	 * @versions 1.21.2-1.21.3
+	 */
+	@ApiStatus.Obsolete
+	public static final EntityType CREAKING_TRANSIENT = define("creaking_transient", EntityHierarchy.ABSTRACT_MONSTER,
+			CREAKING);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType DARK_OAK_BOAT = define("dark_oak_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType DARK_OAK_CHEST_BOAT = define("dark_oak_chest_boat",
+			EntityHierarchy.ABSTRACT_CHEST_BOAT, CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType JUNGLE_BOAT = define("jungle_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType JUNGLE_CHEST_BOAT = define("jungle_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType MANGROVE_BOAT = define("mangrove_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType MANGROVE_CHEST_BOAT = define("mangrove_chest_boat",
+			EntityHierarchy.ABSTRACT_CHEST_BOAT, CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType OAK_BOAT = define("oak_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType OAK_CHEST_BOAT = define("oak_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType PALE_OAK_BOAT = define("pale_oak_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType PALE_OAK_CHEST_BOAT = define("pale_oak_chest_boat",
+			EntityHierarchy.ABSTRACT_CHEST_BOAT, CHEST_BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType SPRUCE_BOAT = define("spruce_boat", EntityHierarchy.ABSTRACT_BOAT, BOAT);
+	/**
+	 * @versions 1.21.2+
+	 */
+	public static final EntityType SPRUCE_CHEST_BOAT = define("spruce_chest_boat", EntityHierarchy.ABSTRACT_CHEST_BOAT,
+			CHEST_BOAT);
+	/**
+	 * @versions 1.21.5+
+	 */
+	public static final EntityType SPLASH_POTION = define("splash_potion", EntityHierarchy.ABSTRACT_PROJECTILE, POTION);
+	/**
+	 * @versions 1.21.5+
+	 */
+	public static final EntityType LINGERING_POTION = define("lingering_potion", EntityHierarchy.ABSTRACT_PROJECTILE,
+			POTION);
+	/**
+	 * @versions 1.21.6+
+	 */
+	public static final EntityType HAPPY_GHAST = define("happy_ghast", EntityHierarchy.ABSTRACT_ANIMAL);
+	/**
+	 * @versions 1.21.9+
+	 */
+	public static final EntityType COPPER_GOLEM = define("copper_golem", EntityHierarchy.ABSTRACT_GOLEM);
+	/**
+	 * @versions 1.21.9+
+	 */
+	public static final EntityType MANNEQUIN = define("mannequin", EntityHierarchy.AVATAR);
+	/**
+	 * @versions 1.21.11+
+	 */
+	public static final EntityType CAMEL_HUSK = define("camel_husk", EntityHierarchy.ABSTRACT_HORSE, CAMEL);
+	/**
+	 * @versions 1.21.11+
+	 */
+	public static final EntityType NAUTILUS = define("nautilus", EntityHierarchy.ABSTRACT_NAUTILUS);
+	/**
+	 * @versions 1.21.11+
+	 */
+	public static final EntityType PARCHED = define("parched", EntityHierarchy.ABSTRACT_SKELETON);
+	/**
+	 * @versions 1.21.11+
+	 */
+	public static final EntityType ZOMBIE_NAUTILUS = define("zombie_nautilus", EntityHierarchy.ABSTRACT_NAUTILUS);
+	/**
+	 * @versions 26.2+
+	 */
+	public static final EntityType SULFUR_CUBE = define("sulfur_cube", EntityHierarchy.ABSTRACT_AGEABLE);
+
+	/**
+	 * Returns an immutable view of the concrete entity types.
+	 * Every entry here is a real Minecraft registry entry with protocol IDs.
+	 *
+	 * @return all concrete entity types
+	 */
+	public static Collection<EntityType> values() {
+		return REGISTRY.getEntries();
+	}
+
+	static {
+		REGISTRY.unloadMappings();
+		LEGACY_SPAWN_REGISTRY.unloadMappings();
+	}
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/StaticEntityType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/entity/type/StaticEntityType.java
@@ -18,59 +18,104 @@
 
 package com.github.retrooper.packetevents.protocol.entity.type;
 
-import com.github.retrooper.packetevents.protocol.mapper.AbstractMappedEntity;
-import com.github.retrooper.packetevents.protocol.player.ClientVersion;
-import com.github.retrooper.packetevents.util.mappings.TypesBuilderData;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import com.github.retrooper.packetevents.protocol.mapper.AbstractMappedEntity;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.util.mappings.TypesBuilderData;
+
 public class StaticEntityType extends AbstractMappedEntity implements EntityType {
 
-    private final Optional<EntityType> parent;
-    private final Map<EntityType, Boolean> parents;
+	private final EntityClass entityClass;
+	private final Map<EntityClass, Boolean> classChain;
+	private final @Nullable EntityType concreteParent;
 
-    private @Nullable TypesBuilderData legacyData;
+	private @Nullable TypesBuilderData legacyData;
 
-    @ApiStatus.Internal
-    public StaticEntityType(@Nullable TypesBuilderData data, @Nullable EntityType parent) {
-        super(data);
-        this.parent = Optional.ofNullable(parent);
+	@ApiStatus.Internal
+	public StaticEntityType(@Nullable TypesBuilderData data, EntityClass entityClass) {
+		this(data, entityClass, null);
+	}
 
-        // iterate through all parents and save them for faster access
-        this.parents = new IdentityHashMap<>();
-        this.parents.put(this, true);
-        while (parent != null) {
-            this.parents.put(parent, true);
-            parent = parent.getParent().orElse(null);
-        }
-    }
+	@ApiStatus.Internal
+	public StaticEntityType(@Nullable TypesBuilderData data, EntityClass entityClass,
+			@Nullable EntityType concreteParent) {
+		super(data);
+		this.entityClass = entityClass;
+		this.concreteParent = concreteParent;
 
-    StaticEntityType setLegacyData(@Nullable TypesBuilderData legacyData) {
-        this.legacyData = legacyData;
-        return this;
-    }
+		// build the class chain by walking the EntityClass hierarchy
+		this.classChain = new IdentityHashMap<>();
+		EntityClass cur = entityClass;
+		while (cur != null) {
+			this.classChain.put(cur, true);
+			cur = cur.getParent();
+		}
+	}
 
-    @Override
-    public boolean isInstanceOf(EntityType parent) {
-        return parent != null && this.parents.containsKey(parent);
-    }
+	StaticEntityType setLegacyData(@Nullable TypesBuilderData legacyData) {
+		this.legacyData = legacyData;
+		return this;
+	}
 
-    @Override
-    public Optional<EntityType> getParent() {
-        return this.parent;
-    }
+	@Override
+	public EntityClass getEntityClass() {
+		return this.entityClass;
+	}
 
-    @Override
-    public int getLegacyId(ClientVersion version) {
-        if (version.isNewerThanOrEquals(ClientVersion.V_1_14)) {
-            return -1;
-        } else if (this.legacyData != null) {
-            return this.legacyData.getId(version);
-        }
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	public boolean isInstanceOf(EntityClass clazz) {
+		return clazz != null && this.classChain.containsKey(clazz);
+	}
+
+	@Override
+	@Deprecated
+	public boolean isInstanceOf(EntityType parent) {
+		if (parent == null)
+			return false;
+
+		EntityClass parentClass = parent.getEntityClass();
+		if (parentClass != null && this.classChain.containsKey(parentClass)) {
+			return true;
+		}
+
+		// walk the concrete parent chain (DROWNED → ZOMBIE etc.)
+		// the walk is needed when the concrete parent reference matters
+		// (e.g. two types sharing the same EntityClass but unrelated)
+		EntityType cur = this.concreteParent;
+		while (cur != null) {
+			if (cur == parent)
+				return true;
+			// note: instanceof guard is necessary because the EntityType interface
+			// is public and could theoretically have non-StaticEntityType implementations
+			if (cur instanceof StaticEntityType) {
+				cur = ((StaticEntityType) cur).concreteParent;
+			} else {
+				cur = null;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	@Deprecated
+	public Optional<EntityType> getParent() {
+		return Optional.ofNullable(this.concreteParent);
+	}
+
+	@Override
+	public int getLegacyId(ClientVersion version) {
+		if (version.isNewerThanOrEquals(ClientVersion.V_1_14)) {
+			return -1;
+		} else if (this.legacyData != null) {
+			return this.legacyData.getId(version);
+		}
+		throw new UnsupportedOperationException();
+	}
 }


### PR DESCRIPTION
## Problem

`EntityTypes` mixed two completely separate concepts in one class:

1. **The `minecraft:entity_type` registry** — ~158 concrete, spawnable types (zombie, creeper, pig...)
2. **The entity class hierarchy** — abstract parent types (LIVING_ENTITY, ABSTRACT_MONSTER...) that exist only for `isInstanceOf` checks

Abstract types were stored in the same `VersionedRegistry` with `id=-1` for every version. Passing one to a spawn packet would silently write `-1` into the protocol. `EntityTypes.values()` returned ~200 entries when only ~158 are real registry types.

## Changes

| Concept | Before | After |
|---|---|---|
| Abstract types location | In `EntityTypes` + `VersionedRegistry` | **New `EntityHierarchy` class** — no registry involved |
| Hierarchy node type | `EntityType` (`id=-1`, `isRegistered()=true`) | **New `EntityClass`** — pure tree node, no protocol IDs |
| Concrete type parent type | `@Nullable EntityType` | **`EntityClass`** — structurally impossible to pass an abstract type |
| `values()` | ~200 (abstract + concrete) | **~158 (concrete only)** |
| `isInstanceOf` API | `(EntityType)` only | **`(EntityClass)`** primary; `(EntityType)` deprecated |

## Design

Inspired by ViaVersion's entity type system (`EntityType` interface with `isAbstractType()`, `identifier()`, `isOrHasParent()`). Adapted to packetevents' `VersionedRegistry` architecture with the addition of `EntityClass` — a standalone immutable tree node that mirrors Minecraft's actual class hierarchy.

```
EntityHierarchy (EntityClass tree)         EntityTypes (VersionedRegistry)
  ENTITY                                     ZOMBIE = define("zombie", ABSTRACT_MONSTER)
  LIVING_ENTITY                              CREEPER = define("creeper", ABSTRACT_MONSTER)
  ABSTRACT_MONSTER                           DROWNED = define("drowned", ABSTRACT_MONSTER, ZOMBIE)
  ...                                         ...
        ↓                                           |
        └─── EntityType.isInstanceOf(EntityClass) ←─┘
```

## Backward Compatibility

All old `EntityTypes.*` hierarchy constants (`LIVING_ENTITY`, `ABSTRACT_MONSTER`, etc.) are preserved as `@Deprecated` bridge types. Old code compiling against `EntityTypes.LIVING_ENTITY` still compiles unchanged. `EntityTypes.isTypeInstanceOf()` still works via the deprecated `isInstanceOf(EntityType)` method.

## Bug Fixes

- **Fixed** `INTERACTION` parent from `DISPLAY` → `ENTITY` (Interaction extends Entity directly in Minecraft, not Display)
- `EntityClass.getName()` / `getParent()` follow JavaBean convention matching the rest of the codebase
- `isAssignableFrom(null)` throws `NullPointerException` as `java.lang.Class` does

## Verification

- `:api:compileJava` — BUILD SUCCESSFUL (0 new warnings)
- `:api:test` — all tests pass
- Full project `compileJava` — BUILD SUCCESSFUL

Closes #1552