### PR TITLE
dont inline simple items in ItemStack.encode before 26.1

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/item/ItemStack.java
@@ -137,7 +137,16 @@ public class ItemStack {
     }
 
     public static NBT encode(PacketWrapper<?> wrapper, ItemStack itemStack) {
-        return encodeForParticle(itemStack, wrapper.getServerVersion().toClientVersion());
+        ClientVersion version = wrapper.getServerVersion().toClientVersion();
+        NBT nbt = encodeForParticle(itemStack, version);
+        if (version.isNewerThanOrEquals(ClientVersion.V_1_20_5)
+                && version.isOlderThan(ClientVersion.V_26_1)
+                && nbt instanceof NBTString) {
+            NBTCompound compound = new NBTCompound();
+            compound.setTag("id", nbt);
+            return compound;
+        }
+        return nbt;
     }
 
     @Deprecated


### PR DESCRIPTION
Fixes #1569

ItemStack.encode was using the particle path, which inlines simple items as a string from 1.20.5.
Dialogs still want a compound until 26.1, so the client kicked with Not a map.
