### PR TITLE
fix equippable component slot ids

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemEquippable.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/component/builtin/item/ItemEquippable.java
@@ -114,7 +114,7 @@ public class ItemEquippable {
     }
 
     public static ItemEquippable read(PacketWrapper<?> wrapper) {
-        EquipmentSlot slot = wrapper.readEnum(EquipmentSlot.values());
+        EquipmentSlot slot = EquipmentSlot.getByComponentId(wrapper.readVarInt());
         Sound equipSound = Sound.read(wrapper);
         ResourceLocation assetId = wrapper.readOptional(PacketWrapper::readIdentifier);
         ResourceLocation cameraOverlay = wrapper.readOptional(PacketWrapper::readIdentifier);
@@ -139,7 +139,7 @@ public class ItemEquippable {
     }
 
     public static void write(PacketWrapper<?> wrapper, ItemEquippable equippable) {
-        wrapper.writeEnum(equippable.slot);
+        wrapper.writeVarInt(equippable.slot.getComponentId());
         Sound.write(wrapper, equippable.equipSound);
         wrapper.writeOptional(equippable.assetId, PacketWrapper::writeIdentifier);
         wrapper.writeOptional(equippable.cameraOverlay, PacketWrapper::writeIdentifier);

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/player/EquipmentSlot.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/player/EquipmentSlot.java
@@ -22,21 +22,34 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import org.jetbrains.annotations.Nullable;
 
 public enum EquipmentSlot {
-    MAIN_HAND(0),
-    OFF_HAND(0),
-    BOOTS(1),
-    LEGGINGS(2),
-    CHEST_PLATE(3),
-    HELMET(4),
-    BODY(0),
-    SADDLE(0);
+    MAIN_HAND(0, 0),
+    OFF_HAND(0, 5),
+    BOOTS(1, 1),
+    LEGGINGS(2, 2),
+    CHEST_PLATE(3, 3),
+    HELMET(4, 4),
+    BODY(0, 6),
+    SADDLE(0, 7);
 
     private static final EquipmentSlot[] VALUES = values();
+    private static final EquipmentSlot[] BY_COMPONENT_ID = new EquipmentSlot[VALUES.length];
+
+    static {
+        for (EquipmentSlot slot : VALUES) {
+            BY_COMPONENT_ID[slot.componentId] = slot;
+        }
+    }
 
     private final byte legacyId;
+    private final byte componentId;
 
-    EquipmentSlot(int legacyId) {
+    EquipmentSlot(int legacyId, int componentId) {
         this.legacyId = (byte) legacyId;
+        this.componentId = (byte) componentId;
+    }
+
+    public int getComponentId() {
+        return this.componentId;
     }
 
     public int getId(ServerVersion version) {
@@ -68,5 +81,9 @@ public enum EquipmentSlot {
     @Nullable
     public static EquipmentSlot getById(ServerVersion version, int id) {
         return getById(version.toClientVersion(), id);
+    }
+
+    public static EquipmentSlot getByComponentId(int id) {
+        return BY_COMPONENT_ID[id];
     }
 }


### PR DESCRIPTION
Fixes #1111
Fixes #1124

Entity equipment uses enum ordinal. The equippable component does not.
readEnum mapped boots to off-hand. Component ids are separate now, packet ids are unchanged.
