### PR TITLE
dense table implementation for id storage

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/packettype/PacketType.java
@@ -83,6 +83,7 @@ import com.github.retrooper.packetevents.protocol.packettype.serverbound.Serverb
 import com.github.retrooper.packetevents.protocol.packettype.serverbound.ServerboundPacketType_1_9;
 import com.github.retrooper.packetevents.protocol.packettype.serverbound.ServerboundPacketType_26_1;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.util.IdTable;
 import com.github.retrooper.packetevents.util.VersionMapper;
 import com.github.retrooper.packetevents.wrapper.PacketWrapper;
 import com.github.retrooper.packetevents.wrapper.configuration.client.WrapperConfigClientAcceptCodeOfConduct;
@@ -367,8 +368,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class PacketType {
 
@@ -828,7 +827,8 @@ public final class PacketType {
             ;
 
             private static int INDEX = 0;
-            private static final Map<Byte, Map<Integer, PacketTypeCommon>> PACKET_TYPE_ID_MAP = new HashMap<>();
+            private final static IdTable<PacketTypeCommon> PACKET_TYPE_ID_TABLE =
+                    new IdTable<>(SERVERBOUND_CONFIG_VERSION_MAPPER.size());
             private final int[] ids;
             private final Class<? extends PacketWrapper<?>> wrapper;
 
@@ -845,22 +845,25 @@ public final class PacketType {
 
             public static void load() {
                 INDEX = 0;
+                PACKET_TYPE_ID_TABLE.mutable();
                 loadPacketIds(ServerboundConfigPacketType_1_20_2.values());
                 loadPacketIds(ServerboundConfigPacketType_1_20_5.values());
                 loadPacketIds(ServerboundConfigPacketType_1_21_6.values());
                 loadPacketIds(ServerboundConfigPacketType_1_21_9.values());
                 // TODO UPDATE Update packet type mappings (config serverbound pt. 2)
+                PACKET_TYPE_ID_TABLE.immutable();
             }
 
             private static void loadPacketIds(Enum<?>[] enumConstants) {
                 int index = INDEX;
+                PacketTypeCommon[] packetIdTable = new PacketTypeCommon[enumConstants.length];
                 for (Enum<?> constant : enumConstants) {
                     int id = constant.ordinal();
                     Configuration.Client value = Configuration.Client.valueOf(constant.name());
                     value.ids[index] = id;
-                    Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index, k -> new HashMap<>());
-                    packetIdMap.put(id, value);
+                    packetIdTable[id] = value;
                 }
+                PACKET_TYPE_ID_TABLE.put(index, packetIdTable);
                 INDEX++;
             }
 
@@ -872,8 +875,7 @@ public final class PacketType {
                 PacketType.prepare();
 
                 int index = SERVERBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
-                Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
-                return map.get(packetId);
+                return PACKET_TYPE_ID_TABLE.lookup(index, packetId);
             }
 
             @Deprecated
@@ -958,7 +960,8 @@ public final class PacketType {
             ;
 
             private static int INDEX = 0;
-            private static final Map<Byte, Map<Integer, PacketTypeCommon>> PACKET_TYPE_ID_MAP = new HashMap<>();
+            private static final IdTable<PacketTypeCommon> PACKET_TYPE_ID_TABLE =
+                    new IdTable<>(CLIENTBOUND_CONFIG_VERSION_MAPPER.size());
             private final int[] ids;
             private final Class<? extends PacketWrapper<?>> wrapper;
 
@@ -975,6 +978,7 @@ public final class PacketType {
 
             public static void load() {
                 INDEX = 0;
+                PACKET_TYPE_ID_TABLE.mutable();
                 loadPacketIds(ClientboundConfigPacketType_1_20_2.values());
                 loadPacketIds(ClientboundConfigPacketType_1_20_3.values());
                 loadPacketIds(ClientboundConfigPacketType_1_20_5.values());
@@ -982,17 +986,19 @@ public final class PacketType {
                 loadPacketIds(ClientboundConfigPacketType_1_21_6.values());
                 loadPacketIds(ClientboundConfigPacketType_1_21_9.values());
                 // TODO UPDATE Update packet type mappings (config clientbound pt. 2)
+                PACKET_TYPE_ID_TABLE.immutable();
             }
 
             private static void loadPacketIds(Enum<?>[] enumConstants) {
                 int index = INDEX;
+                PacketTypeCommon[] packetIdTable = new PacketTypeCommon[enumConstants.length];
                 for (Enum<?> constant : enumConstants) {
                     int id = constant.ordinal();
                     Configuration.Server value = Configuration.Server.valueOf(constant.name());
                     value.ids[index] = id;
-                    Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index, k -> new HashMap<>());
-                    packetIdMap.put(id, value);
+                    packetIdTable[id] = value;
                 }
+                PACKET_TYPE_ID_TABLE.put(index, packetIdTable);
                 INDEX++;
             }
 
@@ -1004,8 +1010,7 @@ public final class PacketType {
                 PacketType.prepare();
 
                 int index = CLIENTBOUND_CONFIG_VERSION_MAPPER.getIndex(version);
-                Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
-                return map.get(packetId);
+                return PACKET_TYPE_ID_TABLE.lookup(index, packetId);
             }
 
             @Deprecated
@@ -1205,7 +1210,8 @@ public final class PacketType {
             ;
 
             private static int INDEX = 0;
-            private static final Map<Byte, Map<Integer, PacketTypeCommon>> PACKET_TYPE_ID_MAP = new HashMap<>();
+            private final static IdTable<PacketTypeCommon> PACKET_TYPE_ID_TABLE =
+                    new IdTable<>(SERVERBOUND_PLAY_VERSION_MAPPER.size());
             private final int[] ids;
             private final Class<? extends PacketWrapper<?>> wrapper;
 
@@ -1220,30 +1226,9 @@ public final class PacketType {
                 return wrapper;
             }
 
-            @Nullable
-            public static PacketTypeCommon getById(ClientVersion version, int packetId) {
-                PacketType.prepare();
-
-                int index = SERVERBOUND_PLAY_VERSION_MAPPER.getIndex(version);
-                Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index, k -> new HashMap<>());
-                return packetIdMap.get(packetId);
-            }
-
-            private static void loadPacketIds(Enum<?>[] enumConstants) {
-                int index = INDEX;
-                for (Enum<?> constant : enumConstants) {
-                    int id = constant.ordinal();
-                    Client value = Client.valueOf(constant.name());
-                    value.ids[index] = id;
-                    Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index,
-                            k -> new HashMap<>());
-                    packetIdMap.put(id, value);
-                }
-                INDEX++;
-            }
-
             public static void load() {
                 INDEX = 0;
+                PACKET_TYPE_ID_TABLE.mutable();
                 loadPacketIds(ServerboundPacketType_1_7_10.values());
                 loadPacketIds(ServerboundPacketType_1_8.values());
                 loadPacketIds(ServerboundPacketType_1_9.values());
@@ -1269,6 +1254,28 @@ public final class PacketType {
                 loadPacketIds(ServerboundPacketType_1_21_9.values());
                 loadPacketIds(ServerboundPacketType_26_1.values());
                 //TODO UPDATE Update packet type mappings (serverbound pt. 2)
+                PACKET_TYPE_ID_TABLE.immutable();
+            }
+
+            private static void loadPacketIds(Enum<?>[] enumConstants) {
+                int index = INDEX;
+                PacketTypeCommon[] packetIdTable = new PacketTypeCommon[enumConstants.length];
+                for (Enum<?> constant : enumConstants) {
+                    int id = constant.ordinal();
+                    Client value = Client.valueOf(constant.name());
+                    value.ids[index] = id;
+                    packetIdTable[id] = value;
+                }
+                PACKET_TYPE_ID_TABLE.put(index, packetIdTable);
+                INDEX++;
+            }
+
+            @Nullable
+            public static PacketTypeCommon getById(ClientVersion version, int packetId) {
+                PacketType.prepare();
+
+                int index = SERVERBOUND_PLAY_VERSION_MAPPER.getIndex(version);
+                return PACKET_TYPE_ID_TABLE.lookup(index, packetId);
             }
 
             public int getId(ClientVersion version) {
@@ -1616,7 +1623,8 @@ public final class PacketType {
             ;
 
             private static int INDEX = 0;
-            private static final Map<Byte, Map<Integer, PacketTypeCommon>> PACKET_TYPE_ID_MAP = new HashMap<>();
+            private static final IdTable<PacketTypeCommon> PACKET_TYPE_ID_TABLE =
+                    new IdTable<>(CLIENTBOUND_PLAY_VERSION_MAPPER.size());
             private final int[] ids;
             private final Class<? extends PacketWrapper<?>> wrapper;
 
@@ -1631,41 +1639,9 @@ public final class PacketType {
                 return wrapper;
             }
 
-            public int getId(ClientVersion version) {
-                PacketType.prepare();
-
-                int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
-                return ids[index];
-            }
-
-            @Nullable
-            public static PacketTypeCommon getById(ClientVersion version, int packetId) {
-                PacketType.prepare();
-
-                int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
-                Map<Integer, PacketTypeCommon> map = PACKET_TYPE_ID_MAP.get((byte) index);
-                return map.get(packetId);
-            }
-
-            @Override
-            public PacketSide getSide() {
-                return PacketSide.SERVER;
-            }
-
-            private static void loadPacketIds(Enum<?>[] enumConstants) {
-                int index = INDEX;
-                for (Enum<?> constant : enumConstants) {
-                    int id = constant.ordinal();
-                    Server value = Server.valueOf(constant.name());
-                    value.ids[index] = id;
-                    Map<Integer, PacketTypeCommon> packetIdMap = PACKET_TYPE_ID_MAP.computeIfAbsent((byte) index, k -> new HashMap<>());
-                    packetIdMap.put(id, value);
-                }
-                INDEX++;
-            }
-
             public static void load() {
                 INDEX = 0;
+                PACKET_TYPE_ID_TABLE.mutable();
                 loadPacketIds(ClientboundPacketType_1_7_10.values());
                 loadPacketIds(ClientboundPacketType_1_8.values());
                 loadPacketIds(ClientboundPacketType_1_9.values());
@@ -1695,6 +1671,40 @@ public final class PacketType {
                 loadPacketIds(ClientboundPacketType_1_21_9.values());
                 loadPacketIds(ClientboundPacketType_26_1.values());
                 //TODO UPDATE Update packet type mappings (clientbound pt. 2)
+                PACKET_TYPE_ID_TABLE.immutable();
+            }
+
+            private static void loadPacketIds(Enum<?>[] enumConstants) {
+                int index = INDEX;
+                PacketTypeCommon[] packetIdTable = new PacketTypeCommon[enumConstants.length];
+                for (Enum<?> constant : enumConstants) {
+                    int id = constant.ordinal();
+                    Server value = Server.valueOf(constant.name());
+                    value.ids[index] = id;
+                    packetIdTable[id] = value;
+                }
+                PACKET_TYPE_ID_TABLE.put(index, packetIdTable);
+                INDEX++;
+            }
+
+            public int getId(ClientVersion version) {
+                PacketType.prepare();
+
+                int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
+                return ids[index];
+            }
+
+            @Nullable
+            public static PacketTypeCommon getById(ClientVersion version, int packetId) {
+                PacketType.prepare();
+
+                int index = CLIENTBOUND_PLAY_VERSION_MAPPER.getIndex(version);
+                return PACKET_TYPE_ID_TABLE.lookup(index, packetId);
+            }
+
+            @Override
+            public PacketSide getSide() {
+                return PacketSide.SERVER;
             }
         }
     }

--- a/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/protocol/world/states/WrappedBlockState.java
@@ -39,6 +39,7 @@ import com.github.retrooper.packetevents.protocol.world.states.enums.West;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateType;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateTypes;
 import com.github.retrooper.packetevents.protocol.world.states.type.StateValue;
+import com.github.retrooper.packetevents.util.IdTable;
 import com.github.retrooper.packetevents.util.LogManager;
 import com.github.retrooper.packetevents.util.mappings.MappingHelper;
 import org.jetbrains.annotations.ApiStatus;
@@ -110,7 +111,8 @@ public class WrappedBlockState {
     private static final WrappedBlockState AIR = new WrappedBlockState(StateTypes.AIR,
             new EnumMap<>(StateValue.class), 0, AIR_MAPPING_INDEX);
     private static final Map<String, WrappedBlockState>[] BY_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
-    private static final Map<Integer, WrappedBlockState>[] BY_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
+    private static final WrappedBlockState[] EMPTY_STATES = new WrappedBlockState[0];
+    private static final IdTable<WrappedBlockState> BY_ID = new IdTable<>(HIGHEST_MAPPING_INDEX + 1);
     private static final Map<WrappedBlockState, String>[] INTO_STRING = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<WrappedBlockState, Integer>[] INTO_ID = new Map[HIGHEST_MAPPING_INDEX + 1];
     private static final Map<StateType, WrappedBlockState>[] DEFAULT_STATES = new Map[HIGHEST_MAPPING_INDEX + 1];
@@ -121,7 +123,7 @@ public class WrappedBlockState {
         STRING_UPDATER.put("grass_path", "dirt_path"); // 1.16 -> 1.17
 
         Arrays.fill(BY_STRING, Collections.emptyMap());
-        Arrays.fill(BY_ID, Collections.emptyMap());
+        BY_ID.fill(EMPTY_STATES);
         Arrays.fill(INTO_STRING, Collections.emptyMap());
         Arrays.fill(INTO_ID, Collections.emptyMap());
         Arrays.fill(DEFAULT_STATES, Collections.emptyMap());
@@ -129,7 +131,7 @@ public class WrappedBlockState {
         // because AIR is a constant, preload all data for this into a separate mapping index
         String airName = AIR.getType().getMapped().getName().getKey();
         BY_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(airName, AIR);
-        BY_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getGlobalId(), AIR);
+        BY_ID.put(AIR_MAPPING_INDEX, new WrappedBlockState[]{AIR}); // AIR's global id is 0
         INTO_STRING[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, airName);
         INTO_ID[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR, AIR.getGlobalId());
         DEFAULT_STATES[AIR_MAPPING_INDEX] = Collections.singletonMap(AIR.getType(), AIR);
@@ -171,14 +173,14 @@ public class WrappedBlockState {
 
     private static byte loadMappings(ClientVersion version) {
         byte mappingsIndex = getMappingsIndex(version);
-        if (!PRELOAD_BLOCK_STATE_MAPPINGS && BY_ID[mappingsIndex].isEmpty()) {
+        if (!PRELOAD_BLOCK_STATE_MAPPINGS && BY_ID.get(mappingsIndex).length == 0) {
             loadMappings0(getMappingsVersion(version), mappingsIndex); // try to load mappings
         }
         return mappingsIndex;
     }
 
     private static synchronized void loadMappings0(ClientVersion version, byte mappingsIndex) {
-        if (!BY_ID[mappingsIndex].isEmpty()) {
+        if (BY_ID.get(mappingsIndex).length != 0) {
             return; // already loaded
         }
         PacketEvents.getAPI().getLogManager().info("Loading block mappings for " + version + "/" + mappingsIndex + "...");
@@ -209,16 +211,19 @@ public class WrappedBlockState {
 
         Map<Map<StateValue, Object>, StateCacheValue> cache = new HashMap<>();
         for (byte i = 0; i < HIGHEST_MAPPING_INDEX; i++) {
-            Map<Integer, WrappedBlockState> map = BY_ID[i];
-            if (map == null) {
+            Object[] states = BY_ID.get(i);
+            if (states == null) {
                 continue; // not loaded yet
             }
-            for (WrappedBlockState state : map.values()) {
-                cache.computeIfAbsent(state.data, StateCacheValue::new);
+            for (Object state : states) {
+                if (state != null) {
+                    cache.computeIfAbsent(((WrappedBlockState) state).data, StateCacheValue::new);
+                }
             }
         }
         return cache;
     }
+
 
     public static WrappedBlockState decode(NBT nbt, ClientVersion version) {
         if (nbt instanceof NBTString) {
@@ -301,10 +306,16 @@ public class WrappedBlockState {
     }
 
     @NotNull
+    private static WrappedBlockState lookupById(byte mappingsIndex, int globalID) {
+        WrappedBlockState state = BY_ID.lookup(mappingsIndex, globalID);
+        return state != null ? state : AIR;
+    }
+
+    @NotNull
     public static WrappedBlockState getByGlobalId(ClientVersion version, int globalID, boolean clone) {
         if (globalID == 0) return AIR; // Hardcode for performance
         byte mappingsIndex = loadMappings(version);
-        final WrappedBlockState state = BY_ID[mappingsIndex].getOrDefault(globalID, AIR);
+        final WrappedBlockState state = lookupById(mappingsIndex, globalID);
         return clone ? state.clone() : state;
     }
 
@@ -429,7 +440,7 @@ public class WrappedBlockState {
                 }
             }
 
-            BY_ID[LEGACY_MAPPING_INDEX] = stateByIdMap;
+            BY_ID.putAll(LEGACY_MAPPING_INDEX, stateByIdMap, Integer.MAX_VALUE);
             INTO_ID[LEGACY_MAPPING_INDEX] = stateToIdMap;
             BY_STRING[LEGACY_MAPPING_INDEX] = stateByStringMap;
             INTO_STRING[LEGACY_MAPPING_INDEX] = stateToStringMap;
@@ -531,7 +542,7 @@ public class WrappedBlockState {
                 }
             }
 
-            BY_ID[mappingIndex] = stateByIdMap;
+            BY_ID.putAll(mappingIndex, stateByIdMap, Integer.MAX_VALUE);
             INTO_ID[mappingIndex] = stateToIdMap;
             BY_STRING[mappingIndex] = stateByStringMap;
             INTO_STRING[mappingIndex] = stateToStringMap;
@@ -1603,7 +1614,7 @@ public class WrappedBlockState {
         int oldGlobalID = globalID;
         globalID = getGlobalIdNoCache();
         if (globalID == -1) { // -1 maps to no block as negative ID are impossible
-            WrappedBlockState blockState = BY_ID[this.mappingsIndex].getOrDefault(oldGlobalID, AIR).clone();
+            WrappedBlockState blockState = lookupById(this.mappingsIndex, oldGlobalID).clone();
             this.type = blockState.type;
             this.globalID = blockState.globalID;
             this.data = new HashMap<>(blockState.data);

--- a/api/src/main/java/com/github/retrooper/packetevents/util/IdTable.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/IdTable.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of packetevents - https://github.com/retrooper/packetevents
+ * Copyright (C) 2026 retrooper and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.retrooper.packetevents.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+public class IdTable<T> {
+
+    public static final int MAX_ID = 1 << 16;
+
+    private volatile Object[][] table;
+    private boolean mutable = true;
+
+    public IdTable() {
+        this(0);
+    }
+
+    public IdTable(int rows) {
+        this.table = new Object[rows][];
+    }
+
+    public void put(int index, Object[] array) {
+        this.assertMutable();
+        this.resize(index);
+        this.table[index] = array;
+    }
+
+    public void put(int index, int id, T val) {
+        this.assertMutable();
+        if (id < 0) {
+            throw new IllegalArgumentException("negative id: " + id);
+        }
+        this.resize(index);
+        Object[] row = this.table[index];
+        if (row == null) {
+            this.table[index] = row = new Object[id + 1];
+        } else if (row.length <= id) {
+            this.table[index] = row = Arrays.copyOf(row,
+                    Math.max(id + 1, row.length + (row.length >> 1) + 1));
+        }
+        row[id] = val;
+    }
+
+    public boolean putAll(int index, Map<Integer, ? extends T> values) {
+        return this.putAll(index, values, MAX_ID);
+    }
+
+    public boolean putAll(int index, Map<Integer, ? extends T> values, int idLimit) {
+        this.assertMutable();
+        int maxId = -1;
+        for (Integer id : values.keySet()) {
+            if (id != null && id >= 0 && id < idLimit) {
+                maxId = Math.max(maxId, id);
+            }
+        }
+        if (maxId < 0) {
+            return false;
+        }
+        Object[] row = new Object[maxId + 1];
+        for (Map.Entry<Integer, ? extends T> entry : values.entrySet()) {
+            Integer id = entry.getKey();
+            if (id != null && id >= 0 && id <= maxId) {
+                row[id] = entry.getValue();
+            }
+        }
+        this.put(index, row);
+        return true;
+    }
+
+    public void fill(Object[] val) {
+        this.assertMutable();
+        Arrays.fill(this.table, val);
+    }
+
+    public Object[] get(int index) {
+        return this.table[index];
+    }
+
+    @SuppressWarnings("unchecked")
+    public @Nullable T lookup(int index, int id) {
+        Object[][] table = this.table;
+        if (index < 0 || index >= table.length) {
+            return null;
+        }
+        Object[] arr = table[index];
+        return arr != null && id >= 0 && id < arr.length ? (T) arr[id] : null;
+    }
+
+    public boolean isMutable() {
+        return this.mutable;
+    }
+
+    public void immutable() {
+        this.mutable = false;
+    }
+
+    public void mutable() {
+        this.mutable = true;
+    }
+
+    private void resize(int index) {
+        if (index >= this.table.length) {
+            this.table = Arrays.copyOf(this.table, index + 1);
+        }
+    }
+
+    private void assertMutable() {
+        if (!mutable) {
+            throw new IllegalStateException("table is immutable");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        IdTable<?> idTable = (IdTable<?>) o;
+        return Objects.deepEquals(table, idTable.table);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.deepHashCode(table);
+    }
+}

--- a/api/src/main/java/com/github/retrooper/packetevents/util/VersionMapper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/VersionMapper.java
@@ -28,6 +28,7 @@ public class VersionMapper {
 
     private final ClientVersion[] versions;
     private final ClientVersion[] reversedVersions;
+    private final int[] indexByVersionOrdinal;
 
     public VersionMapper(ClientVersion... versions) {
         this.versions = versions.clone();
@@ -36,6 +37,12 @@ public class VersionMapper {
         this.reversedVersions = new ClientVersion[this.versions.length];
         for (int i = this.versions.length - 1, j = 0; i >= 0; i--, j++) {
             this.reversedVersions[j] = this.versions[i];
+        }
+
+        ClientVersion[] allVersions = ClientVersion.values();
+        this.indexByVersionOrdinal = new int[allVersions.length];
+        for (ClientVersion version : allVersions) {
+            this.indexByVersionOrdinal[version.ordinal()] = this.computeIndex(version);
         }
     }
 
@@ -57,6 +64,10 @@ public class VersionMapper {
     }
 
     public int getIndex(ClientVersion version) {
+        return this.indexByVersionOrdinal[version.ordinal()];
+    }
+
+    private int computeIndex(ClientVersion version) {
         int index = reversedVersions.length - 1;
         for (ClientVersion v : reversedVersions) {
             if (version.isNewerThanOrEquals(v)) {

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/MappingHelper.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/MappingHelper.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.protocol.nbt.NBTNumber;
 import com.github.retrooper.packetevents.protocol.nbt.NBTString;
 import com.github.retrooper.packetevents.protocol.nbt.serializer.SequentialNBTReader;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.util.IdTable;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.io.BufferedInputStream;
@@ -112,7 +113,8 @@ public class MappingHelper {
     public static <T extends MappedEntity> void registerMapping(
             TypesBuilder builder,
             Map<String, T>[] typeNames,
-            Map<Integer, T>[] typeIds,
+            IdTable<T> typeIdTable,
+            Map<Integer, T>[] typeIdOverflow,
             TypesBuilderData typeData,
             T type
     ) {
@@ -128,11 +130,16 @@ public class MappingHelper {
             }
             nameMap.put(typeData.getName().toString(), type);
             // set by version-specific id
-            Map<Integer, T> idMap = typeIds[index];
-            if (idMap == null) {
-                typeIds[index] = idMap = new HashMap<>();
+            int id = typeData.getId(version);
+            if (id >= 0 && id < IdTable.MAX_ID) {
+                typeIdTable.put(index, id, type);
+            } else {
+                Map<Integer, T> overflow = typeIdOverflow[index];
+                if (overflow == null) {
+                    typeIdOverflow[index] = overflow = new HashMap<>(4);
+                }
+                overflow.put(id, type);
             }
-            idMap.put(typeData.getId(version), type);
         }
     }
 

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SimpleRegistry.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/SimpleRegistry.java
@@ -20,6 +20,7 @@ package com.github.retrooper.packetevents.util.mappings;
 
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.util.IdTable;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -35,8 +36,9 @@ public final class SimpleRegistry<T extends MappedEntity> implements IRegistry<T
 
     private final ResourceLocation registryKey;
     private final Map<String, T> typeMap = new HashMap<>();
-    private final Map<Integer, T> typeIdMap = new HashMap<>();
     private final Map<String, Integer> reverseTypeIdMap = new HashMap<>();
+    private final IdTable<T> typeIdTable = new IdTable<>(1);
+    private @Nullable Map<Integer, T> typeIdOverflow;
 
     public SimpleRegistry(String registryKey) {
         this(new ResourceLocation(registryKey));
@@ -55,8 +57,15 @@ public final class SimpleRegistry<T extends MappedEntity> implements IRegistry<T
     public <Z extends T> Z define(ResourceLocation name, int id, Z instance) {
         String nameStr = name.toString();
         this.typeMap.put(nameStr, instance);
-        this.typeIdMap.put(id, instance);
         this.reverseTypeIdMap.put(nameStr, id);
+        if (id >= 0 && id < IdTable.MAX_ID) {
+            this.typeIdTable.put(0, id, instance);
+        } else {
+            if (this.typeIdOverflow == null) {
+                this.typeIdOverflow = new HashMap<>(4);
+            }
+            this.typeIdOverflow.put(id, instance);
+        }
         return instance;
     }
 
@@ -68,7 +77,11 @@ public final class SimpleRegistry<T extends MappedEntity> implements IRegistry<T
 
     @Override
     public @Nullable T getById(ClientVersion version, int id) {
-        return this.typeIdMap.get(id);
+        T byId = this.typeIdTable.lookup(0, id);
+        if (byId != null) {
+            return byId;
+        }
+        return this.typeIdOverflow != null ? this.typeIdOverflow.get(id) : null;
     }
 
     @Override

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/TypesBuilder.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/TypesBuilder.java
@@ -36,14 +36,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.Arrays;
+import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 @ApiStatus.Internal
 public class TypesBuilder {
     private final String mapPath;
-    private Map<ClientVersion, Map<String, Integer>> entries = new HashMap<>();
+    private @Nullable Map<String, int[]> idsByName = new HashMap<>();
+    private int[] fileSlotByVersionOrdinal = new int[0];
+    private int[] slotBySortedIndex = new int[0];
     private VersionMapper versionMapper;
 
     @Nullable
@@ -61,8 +64,8 @@ public class TypesBuilder {
     }
 
     public void load() {
-        if (this.entries == null) {
-            this.entries = new HashMap<>();
+        if (this.idsByName == null) {
+            this.idsByName = new HashMap<>();
         }
         try (final SequentialNBTReader.Compound rootCompound = MappingHelper.decompress("mappings/" + this.mapPath)) {
             rootCompound.skipOne(); // skip version tag for now
@@ -79,7 +82,13 @@ public class TypesBuilder {
                 loadAsMap(first, entries, versions);
             }
 
-            versionMapper = new VersionMapper(versions);
+            this.fileSlotByVersionOrdinal = new int[ClientVersion.values().length];
+            Arrays.fill(this.fileSlotByVersionOrdinal, -1);
+            for (int slot = 0; slot < versions.length; slot++) {
+                this.fileSlotByVersionOrdinal[versions[slot].ordinal()] = slot;
+            }
+            this.versionMapper = new VersionMapper(versions);
+            this.rebuildSlotMapping();
         } catch (IOException e) {
             throw new RuntimeException("Unable to load mapping files.", e);
         }
@@ -97,27 +106,46 @@ public class TypesBuilder {
             lastEntries.add(((NBTString) entry).getValue());
         }
 
-        final Consumer<ClientVersion> mapLoader = version -> {
-            final Map<String, Integer> map = new HashMap<>();
+        final int slots = versions.length;
+        final IntConsumer slotLoader = slot -> {
             int size = lastEntries.size();
             for (int i = 0; i < size; i++) {
-                map.put(lastEntries.get(i), i);
+                this.idsFor(lastEntries.get(i), slots)[slot] = i;
             }
-            this.entries.put(version, map);
         };
-        mapLoader.accept(start);
+        slotLoader.accept(0);
 
         int i = 1;
         for (Map.Entry<String, NBT> entry : entries) {
             final ClientVersion version = ClientVersion.valueOf(entry.getKey());
-            versions[i++] = version;
+            versions[i] = version;
             final List<ListDiff<String>> diff = MappingHelper.createListDiff((SequentialNBTReader.Compound) entry.getValue());
 
             for (int j = diff.size() - 1; j >= 0; j--) {
                 diff.get(j).applyTo(lastEntries);
             }
-            mapLoader.accept(version);
+            slotLoader.accept(i++);
         }
+    }
+
+    private int[] idsFor(String name, int slots) {
+        int[] ids = this.idsByName.get(name);
+        if (ids == null) {
+            ids = new int[slots];
+            Arrays.fill(ids, -1);
+            this.idsByName.put(name, ids);
+        }
+        return ids;
+    }
+
+    private void rebuildSlotMapping() {
+        ClientVersion[] sorted = this.versionMapper.getVersions();
+        int[] mapping = new int[sorted.length];
+        for (int i = 0; i < sorted.length; i++) {
+            int slot = this.fileSlotByVersionOrdinal[sorted[i].ordinal()];
+            mapping[i] = slot != -1 ? slot : (i > 0 ? mapping[i - 1] : 0);
+        }
+        this.slotBySortedIndex = mapping;
     }
 
     private void loadAsMap(
@@ -130,22 +158,24 @@ public class TypesBuilder {
         final Map<String, Integer> lastEntries = StreamSupport.stream(((SequentialNBTReader.Compound) first.getValue()).spliterator(), false)
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> ((NBTNumber) entry.getValue()).getAsInt()));
 
-        final Consumer<ClientVersion> mapLoader = version -> {
-            final Map<String, Integer> map = new HashMap<>(lastEntries);
-            this.entries.put(version, map);
+        final int slots = versions.length;
+        final IntConsumer slotLoader = slot -> {
+            for (Map.Entry<String, Integer> e : lastEntries.entrySet()) {
+                this.idsFor(e.getKey(), slots)[slot] = e.getValue();
+            }
         };
-        mapLoader.accept(start);
+        slotLoader.accept(0);
 
         int i = 1;
         for (Map.Entry<String, NBT> entry : entries) {
             final ClientVersion version = ClientVersion.valueOf(entry.getKey());
-            versions[i++] = version;
+            versions[i] = version;
             final List<MapDiff<String, Integer>> diff = MappingHelper.createDiff((SequentialNBTReader.Compound) entry.getValue());
 
             for (MapDiff<String, Integer> d : diff) {
                 d.applyTo(lastEntries);
             }
-            mapLoader.accept(version);
+            slotLoader.accept(i++);
         }
     }
 
@@ -172,42 +202,55 @@ public class TypesBuilder {
     public void addExtraVersionStep(ClientVersion version) {
         VersionMapper newMapper = this.versionMapper.withExtra(version);
         if (this.versionMapper != newMapper) {
-            // version was inserted, update entries
-            int baseIndex = this.versionMapper.getIndex(version);
-            ClientVersion baseVersion = this.versionMapper.getVersions()[baseIndex];
-            this.entries.put(version, this.entries.get(baseVersion));
             this.versionMapper = newMapper; // save new mapper
+            this.rebuildSlotMapping(); // the reads the nearest older version's slot
         }
     }
 
     @VisibleForTesting
     public boolean isMappingDataLoaded() {
-        return this.entries != null;
+        return this.idsByName != null;
     }
 
     public void unloadFileMappings() {
-        entries.clear();
-        entries = null;
+        if (this.idsByName != null) {
+            this.idsByName.clear();
+            this.idsByName = null;
+        }
     }
 
     public TypesBuilderData define(String key, VersionRange range) {
         final ResourceLocation name = new ResourceLocation(key);
-        final int[] ids = new int[this.getVersions().length];
-        int index = 0;
-        for (ClientVersion v : this.getVersions()) {
-            final Map<String, Integer> map = entries.get(v);
-            if (map.containsKey(key)) {
-                int id = map.get(key);
-                ids[index] = id;
-            } else {
-                ids[index] = -1;
+        final int[] slots = this.slotBySortedIndex;
+        final int[] ids = new int[slots.length];
+        final int[] fileIds = this.idsByName.get(key);
+        if (fileIds == null) {
+            Arrays.fill(ids, -1);
+        } else {
+            for (int i = 0; i < slots.length; i++) {
+                ids[i] = fileIds[slots[i]];
             }
-            index++;
         }
         return new TypesBuilderData(name, ids, this, range);
     }
 
     public @Nullable Map<ClientVersion, Map<String, Integer>> getEntries() {
-        return this.entries;
+        if (this.idsByName == null) {
+            return null;
+        }
+        ClientVersion[] sorted = this.versionMapper.getVersions();
+        Map<ClientVersion, Map<String, Integer>> view = new HashMap<>(sorted.length * 2);
+        for (int i = 0; i < sorted.length; i++) {
+            Map<String, Integer> perVersion = new HashMap<>();
+            int slot = this.slotBySortedIndex[i];
+            for (Map.Entry<String, int[]> entry : this.idsByName.entrySet()) {
+                int id = entry.getValue()[slot];
+                if (id != -1) {
+                    perVersion.put(entry.getKey(), id);
+                }
+            }
+            view.put(sorted[i], perVersion);
+        }
+        return view;
     }
 }

--- a/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/util/mappings/VersionedRegistry.java
@@ -23,6 +23,7 @@ import com.github.retrooper.packetevents.protocol.mapper.MappedEntity;
 import com.github.retrooper.packetevents.protocol.mapper.MappedEntityBuilder;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.resources.ResourceLocation;
+import com.github.retrooper.packetevents.util.IdTable;
 import com.github.retrooper.packetevents.util.MapUtil;
 import com.github.retrooper.packetevents.util.VersionRange;
 import org.jetbrains.annotations.ApiStatus;
@@ -47,7 +48,8 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
     private final ClientVersion[] extraSteps;
 
     private final Map<String, T>[] typeNames;
-    private final Map<Integer, T>[] typeIds;
+    private final Map<Integer, T> @Nullable [] typeIds;
+    private final IdTable<T> typeIdTable;
     private final Set<T> entries = new HashSet<>();
 
     public VersionedRegistry(String registry) {
@@ -80,6 +82,7 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
         int versions = this.typesBuilder.getVersionMapper().size();
         this.typeNames = new Map[versions];
         this.typeIds = new Map[versions];
+        this.typeIdTable = new IdTable<>(versions);
     }
 
     @ApiStatus.Internal
@@ -96,7 +99,8 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
     public <Z extends T> Z define(String name, VersionRange range, Function<TypesBuilderData, Z> builder) {
         TypesBuilderData typeData = this.typesBuilder.define(name, range);
         Z instance = builder.apply(typeData);
-        MappingHelper.registerMapping(this.typesBuilder, this.typeNames, this.typeIds, typeData, instance);
+        MappingHelper.registerMapping(this.typesBuilder, this.typeNames,
+                this.typeIdTable, this.typeIds, typeData, instance);
         return instance;
     }
 
@@ -143,6 +147,8 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
                 }
             }
         }
+
+        this.typeIdTable.immutable();
     }
 
     @Override
@@ -173,7 +179,12 @@ public final class VersionedRegistry<T extends MappedEntity> implements IRegistr
     @Override
     public @Nullable T getById(ClientVersion version, int id) {
         int index = this.typesBuilder.getDataIndex(version);
-        return this.typeIds[index].get(id);
+        T byId = this.typeIdTable.lookup(index, id);
+        if (byId != null) {
+            return byId;
+        }
+        Map<Integer, T> overflow = this.typeIds[index];
+        return overflow != null ? overflow.get(id) : null;
     }
 
     @Override


### PR DESCRIPTION
This dense table implementation has 2x more performance and 15-20% lower memory footprint than the previous maps implementation. Since most of the mapping ids are sequential, table lookup is way cheaper than hash lookup.