### PR TITLE
fix block action type id

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBlockAction.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerBlockAction.java
@@ -21,7 +21,9 @@ package com.github.retrooper.packetevents.wrapper.play.server;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
+import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 import com.github.retrooper.packetevents.util.Vector3i;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 
@@ -113,10 +115,11 @@ public class WrapperPlayServerBlockAction extends PacketWrapper<WrapperPlayServe
     }
 
     public WrappedBlockState getBlockType() {
-        return WrappedBlockState.getByGlobalId(serverVersion.toClientVersion(), blockTypeID);
+        ClientVersion version = serverVersion.toClientVersion();
+        return StateTypes.getById(version, blockTypeID).createBlockState(version);
     }
 
     public void setBlockType(WrappedBlockState blockType) {
-        this.blockTypeID = blockType.getGlobalId();
+        this.blockTypeID = blockType.getType().getMapped().getId(serverVersion.toClientVersion());
     }
 }


### PR DESCRIPTION
Fixes #1392

BLOCK_ACTION sends a block type id, not a state id.
getBlockType() was looking it up in the state table so chests came out as random blocks.
